### PR TITLE
ci: Move from Incus to Docker for image building

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -24,9 +24,6 @@ defaults:
     working-directory: debos-recipes
 
 env:
-  INCUS_IMAGE: images:debian/trixie/arm64
-  INCUS_NAME: debos
-  FILESERVER_DIR: /srv/gh-runners/quic-yocto/builds
   FILESERVER_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
 
 # cancel in progress builds for this workflow triggered by the same ref
@@ -37,6 +34,11 @@ concurrency:
 jobs:
   build-debos:
     runs-on: [self-hosted, arm64, debbuilder]
+    container:
+      image: debian:trixie
+      volumes:
+        - /srv/gh-runners/quic-yocto/builds:/builds
+      options: --privileged
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,48 +49,14 @@ jobs:
       - name: Update OS packages
         run: |
           set -x
-          sudo apt update
-          sudo apt -y upgrade
-          sudo apt -y full-upgrade
-
-      # this is the default in our self-hosted runners
-      - name: Make sure Incus is setup
-        run: |
-          set -x
-          sudo apt -y install incus
-          sudo incus admin init --auto
-
-      # create a fresh container build environment to decouple the build
-      # operating system from the github runner one; install debos
-      - name: Setup build environment
-        run: |
-          set -x
-          # privileged container as debos will use mounts
-          sudo incus init "${INCUS_IMAGE}" "${INCUS_NAME}" \
-              -c security.privileged=true -c security.nesting=true
-          sudo incus start "${INCUS_NAME}"
-          # wait for network to be up (prior to running apt)
-          sudo incus exec "${INCUS_NAME}" \
-              /usr/lib/systemd/systemd-networkd-wait-online
-
-          # commands are piped to be run inside the container
-          sudo incus exec "${INCUS_NAME}" -- sh -e -x <<EOF
           apt update
           apt -y upgrade
           apt -y full-upgrade
           apt -y install debos
-          EOF
 
       - name: Build debos recipe
         run: |
           set -x
-          # mount current directory under /build
-          sudo incus config device add "${INCUS_NAME}" build-dir \
-              disk "source=${PWD}" path=/build shift=true
-
-          # commands are piped to be run inside the container
-          sudo incus exec "${INCUS_NAME}" -- sh -e -x <<EOF
-          cd /build
           # start by building the root filesystem
           debos qualcomm-linux-debian-rootfs.yaml
           # debos tries KVM and UML as backends, and falls back to
@@ -101,19 +69,18 @@ jobs:
               qualcomm-linux-debian-image.yaml
           debos -b qemu --scratchsize 4GiB -t imagetype:sdcard \
               qualcomm-linux-debian-image.yaml
-          EOF
 
       - name: Upload artifacts to fileserver
         run: |
           set -x
           # curl will be used to talk to fileserver; should be installed by
           # default
-          sudo apt -y install curl
+          apt -y install curl
           # github runs are only unique per repository and may also be re-run;
           # create an unique id with repository, run id, and run attempt
           id="${GITHUB_REPOSITORY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           # create a directory for the current run
-          dir="${FILESERVER_DIR}/${id}"
+          dir="/build/${id}"
           mkdir -vp "${dir}"
           # copy output files
           cp -v disk-ufs.img.gz "${dir}"


### PR DESCRIPTION
Docker is supported as a firt-class citizen in GitHub Actions. This change removes a few actions we were having to perform. This change will also make the upcoming move to AWS self-hosted runners easier.