### PR TITLE
Flat images for RB1

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -106,7 +106,12 @@ jobs:
           cp -av dtbs.tar.gz "${dir}"
           cp -av disk-ufs.img.gz "${dir}"
           cp -av disk-sdcard.img.gz "${dir}"
-          tar -cvf "${dir}"/flash.tar.gz disk-ufs.img1 disk-ufs.img2 flash_*
+          tar -cvf "${dir}"/flash.tar.gz \
+              disk-ufs.img1 \
+              disk-ufs.img2 \
+              disk-sdcard.img1 \
+              disk-sdcard.img2 \
+              flash_*
           # instruct fileserver to publish this directory
           url="${FILESERVER_URL}/${id}/"
           curl -X POST -H 'Accept: text/event-stream' "${url}"

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -106,12 +106,15 @@ jobs:
           cp -av dtbs.tar.gz "${dir}"
           cp -av disk-ufs.img.gz "${dir}"
           cp -av disk-sdcard.img.gz "${dir}"
-          tar -cvf "${dir}"/flash.tar.gz \
+          # TODO: separate flash_* directories between UFS and eMMC
+          tar -cvf "${dir}"/flash-ufs.tar.gz \
               disk-ufs.img1 \
               disk-ufs.img2 \
+              flash_rb3*
+          tar -cvf "${dir}"/flash-emmc.tar.gz \
               disk-sdcard.img1 \
               disk-sdcard.img2 \
-              flash_*
+              flash_rb1*
           # instruct fileserver to publish this directory
           url="${FILESERVER_URL}/${id}/"
           curl -X POST -H 'Accept: text/event-stream' "${url}"

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -38,11 +38,26 @@ jobs:
       image: debian:trixie
       volumes:
         - /srv/gh-runners/quic-yocto/builds:/fileserver-builds
+        - /srv/gh-runners/quic-yocto/downloads/qcom-deb-images:/fileserver-downloads
       options: --privileged
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Copy Linux deb and U-Boot for RB1 from fileserver's downloads
+        run: |
+            set -ux
+            mkdir -v local-debs
+            # copy linux-image but not the -dbg e.g.
+            # linux-image-6.15.0-..._6.15.0...-1_arm64.deb but not
+            # linux-image-6.15.0-...-dbg_6.15.0...-1_arm64.deb
+            find /fileserver-downloads/linux-deb-latest/ \
+                -name linux-image\*.deb \
+                -not -name linux-image\*-dbg_\*.deb \
+                -exec cp -av '{}' local-debs/ \;
+            # copy U-Boot RB1 binary
+            cp -av /fileserver-downloads/u-boot-rb1-latest/rb1-boot.img .
 
       # make sure we have latest packages first, to get latest fixes and to
       # avoid an automated update while we're building
@@ -60,7 +75,7 @@ jobs:
         run: |
           set -x
           # start by building the root filesystem
-          debos qualcomm-linux-debian-rootfs.yaml
+          debos -t localdebs:local-debs/ qualcomm-linux-debian-rootfs.yaml
           # debos tries KVM and UML as backends, and falls back to
           # building directly on the host, but that requires loop
           # devices; use qemu backend explicitly even if it's slower
@@ -72,7 +87,7 @@ jobs:
           debos -b qemu --scratchsize 4GiB -t imagetype:sdcard \
               qualcomm-linux-debian-image.yaml
           # build flashable files
-          debos qualcomm-linux-debian-flash.yaml
+          debos -t u_boot_rb1:rb1-boot.img qualcomm-linux-debian-flash.yaml
 
       - name: Upload artifacts to fileserver
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
             apt -y install git crossbuild-essential-arm64 make flex bison bc \
                 libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev \
                 debhelper-compat kmod python3 rsync coreutils
-            scripts/build-linux-deb.sh
+            scripts/build-linux-deb.sh kernel-configs/systemd-boot.config
 
       - name: Upload results to fileserver
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,84 @@
+name: Build Linux kernel deb
+
+on:
+  # run weekly on Monday at 8:30am
+  schedule:
+    - cron: '30 8 * * 1'
+  # allow manual runs
+  workflow_dispatch:
+
+# only need permission to read repository; implicitely set all other
+# permissions to none
+permissions:
+  contents: read
+
+env:
+  # where results will be posted/hosted
+  FILESERVER_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
+  # github runs are only unique per repository and may also be re-run; create a
+  # build id for the current run
+  BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+# cancel in progress builds for this workflow triggered by the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux-deb:
+    # for cross-builds
+    runs-on: [self-hosted, x86]
+    # alternative for native builds, but overkill to do both
+    #runs-on: [self-hosted, arm64, debbuilder]
+    container:
+      image: debian:trixie
+      volumes:
+        - /srv/gh-runners/quic-yocto/builds:/fileserver-builds
+        - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # make sure we have latest packages first, to get latest fixes, to avoid
+      # an automated update while we're building, and to prevent version skews
+      - name: Update OS packages
+        run: |
+          set -ux
+          apt update
+          apt -y upgrade
+          apt -y full-upgrade
+
+      - name: Build Linux kernel deb
+        run: |
+            set -ux
+            # download arm64 package lists to install cross build-dependencies
+            if [ "$(dpkg --print-architecture)" != arm64 ]; then
+                dpkg --add-architecture arm64
+                apt update
+            fi
+            # install build-dependencies; TODO: --no-install-recommends
+            apt -y install git crossbuild-essential-arm64 make flex bison bc \
+                libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev \
+                debhelper-compat kmod python3 rsync coreutils
+            scripts/build-linux-deb.sh
+
+      - name: Upload results to fileserver
+        run: |
+          set -ux
+          # dcmd from devscripts will be used to parse .changes file
+          apt -y install --no-install-recommends devscripts
+          # curl will be used to talk to fileserver; should be installed by
+          # default
+          apt -y install curl
+          # copy to fileserver builds and downloads directories
+          for dir in "/fileserver-builds/${BUILD_ID}" \
+              "/fileserver-downloads/qcom-deb-images/linux-deb-latest"; do
+              mkdir -vp "${dir}"
+              cp -av `dcmd *.changes` "${dir}"
+          done
+          # perhaps help NFS sync
+          sync
+          # instruct fileserver to publish this directory
+          url="${FILESERVER_URL}/${BUILD_ID}/"
+          curl -X POST -H 'Accept: text/event-stream' "${url}"

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -1,0 +1,79 @@
+name: Build U-Boot for RB1
+
+on:
+  # allow manual runs
+  workflow_dispatch:
+
+# only need permission to read repository; implicitely set all other
+# permissions to none
+permissions:
+  contents: read
+
+env:
+  # where results will be posted/hosted
+  FILESERVER_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
+  # github runs are only unique per repository and may also be re-run; create a
+  # build id for the current run
+  BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+# cancel in progress builds for this workflow triggered by the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-u-boot-rb1:
+    # for cross-builds
+    runs-on: [self-hosted, x86]
+    # alternative for native builds, but overkill to do both
+    #runs-on: [self-hosted, arm64, debbuilder]
+    container:
+      image: debian:trixie
+      volumes:
+        - /srv/gh-runners/quic-yocto/builds:/fileserver-builds
+        - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # make sure we have latest packages first, to get latest fixes, to avoid
+      # an automated update while we're building, and to prevent version skews
+      - name: Update OS packages
+        run: |
+          set -ux
+          apt update
+          apt -y upgrade
+          apt -y full-upgrade
+
+      - name: Build U-Boot Android boot image for RB1
+        run: |
+            set -ux
+            # install build-dependencies
+            apt -y install git crossbuild-essential-arm64 make bison flex bc \
+                libssl-dev gnutls-dev xxd coreutils gzip mkbootimg
+            scripts/build-u-boot-rb1.sh
+
+      - name: Upload results to fileserver
+        run: |
+          set -ux
+          # curl will be used to talk to fileserver; should be installed by
+          # default
+          apt -y install curl
+          for dir in "/fileserver-builds/${BUILD_ID}" \
+              "/fileserver-downloads/qcom-deb-images/u-boot-rb1-latest"; do
+              mkdir -vp "${dir}"
+              cp -av \
+                  u-boot/u-boot-nodtb.bin.gz \
+                  u-boot/dts/upstream/src/arm64/qcom/qrb2210-rb1.dtb \
+                  u-boot/u-boot-nodtb.bin.gz-dtb \
+                  u-boot/u-boot.bin \
+                  u-boot/rb1-boot.img \
+                  "${dir}"
+          done
+          # perhaps help NFS sync
+          sync
+          # instruct fileserver to publish this directory
+          url="${FILESERVER_URL}/${BUILD_ID}/"
+          curl -X POST -H 'Accept: text/event-stream' "${url}"
+

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ U-Boot will be chainloaded from the first Android boot partition.
     sudo apt install git build-essential crossbuild-essential-arm64 flex bison libssl-dev gnutls-dev mkbootimg
     ```
 
-1. get the qcom-mainline branch from Sumit Garg's U-Boot repository ([upstream submission](https://patchwork.ozlabs.org/project/uboot/list/?series=451544))
+1. get the qcom-mainline branch from Sumit Garg's U-Boot repository ([upstream submission](https://lore.kernel.org/u-boot/20250410080027.208674-1-sumit.garg@kernel.org/))
     ```bash
     git clone -b qcom-mainline https://github.com/b49020/u-boot/
     ```

--- a/README.md
+++ b/README.md
@@ -131,24 +131,14 @@ debos \
 
 U-Boot will be chainloaded from the first Android boot partition.
 
-1. install build-dependencies to build U-Boot and to generate Android boot images
-    ```bash
-    sudo apt install git build-essential crossbuild-essential-arm64 flex bison libssl-dev gnutls-dev mkbootimg
-    ```
+A convenience shell script is provided to checkout the relevant U-Boot branch and to build U-Boot for RB1 and wrap it in an Android boot image.
 
-1. get the qcom-mainline branch from Sumit Garg's U-Boot repository ([upstream submission](https://lore.kernel.org/u-boot/20250410080027.208674-1-sumit.garg@kernel.org/))
-    ```bash
-    git clone -b qcom-mainline https://github.com/b49020/u-boot/
-    ```
+```bash
+sudo apt install git build-essential crossbuild-essential-arm64 flex bison \
+    libssl-dev gnutls-dev mkbootimg
 
-1. build U-Boot and pack it into an Android boot image with the RB1 DTB
-    ```bash
-    make qcom_defconfig
-    make -j`nproc` DEVICE_TREE=qcom/qrb2210-rb1
-    gzip u-boot-nodtb.bin
-    cat u-boot-nodtb.bin.gz dts/upstream/src/arm64/qcom/qrb2210-rb1.dtb >u-boot-nodtb.bin.gz-dtb
-    mkbootimg --base 0x80000000 --pagesize 4096 --kernel u-boot-nodtb.bin.gz-dtb  --cmdline "root=/dev/notreal" --ramdisk u-boot.bin --output rb1-boot.img
-    ```
+scripts/build-u-boot-rb1.sh
+```
 
 #### Build an upstream Linux kernel to workaround boot issues
 

--- a/README.md
+++ b/README.md
@@ -144,14 +144,14 @@ scripts/build-u-boot-rb1.sh
 
 Linux 6.14 or later will just work, but 6.13 kernels need `CONFIG_CLK_QCM2290_GPUCC=m` ([upstream submission](https://lore.kernel.org/linux-arm-msm/20250214-rb1-enable-gpucc-v1-1-346b5b579fca@linaro.org/))
 
-In any case, make sure to set `CONFIG_EFI_ZBOOT=y` as [systemd-boot won't implement support for compressed images (zImage)](https://github.com/systemd/systemd/issues/23788).
+In any case, make sure to set `CONFIG_EFI_ZBOOT=y` as [systemd-boot won't implement support for compressed images (zImage)](https://github.com/systemd/systemd/issues/23788); the kernel config fragment in `kernel-configs/systemd-boot.config` does this.
 
 1. A convenience shell script is provided to checkout the latest kernel and build a deb package from it with the above config.
     ```bash
     sudo apt install git crossbuild-essential-arm64 make flex bison bc \
         libelf-dev libssl-dev dpkg-dev debhelper-compat kmod python3 rsync \
         coreutils
-    scripts/build-linux-deb.sh
+    scripts/build-linux-deb.sh kernel-configs/systemd-boot.config
     ```
 
 1. on an arm64 capable machine, chroot into the disk image's root filesystem, mount the ESP and install the kernel

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `xfcedesktop`: install a Xfce desktop environment; default: console only environment
 
 For the image recipe:
-- dtb: override the firmware provided device tree with one from the linux kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override
-- imagetype: either `ufs` (the default) or (`sdcard`); UFS images are named disk-ufs.img and use 4096 bytes sectors and SD card images are named disk-sdcard.img and use 512 bytes sectors
-- imagesize: set the output disk image size; default: `4GiB`
+- `dtb`: override the firmware provided device tree with one from the linux kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override
+- `imagetype`: either `ufs` (the default) or (`sdcard`); UFS images are named disk-ufs.img and use 4096 bytes sectors and SD card images are named disk-sdcard.img and use 512 bytes sectors
+- `imagesize`: set the output disk image size; default: `4GiB`
+
+For the flash recipe:
+- `u_boot_rb1`: prebuilt U-Boot binary for RB1 in Android boot image format -- see below (NB: debos expects relative pathnames)
 
 Here are some example invocations:
 ```bash

--- a/README.md
+++ b/README.md
@@ -144,12 +144,14 @@ scripts/build-u-boot-rb1.sh
 
 Linux 6.14 or later will just work, but 6.13 kernels need `CONFIG_CLK_QCM2290_GPUCC=m` ([upstream submission](https://lore.kernel.org/linux-arm-msm/20250214-rb1-enable-gpucc-v1-1-346b5b579fca@linaro.org/))
 
-1. install build-dependencies, get latest kernel (or a stable one)
+In any case, make sure to set `CONFIG_EFI_ZBOOT=y` as [systemd-boot won't implement support for compressed images (zImage)](https://github.com/systemd/systemd/issues/23788).
+
+1. A convenience shell script is provided to checkout the latest kernel and build a deb package from it with the above config.
     ```bash
-    sudo apt install git flex bison bc libelf-dev libssl-dev
-    git clone --depth=1  https://github.com/torvalds/linux
-    make defconfig
-    make deb-pkg -j$(nproc)
+    sudo apt install git crossbuild-essential-arm64 make flex bison bc \
+        libelf-dev libssl-dev dpkg-dev debhelper-compat kmod python3 rsync \
+        coreutils
+    scripts/build-linux-deb.sh
     ```
 
 1. on an arm64 capable machine, chroot into the disk image's root filesystem, mount the ESP and install the kernel

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ debos --fakemachine-backend qemu --memory 1GiB --scratchsize 4GiB debos-recipes/
 ### Build options
 
 A few options are provided in the debos recipes; for the root filesystem recipe:
-- experimentalkernel: update the linux kernel to the version from experimental; default: don't update the kernel
-- xfcedesktop: install a Xfce desktop environment; default: console only environment
+- `experimentalkernel`: update the linux kernel to the version from experimental; default: don't update the kernel
+- `localdebs`: path to a directory with local deb packages to install (NB: debos expects relative pathnames)
+- `xfcedesktop`: install a Xfce desktop environment; default: console only environment
 
 For the image recipe:
 - dtb: override the firmware provided device tree with one from the linux kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override

--- a/README.md
+++ b/README.md
@@ -111,21 +111,21 @@ The RB1 board boots from eMMC by default and uses an Android style boot architec
 
 #### Build disk-sdcard.img with debos
 As above, build a SD card image as it's using a 512 sector size, like eMMC on the RB1:
-    ```bash
-    debos \
-        --fakemachine-backend qemu \
-        --memory 1GiB \
-        --scratchsize 4GiB \
-        -t xfcedesktop:true \
-        debos-recipes/qualcomm-linux-debian-rootfs.yaml
-    debos \
-        --fakemachine-backend qemu \
-        --memory 1GiB \
-        --scratchsize 4GiB \
-        -t dtb:qcom/qrb2210-rb1.dtb \
-        -t imagetype:sdcard \
-        debos-recipes/qualcomm-linux-debian-image.yaml
-    ```
+```bash
+debos \
+    --fakemachine-backend qemu \
+    --memory 1GiB \
+    --scratchsize 4GiB \
+    -t xfcedesktop:true \
+    debos-recipes/qualcomm-linux-debian-rootfs.yaml
+debos \
+    --fakemachine-backend qemu \
+    --memory 1GiB \
+    --scratchsize 4GiB \
+    -t dtb:qcom/qrb2210-rb1.dtb \
+    -t imagetype:sdcard \
+    debos-recipes/qualcomm-linux-debian-image.yaml
+```
 
 #### Build U-Boot with RB1 support
 

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -1,3 +1,8 @@
+{{- $build_rb1 := "false" -}}
+{{- if .u_boot_rb1 -}}
+{{- $build_rb1 := "true" }}
+{{- end -}}
+
 architecture: arm64
 
 actions:
@@ -7,6 +12,15 @@ actions:
     name: qcom-ptool
     filename: qcom-ptool.tar.gz
     unpack: true
+
+{{- if .u_boot_rb1 }}
+  # TODO: consider switching to https://releases.linaro.org/96boards/rb1/qualcomm/firmware/RB1_firmware_20231124-v4.zip instead
+  - action: download
+    description: Download RB1 rescue image
+    url: https://releases.linaro.org/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip
+    name: qrb2210-rb1_rescue-image.zip
+    filename: qrb2210-rb1_rescue-image.zip
+{{- end }}
 
   - action: download
     description: Download QCM6490 boot binaries
@@ -21,7 +35,7 @@ actions:
     filename: rb3gen2-vision-kit_cdt.zip
 
   - action: run
-    description: Generate flash directories for UFS boards
+    description: Generate flash directories for eMMC and UFS boards
     chroot: false
     command: |
       set -eux
@@ -30,6 +44,43 @@ actions:
 
       # path to unpacked qcom-ptool tarball
       QCOM_PTOOL="${ROOTDIR}/../qcom-ptool.tar.gz.d/qcom-ptool-main"
+
+{{- if .u_boot_rb1 }}
+      ### board: qrb2210-rb1
+      # unpack rescue image
+      unzip -j "${ROOTDIR}/../qrb2210-rb1_rescue-image.zip" \
+          -d build/qrb2210-rb1_rescue-image
+      # TODO: on RB1, we don't generate partition files with ptool since its
+      # partitions.conf does not have entries for data files from the rescue
+      # image, while the rescue image defines useful partitions such as the ESP
+      flash_dir="${ARTIFACTDIR}/flash_rb1"
+      rm -rf "${flash_dir}"
+      mkdir -v "${flash_dir}"
+      # copy rescue image files
+      cp --preserve=mode,timestamps -v build/qrb2210-rb1_rescue-image/* \
+          "${flash_dir}"
+      # copy RB1 U-Boot binary to u-boot-abootimg.img
+      cp --preserve=mode,timestamps -v "${ARTIFACTDIR}/{{- .u_boot_rb1 -}}" \
+          "${flash_dir}/rb1-boot.img"
+
+      # update flashing file for RB1 U-Boot; in the rescue image, this
+      # partition is blanked with boot-erase.img
+      sed -i '/label="boot_a"/s/filename="[^"]*"/filename="rb1-boot.img"/' "${flash_dir}"/rawprogram*.xml
+
+      # update flashing files for ESP image; in the rescue image, this
+      # partition is blanked with boot-erase.img
+      sed -i '/label="esp"/s#filename="[^"]*"#filename="../disk-sdcard.img1"#' "${flash_dir}"/rawprogram*.xml
+
+      # update flashing files for rootfs image;; in the rescue image, this
+      # partition is not provisioned
+      sed -i '/label="rootfs"/s#filename="[^"]*"#filename="../disk-sdcard.img2"#' "${flash_dir}"/rawprogram*.xml
+
+      # TODO: there is currently no dtb.bin alike system with the RB1 firmware
+
+      # TODO: currently not providing CDT; it's present in
+      # RB1_firmware_20231124-v4.zip but not in
+      # rb1-bootloader-emmc-linux-47528.zip
+{{- end }}
 
       ## platform: QCM6490
       # unpack boot binaries
@@ -45,6 +96,8 @@ actions:
           # partitions.conf sets --type=emmc, nand or ufs
           if grep -F '^--disk --type=ufs ' "${conf}"; then
               touch flash-ufs
+          elif grep -F '^--disk --type=emmc ' "${conf}"; then
+              touch flash-emmc
           fi
           "${QCOM_PTOOL}/ptool.py" -x ptool-partitions.xml
       )

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -176,3 +176,5 @@ actions:
       # cleanup
       rm -rf build
 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -136,3 +136,5 @@ actions:
     postprocess: true
     command: gzip -v -f "${ARTIFACTDIR}/{{ $image }}"
 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -69,6 +69,27 @@ actions:
       # Depends on grub packages
       - shim-signed-
 
+  # this is to provide an updated copy of DTBs from the OS to U-Boot, notably
+  # on RB1
+  - action: run
+    description: Setup copying of DTBs to ESP partition
+    chroot: true
+    command: |
+      set -eux
+      # u-boot-efi-dtb installs a kernel hook that will trigger on kernel
+      # installation/upgrade, but also calls it explicitely in its postinst in
+      # case it was installed after the kernel; it requires an ESP partition to
+      # copy the DTBs though, so install it after the ESP partition is
+      # available
+      apt -y install u-boot-efi-dtb
+      # when building under debos, /sys/firmware/efi is not always present, so
+      # the u-boot-efi-dtb postinst doesn't install an initial copy of the
+      # DTBs; do this once here
+      latest_kernel="$(
+          linux-version list | linux-version sort --reverse | head -1)"
+      dtb_path="/usr/lib/linux-image-${latest_kernel}"
+      cp -RT "$dtb_path" "/boot/efi/dtb"
+
   - action: run
     description: Create task to grow root filesystem on first boot
     chroot: true

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -1,5 +1,6 @@
 {{- $xfcedesktop := or .xfcedesktop "false" }}
 {{- $experimentalkernel := or .experimentalkernel "false" }}
+{{- $localdebs := or .localdebs "none" }}
 
 architecture: arm64
 
@@ -188,6 +189,20 @@ actions:
       # disable experimental from APT sources
       sed -i "1s/^/Enabled: no\n/" \
           /etc/apt/sources.list.d/debian-experimental.sources
+{{- end }}
+
+{{- if ne $localdebs "none" }}
+  - action: overlay
+    description: Overlay local debs directory {{ $localdebs }} to /root/
+    source: {{ $localdebs }}
+    destination: /root/
+
+  - action: run
+    description: Install local debs from /root/
+    chroot: yes
+    command: |
+      set -eux
+      apt -y install /root/*.deb
 {{- end }}
 
   - action: run

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -191,6 +191,15 @@ actions:
           /etc/apt/sources.list.d/debian-experimental.sources
 {{- end }}
 
+  # this is currently needed on boards such as RB1 which are using Android
+  # bootloader to check the boot count of the boot_a/boot_b partitions
+  - action: apt
+    description: Support boards chainloading from Android bootloader
+    recommends: true
+    packages:
+      # marks the current Android boot partition as booted successfully
+      - qbootctl
+
 {{- if ne $localdebs "none" }}
   - action: overlay
     description: Overlay local debs directory {{ $localdebs }} to /root/

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -236,3 +236,5 @@ actions:
     file: rootfs.tar.gz
     compression: gz
 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/kernel-configs/systemd-boot.config
+++ b/kernel-configs/systemd-boot.config
@@ -1,0 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# systemd-boot won't implement support for compressed images (zImage); see
+# https://github.com/systemd/systemd/issues/23788
+CONFIG_EFI_ZBOOT=y

--- a/scripts/build-linux-deb.sh
+++ b/scripts/build-linux-deb.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -eu
+
+# git repo/branch to use
+GIT_REPO="https://github.com/torvalds/linux"
+GIT_BRANCH="master"
+# base config to use
+CONFIG="defconfig"
+# extra configs to set
+# systemd-boot won't implement support for compressed images (zImage); see
+# https://github.com/systemd/systemd/issues/23788
+EXTRA_CONFIGS="CONFIG_EFI_ZBOOT=y"
+
+log_i() {
+    echo "I: $*" >&2
+}
+
+fatal() {
+    echo "F: $*" >&2
+    exit 1
+}
+
+# needed to clone repository
+packages="git"
+# will pull gcc-aarch64-linux-gnu; should pull a native compiler on arm64 and
+# a cross-compiler on other architectures
+packages="${packages} crossbuild-essential-arm64"
+# linux build-dependencies
+packages="${packages} make flex bison bc libelf-dev libssl-dev libssl-dev:arm64"
+# linux build-dependencies for debs
+packages="${packages} dpkg-dev debhelper-compat kmod python3 rsync"
+# for nproc
+packages="${packages} coreutils"
+
+log_i "Checking build-dependencies ($packages)"
+missing=""
+for pkg in ${packages}; do
+    # check if package with this name is installed
+    if dpkg -l "${pkg}" 2>&1 | grep -q "^ii  ${pkg}"; then
+        continue
+    fi
+    # otherwise, check if it's a virtual package and if some package providing
+    # it is installed
+    providers="$(apt-cache showpkg "${pkg}" |
+                     sed -e '1,/^Reverse Provides: *$/ d' -e 's/ .*$//' |
+                     sort -u)"
+    provider_found="no"
+    for provider in ${providers}; do
+        if dpkg -l "${provider}" 2>&1 | grep -q "^ii  ${provider}"; then
+            provider_found="yes"
+            break
+        fi
+    done
+    if [ "${provider_found}" = yes ]; then
+        continue
+    fi
+    missing="${missing} ${pkg}"
+done
+if [ -n "${missing}" ]; then
+    fatal "Missing build-dependencies: ${missing}"
+fi
+
+log_i "Cloning Linux (${GIT_REPO}:${GIT_BRANCH})"
+git clone --depth=1 --branch "${GIT_BRANCH}" "${GIT_REPO}" linux
+
+cd linux
+
+log_i "Configuring Linux (${CONFIG}, ${EXTRA_CONFIGS})"
+rm -vf kernel/configs/local.config
+touch kernel/configs/local.config
+for c in ${EXTRA_CONFIGS}; do
+    echo "${c}" >>kernel/configs/local.config
+done
+make ARCH=arm64 "${CONFIG}" local.config
+
+log_i "Building Linux deb"
+# TODO: build other packages?
+make -j$(nproc) \
+    ARCH=arm64 DEB_HOST_ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- \
+    bindeb-pkg
+

--- a/scripts/build-u-boot-rb1.sh
+++ b/scripts/build-u-boot-rb1.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -eu
+
+# patches in this repo/branch were submitted upstream here:
+# https://lore.kernel.org/u-boot/20250410080027.208674-1-sumit.garg@kernel.org/
+GIT_REPO="https://github.com/b49020/u-boot"
+GIT_BRANCH="qcom-mainline"
+CONFIG="qcom_defconfig"
+U_BOOT_DEVICE_TREE="qcom/qrb2210-rb1"
+ABOOT_BASE_ADDRESS="0x80000000"
+ABOOT_PAGE_SIZE="4096"
+ABOOT_OUTPUT="rb1-boot.img"
+
+log_i() {
+    echo "I: $*" >&2
+}
+
+fatal() {
+    echo "F: $*" >&2
+    exit 1
+}
+
+# needed to clone repository
+packages="git"
+# will pull gcc-aarch64-linux-gnu; should pull a native compiler on arm64 and
+# a cross-compiler on other architectures
+packages="${packages} crossbuild-essential-arm64"
+# u-boot build-dependencies
+packages="${packages} make bison flex bc libssl-dev gnutls-dev xxd"
+# for nproc
+packages="${packages} coreutils"
+# needed to pack resulting u-boot binary into an Android boot image
+packages="${packages} gzip mkbootimg"
+
+log_i "Checking build-dependencies ($packages)"
+missing=""
+for pkg in ${packages}; do
+    # check if package with this name is installed
+    if dpkg -l "${pkg}" 2>&1 | grep -q "^ii  ${pkg}"; then
+        continue
+    fi
+    # otherwise, check if it's a virtual package and if some package providing
+    # it is installed
+    providers="$(apt-cache showpkg "${pkg}" |
+                     sed -e '1,/^Reverse Provides: *$/ d' -e 's/ .*$//' |
+                     sort -u)"
+    provider_found="no"
+    for provider in ${providers}; do
+        if dpkg -l "${provider}" 2>&1 | grep -q "^ii  ${provider}"; then
+            provider_found="yes"
+            break
+        fi
+    done
+    if [ "${provider_found}" = yes ]; then
+        continue
+    fi
+    missing="${missing} ${pkg}"
+done
+if [ -n "${missing}" ]; then
+    fatal "Missing build-dependencies: ${missing}"
+fi
+
+log_i "Cloning U-Boot (${GIT_REPO}:${GIT_BRANCH})"
+git clone --depth=1 --branch "${GIT_BRANCH}" "${GIT_REPO}" u-boot
+
+cd u-boot
+
+log_i "Configuring U-Boot (${CONFIG})"
+make "${CONFIG}"
+
+log_i "Building U-Boot (with device tree ${U_BOOT_DEVICE_TREE})"
+make -j`nproc` \
+    CROSS_COMPILE=aarch64-linux-gnu- DEVICE_TREE="${U_BOOT_DEVICE_TREE}"
+
+log_i "Creating Android boot image (${ABOOT_OUTPUT})"
+gzip u-boot-nodtb.bin
+cat u-boot-nodtb.bin.gz \
+    "dts/upstream/src/arm64/${U_BOOT_DEVICE_TREE}.dtb" \
+    >u-boot-nodtb.bin.gz-dtb
+# dummy empty file as we don't need a ramdisk
+touch empty-ramdisk
+mkbootimg --base "${ABOOT_BASE_ADDRESS}" \
+    --pagesize "${ABOOT_PAGE_SIZE}" \
+    --kernel u-boot-nodtb.bin.gz-dtb  \
+    --cmdline "root=/dev/notreal" \
+    --ramdisk empty-ramdisk \
+    --output "${ABOOT_OUTPUT}"
+

--- a/scripts/disk-image-edit.sh
+++ b/scripts/disk-image-edit.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Input disk image and sector size


### PR DESCRIPTION
Progressively implement steps described in the README towards a working flat
image for RB1:
- build an Android boot image of U-Boot for RB1
- build an upstream Linux kernel
- add an option to include more debs in the root fs
- add support for generating flat images for RB1, taking the U-Boot binary as
  an input
- use all of this in our CI builds
- copy DTBs to ESP as to allow U-Boot to pickup newer DTs
- pre-install qbootctl as to avoid hitting the ABL failed boot count limit on boot_a
