### PR TITLE
flat images

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -52,7 +52,9 @@ jobs:
           apt update
           apt -y upgrade
           apt -y full-upgrade
-          apt -y install debos
+          # debos is needed to build recipes, mtools is needed for the flash
+          # recipe
+          apt -y install debos mtools
 
       - name: Build debos recipe
         run: |
@@ -69,6 +71,8 @@ jobs:
               qualcomm-linux-debian-image.yaml
           debos -b qemu --scratchsize 4GiB -t imagetype:sdcard \
               qualcomm-linux-debian-image.yaml
+          # build flashable files
+          debos qualcomm-linux-debian-flash.yaml
 
       - name: Upload artifacts to fileserver
         run: |
@@ -83,8 +87,11 @@ jobs:
           dir="/fileserver-builds/${id}"
           mkdir -vp "${dir}"
           # copy output files
-          cp -v disk-ufs.img.gz "${dir}"
-          cp -v disk-sdcard.img.gz "${dir}"
+          cp -av rootfs.tar.gz "${dir}"
+          cp -av dtbs.tar.gz "${dir}"
+          cp -av disk-ufs.img.gz "${dir}"
+          cp -av disk-sdcard.img.gz "${dir}"
+          tar -cvf "${dir}"/flash.tar.gz disk-ufs.img1 disk-ufs.img2 flash_*
           # instruct fileserver to publish this directory
           url="${FILESERVER_URL}/${id}/"
           curl -X POST -H 'Accept: text/event-stream' "${url}"

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -1,0 +1,125 @@
+architecture: arm64
+
+actions:
+  - action: download
+    description: Download qcom-ptool
+    url: https://github.com/qualcomm-linux/qcom-ptool/archive/refs/heads/main.tar.gz
+    name: qcom-ptool
+    filename: qcom-ptool.tar.gz
+    unpack: true
+
+  - action: download
+    description: Download QCM6490 boot binaries
+    url: https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00058.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip
+    name: qcm6490_boot-binaries
+    filename: qcm6490_boot-binaries.zip
+
+  - action: download
+    description: Download RB3 Gen2 Vision Kit CDT
+    url: https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-vision-kit.zip
+    name: rb3gen2-vision-kit_cdt
+    filename: rb3gen2-vision-kit_cdt.zip
+
+  - action: run
+    description: Generate flash directories for UFS boards
+    chroot: false
+    command: |
+      set -eux
+      # work dir that will be thrown away
+      mkdir -v build
+
+      # path to unpacked qcom-ptool tarball
+      QCOM_PTOOL="${ROOTDIR}/../qcom-ptool.tar.gz.d/qcom-ptool-main"
+
+      ## platform: QCM6490
+      # unpack boot binaries
+      unzip -j "${ROOTDIR}/../qcm6490_boot-binaries.zip" \
+          -d build/qcm6490_boot-binaries
+      # generate partition files
+      mkdir -v build/qcm6490_partitions
+      (
+          cd build/qcm6490_partitions
+          conf="${QCOM_PTOOL}/platforms/qcm6490/partitions.conf"
+          "${QCOM_PTOOL}/gen_partition.py" -i "$conf" \
+              -o ptool-partitions.xml
+          # partitions.conf sets --type=emmc, nand or ufs
+          if grep -F '^--disk --type=ufs ' "${conf}"; then
+              touch flash-ufs
+          fi
+          "${QCOM_PTOOL}/ptool.py" -x ptool-partitions.xml
+      )
+
+      ### board: RB3Gen2 Vision Kit
+      flash_dir="${ARTIFACTDIR}/flash_rb3gen2-vision-kit"
+      rm -rf "${flash_dir}"
+      mkdir -v "${flash_dir}"
+      # copy platform partition files
+      cp --preserve=mode,timestamps -v build/qcm6490_partitions/* \
+          "${flash_dir}"
+      # copy platform boot binaries; these shouldn't ship partition files, but
+      # make sure not to accidentally clobber any such file
+      find build/qcm6490_boot-binaries \
+          -not -name 'gpt_*' \
+          -not -name 'patch*.xml' \
+          -not -name 'rawprogram*.xml' \
+          -not -name 'wipe*.xml' \
+          -not -name 'zeros_*' \
+          \( \
+              -name Qualcomm-Technologies-Inc.-Proprietary \
+              -or -name 'prog_*' \
+              -or -name '*.bin' \
+              -or -name '*.elf' \
+              -or -name '*.fv' \
+              -or -name '*.mbn' \
+          \) \
+          -exec cp --preserve=mode,timestamps -v '{}' "${flash_dir}" \;
+      # unpack board CDT
+      unzip -j "${ROOTDIR}/../rb3gen2-vision-kit_cdt.zip" \
+          -d build/rb3gen2-vision-kit_cdt
+      # copy just the CDT data; no partition or flashing files
+      cp --preserve=mode,timestamps -v build/rb3gen2-vision-kit_cdt/cdt_vision_kit.bin \
+          "${flash_dir}"
+
+      # update flashing files for CDT
+      sed -i '/label="cdt"/s/filename=""/filename="cdt_vision_kit.bin"/' \
+          "${flash_dir}"/rawprogram*.xml
+
+      # generate a dtb.bin FAT partition with just a single dtb for the current
+      # board; long-term this should really be a set of dtbs and overlays as to
+      # share dtb.bin across boards
+      dtb_bin="${flash_dir}/dtb.bin"
+      rm -f "${dtb_bin}"
+      # dtb.bin is only used in UFS based boards at the moment and UFS uses a
+      # 4k sector size, so pass -S 4096
+      # in qcom-ptool/platforms/*/partitions.conf, dtb_a and _b partitions
+      # are provisioned with 64MiB; create a 4MiB FAT that will comfortably fit
+      # in these and hold the target device tree, which is 4096 KiB sized
+      # blocks for mkfs.vfat's last argument
+      mkfs.vfat -S 4096 -C "${dtb_bin}" 4096
+      # RB3 Gen2 Vision Kit will probably have a more specific DTB (see
+      # <20241204100003.300123-6-quic_vikramsa@quicinc.com> on lore.kernel.org)
+      # but for now use the core kit one
+      dtb="qcom/qcs6490-rb3gen2.dtb"
+      # extract board device tree from the root filesystem provided tarball
+      tar -C build -xvf "${ARTIFACTDIR}/dtbs.tar.gz" "${dtb}"
+      # copy into the FAT as combined-dtb.dtb
+      mcopy -vmp -i "${dtb_bin}" "build/${dtb}" ::/combined-dtb.dtb
+
+      # (NB: flashing files already expect "dtb.bin" as a filename)
+
+      # update flashing files for ESP image;
+      # qcom-ptool/platforms/*/partitions.conf uses filename=efi.bin for the
+      # ESP partition on EFI capable platforms
+      sed -i '/label="efi"/s#filename="[^"]*"#filename="../disk-ufs.img1"#' \
+          "${flash_dir}"/rawprogram*.xml
+
+      # update flashing files for rootfs image;
+      # qcom-ptool/platforms/*/partitions.conf uses filename=rootfs.img for the
+      # rootfs partition
+      sed -i \
+          '/label="rootfs"/s#filename="[^"]*"#filename="../disk-ufs.img2"#' \
+          "${flash_dir}"/rawprogram*.xml
+
+      # cleanup
+      rm -rf build
+

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -56,12 +56,13 @@ actions:
 
   # XXX these kernel options might be specific to a kernel version or board
   - action: filesystem-deploy
+    description: Deploy root filesystem to mounted image
     setup-fstab: true
     append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30
 
   - action: apt
-    recommends: true
     description: Make system bootable with systemd-boot
+    recommends: true
     packages:
       - systemd-boot
       # TODO investigate why systemd-boot Recommends: shim-signed which

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -97,6 +97,20 @@ actions:
       systemctl enable debos-grow-rootfs
 
   - action: run
+    description: Extract partition images
+    postprocess: true
+    command: |
+      set -eux
+      sector_size="{{if eq $imagetype "ufs"}}4096{{else}}512{{end}}"
+      image="{{ $image }}"
+      fdisk -b "${sector_size}" -l "${image}" |
+          sed -n '1,/^Device/ d; p' |
+          while read name start end sectors rest; do
+              dd if="${image}" of="${ARTIFACTDIR}/${name}" \
+                  bs="${sector_size}" skip="${start}" count="${sectors}"
+          done
+
+  - action: run
     description: Compress image file
     postprocess: true
     command: gzip -v -f "${ARTIFACTDIR}/{{ $image }}"

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -4,7 +4,7 @@
 {{- $image := printf "disk-%s.img" $imagetype }}
 
 architecture: arm64
-sectorsize: {{if eq $imagetype "ufs"}} 4096 {{else}} 512 {{end}}
+sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
 
 actions:
   - action: unpack

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -96,6 +96,7 @@ actions:
       systemctl enable debos-grow-rootfs
 
   - action: run
+    description: Compress image file
     postprocess: true
     command: gzip -v -f "${ARTIFACTDIR}/{{ $image }}"
 

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -5,6 +5,7 @@ architecture: arm64
 
 actions:
   - action: debootstrap
+    description: Bootstrap initial filesystem
     # NB: not currently configurable
     suite: trixie
     components:
@@ -190,6 +191,7 @@ actions:
 {{- end }}
 
   - action: pack
+    description: Create root filesystem tarball
     file: rootfs.tar.gz
     compression: gz
 

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -190,6 +190,23 @@ actions:
           /etc/apt/sources.list.d/debian-experimental.sources
 {{- end }}
 
+  - action: run
+    description: Create DTBs tarball
+    chroot: false
+    command: |
+      set -eux
+      # find the highest kernel version installed; kernels are backwards
+      # compatible with older dtbs, so it would make sense to take dtbs from
+      # the oldest available kernel as to allow all kernels to boot, but if
+      # this image has pulled a more recent kernel, it's probably to gain
+      # support for new hardware which would happen through new or updated dtbs
+      # only in that new kernel, so use the latest dtbs
+      latest_kernel="$(
+          ls -d "$ROOTDIR"/usr/lib/linux-image-* | sort -V | tail -1)"
+      tar -C "${latest_kernel}" -cvzf "$ARTIFACTDIR/dtbs.tar.gz" \
+          qcom/qcs6490-rb3gen2.dtb \
+          qcom/qrb2210-rb1.dtb
+
   - action: pack
     description: Create root filesystem tarball
     file: rootfs.tar.gz


### PR DESCRIPTION
Recipes:
- add missing descriptions
- rootfs: create a tarball with DTBs
- image: extract partition images
- flash: new recipe to generate flat images

workflows: Generate flashable assets and upload these to fileserver

README: update

Fixes #10 
