### PR TITLE
ci: debos: Update OS packages first

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -40,6 +40,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # make sure we have latest packages first, to get latest fixes and to
+      # avoid an automated update while we're building
+      - name: Update OS packages
+        run: |
+          set -x
+          sudo apt update
+          sudo apt -y upgrade
+          sudo apt -y full-upgrade
+
       # this is the default in our self-hosted runners
       - name: Make sure Incus is setup
         run: |


### PR DESCRIPTION
During some GitHub workflow runs, incus exec commands are randomly
interrupted by:
    Error: websocket: close 1006 (abnormal closure): unexpected EOF

It's possible that this is due to an OS update happening during the run,
so pre-emptively do the updates first, which is a good idea for bug
fixes and predicatibility anyway.
