### PR TITLE
Cleanup debos recipe

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -39,6 +39,15 @@ jobs:
         - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
       options: --privileged
     steps:
+      # make sure we have latest packages first, to get latest fixes and to
+      # avoid an automated update while we're building
+      - name: Update OS packages
+        run: |
+          set -ux
+          apt update
+          apt -y upgrade
+          apt -y full-upgrade
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -58,27 +67,22 @@ jobs:
           # copy U-Boot RB1 binary
           cp -av "${dir}/u-boot-rb1-latest/rb1-boot.img" .
 
-      # make sure we have latest packages first, to get latest fixes and to
-      # avoid an automated update while we're building
-      - name: Update OS packages
-        run: |
-          set -x
-          apt update
-          apt -y upgrade
-          apt -y full-upgrade
-          # debos is needed to build recipes, mtools is needed for the flash
-          # recipe
-          apt -y install debos mtools
+      # mtools is needed for the flash recipe
+      - name: Install debos and dependencies of the recipes
+        run: apt -y install debos mtools
 
-      - name: Build debos recipe
+      - name: Build rootfs with debos
         run: |
-          set -x
-          # start by building the root filesystem
+          set -ux
           debos -t xfcedesktop:true -t localdebs:local-debs/ \
-              qualcomm-linux-debian-rootfs.yaml
+              debos-recipes/qualcomm-linux-debian-rootfs.yaml
+
+      - name: Build UFS and SD card images with debos
+        run: |
+          set -ux
           # debos tries KVM and UML as backends, and falls back to
           # building directly on the host, but that requires loop
-          # devices; use qemu backend explicitly even if it's slower
+          # devices; use qemu backend explicitly even if it's slower;
           # qemu backend also requires to set scratchsize, otherwise the
           # whole build is done from memory and the out of memory killer
           # gets triggered
@@ -86,9 +90,12 @@ jobs:
               debos-recipes/qualcomm-linux-debian-image.yaml
           debos -b qemu --scratchsize 4GiB -t imagetype:sdcard \
               debos-recipes/qualcomm-linux-debian-image.yaml
-          # build flashable files
+
+      - name: Build flashable files with debos
+        run: |
+          set -ux
           debos -t u_boot_rb1:rb1-boot.img \
-              debos-recipes/qualcomm-linux-debian-image.yaml
+                 debos-recipes/qualcomm-linux-debian-flash.yaml
 
       - name: Upload artifacts to fileserver
         run: |

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -50,18 +50,18 @@ jobs:
 
       - name: Copy Linux deb and U-Boot for RB1 from fileserver's downloads
         run: |
-            set -ux
-            mkdir -v local-debs
-            dir="/fileserver-downloads/qcom-deb-images"
-            # copy linux-image but not the -dbg e.g.
-            # linux-image-6.15.0-..._6.15.0...-1_arm64.deb but not
-            # linux-image-6.15.0-...-dbg_6.15.0...-1_arm64.deb
-            find "${dir}/linux-deb-latest/" \
-                -name linux-image\*.deb \
-                -not -name linux-image\*-dbg_\*.deb \
-                -exec cp -av '{}' local-debs/ \;
-            # copy U-Boot RB1 binary
-            cp -av "${dir}/u-boot-rb1-latest/rb1-boot.img" .
+          set -ux
+          mkdir -v local-debs
+          dir="/fileserver-downloads/qcom-deb-images"
+          # copy linux-image but not the -dbg e.g.
+          # linux-image-6.15.0-..._6.15.0...-1_arm64.deb but not
+          # linux-image-6.15.0-...-dbg_6.15.0...-1_arm64.deb
+          find "${dir}/linux-deb-latest/" \
+              -name linux-image\*.deb \
+              -not -name linux-image\*-dbg_\*.deb \
+              -exec cp -av '{}' local-debs/ \;
+          # copy U-Boot RB1 binary
+          cp -av "${dir}/u-boot-rb1-latest/rb1-boot.img" .
 
       # make sure we have latest packages first, to get latest fixes and to
       # avoid an automated update while we're building

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload artifacts to fileserver
         run: |
-          set -x
+          set -ux
           # curl will be used to talk to fileserver; should be installed by
           # default
           apt -y install curl

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -41,7 +41,7 @@ jobs:
       image: debian:trixie
       volumes:
         - /srv/gh-runners/quic-yocto/builds:/fileserver-builds
-        - /srv/gh-runners/quic-yocto/downloads/qcom-deb-images:/fileserver-downloads
+        - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
       options: --privileged
     steps:
       - uses: actions/checkout@v4
@@ -52,15 +52,16 @@ jobs:
         run: |
             set -ux
             mkdir -v local-debs
+            dir="/fileserver-downloads/qcom-deb-images"
             # copy linux-image but not the -dbg e.g.
             # linux-image-6.15.0-..._6.15.0...-1_arm64.deb but not
             # linux-image-6.15.0-...-dbg_6.15.0...-1_arm64.deb
-            find /fileserver-downloads/linux-deb-latest/ \
+            find "${dir}/linux-deb-latest/" \
                 -name linux-image\*.deb \
                 -not -name linux-image\*-dbg_\*.deb \
                 -exec cp -av '{}' local-debs/ \;
             # copy U-Boot RB1 binary
-            cp -av /fileserver-downloads/u-boot-rb1-latest/rb1-boot.img .
+            cp -av "${dir}/u-boot-rb1-latest/rb1-boot.img" .
 
       # make sure we have latest packages first, to get latest fixes and to
       # avoid an automated update while we're building

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -24,6 +24,9 @@ defaults:
     working-directory: debos-recipes
 
 env:
+  # github runs are only unique per repository and may also be re-run; create a
+  # build id for the current run
+  BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
   FILESERVER_URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app
 
 # cancel in progress builds for this workflow triggered by the same ref
@@ -96,11 +99,8 @@ jobs:
           # curl will be used to talk to fileserver; should be installed by
           # default
           apt -y install curl
-          # github runs are only unique per repository and may also be re-run;
-          # create an unique id with repository, run id, and run attempt
-          id="${GITHUB_REPOSITORY}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           # create a directory for the current run
-          dir="/fileserver-builds/${id}"
+          dir="/fileserver-builds/${BUILD_ID}"
           mkdir -vp "${dir}"
           # copy output files
           cp -av rootfs.tar.gz "${dir}"
@@ -117,6 +117,6 @@ jobs:
               disk-sdcard.img2 \
               flash_rb1*
           # instruct fileserver to publish this directory
-          url="${FILESERVER_URL}/${id}/"
+          url="${FILESERVER_URL}/${BUILD_ID}/"
           curl -X POST -H 'Accept: text/event-stream' "${url}"
 

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Copy Linux deb and U-Boot for RB1 from fileserver's downloads
+      - name: Copy Linux deb and U-Boot for RB1 from fileserver space for downloads
         run: |
           set -ux
           mkdir -v debos-recipes/local-debs
@@ -97,7 +97,7 @@ jobs:
           debos -t u_boot_rb1:rb1-boot.img \
                  debos-recipes/qualcomm-linux-debian-flash.yaml
 
-      - name: Upload artifacts to fileserver
+      - name: Upload artifacts to fileserver space for builds
         run: |
           set -ux
           # curl will be used to talk to fileserver; should be installed by

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -18,11 +18,6 @@ on:
 permissions:
   contents: read
 
-defaults:
-  # run all commands from the debos-recipes directory
-  run:
-    working-directory: debos-recipes
-
 env:
   # github runs are only unique per repository and may also be re-run; create a
   # build id for the current run
@@ -51,7 +46,7 @@ jobs:
       - name: Copy Linux deb and U-Boot for RB1 from fileserver's downloads
         run: |
           set -ux
-          mkdir -v local-debs
+          mkdir -v debos-recipes/local-debs
           dir="/fileserver-downloads/qcom-deb-images"
           # copy linux-image but not the -dbg e.g.
           # linux-image-6.15.0-..._6.15.0...-1_arm64.deb but not
@@ -59,7 +54,7 @@ jobs:
           find "${dir}/linux-deb-latest/" \
               -name linux-image\*.deb \
               -not -name linux-image\*-dbg_\*.deb \
-              -exec cp -av '{}' local-debs/ \;
+              -exec cp -av '{}' debos-recipes/local-debs/ \;
           # copy U-Boot RB1 binary
           cp -av "${dir}/u-boot-rb1-latest/rb1-boot.img" .
 
@@ -88,11 +83,12 @@ jobs:
           # whole build is done from memory and the out of memory killer
           # gets triggered
           debos -b qemu --scratchsize 4GiB -t imagetype:ufs \
-              qualcomm-linux-debian-image.yaml
+              debos-recipes/qualcomm-linux-debian-image.yaml
           debos -b qemu --scratchsize 4GiB -t imagetype:sdcard \
-              qualcomm-linux-debian-image.yaml
+              debos-recipes/qualcomm-linux-debian-image.yaml
           # build flashable files
-          debos -t u_boot_rb1:rb1-boot.img qualcomm-linux-debian-flash.yaml
+          debos -t u_boot_rb1:rb1-boot.img \
+              debos-recipes/qualcomm-linux-debian-image.yaml
 
       - name: Upload artifacts to fileserver
         run: |


### PR DESCRIPTION
These are misc cleanups extracted from the preliminary work to generate SBOMs with Syft – see https://github.com/qualcomm-linux/qcom-deb-images/pull/28
- **workflows: debos: Define BUILD_ID in environment**
- **workflows: debos: Consistent path for downloads**
- **workflows: debos: Consistent indentation**
- **workflows: debos: Drop working-directory default**
- **workflows: debos: Split in smaller steps**
- **workflows: debos: Consistent use of set -ux**
- **workflows: debos: Clarify fileserver's directories**
