### PR TITLE
ci: debos: Enable Xfce

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -75,7 +75,8 @@ jobs:
         run: |
           set -x
           # start by building the root filesystem
-          debos -t localdebs:local-debs/ qualcomm-linux-debian-rootfs.yaml
+          debos -t xfcedesktop:true -t localdebs:local-debs/ \
+              qualcomm-linux-debian-rootfs.yaml
           # debos tries KVM and UML as backends, and falls back to
           # building directly on the host, but that requires loop
           # devices; use qemu backend explicitly even if it's slower


### PR DESCRIPTION
Xfce was initially disabled as to limit the size/duration of ours builds, but since we target Xfce by default and we want to use our builds as input for OSS compliance, enable Xfce to have a representative set of packages.