### PR TITLE
debos: rootfs: Install adbd

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -28,6 +28,8 @@ actions:
     description: Install foundational packages
     recommends: true
     packages:
+      # Android Debug Bridge (daemon)
+      - adbd
       # bluetooth
       - bluez
       # vfat tools, notably fsck.fat for the ESP


### PR DESCRIPTION
After installation, adbd just comes up automatically on boot and can be
used to open shells or push/pull files.

Fixes: #24
