### PR TITLE
debos: rootfs: Fix comments on RB1 WiFi deps

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -42,12 +42,12 @@ actions:
       - network-manager
       # standard networking files (/etc/hosts, /etc/services etc.)
       - netbase
-      # Qualcomm's IPC Router protocol; needed for WiFi on some ath10k devices
-      # such as on RB1
-      - qrtr-tools
-      # Qualcomm Remote Filesystem Service; this is a dependency of the
+      # Qualcomm's IPC Router protocol; this is a dependency of the
       # tqftpserv service, but it's actually not needed on RB1
       # TODO drop me once https://bugs.debian.org/1104039 is fixed
+      - qrtr-tools
+      # Qualcomm Remote Filesystem Service; needed for WiFi on
+      # some ath10k devices such as on RB1
       - rmtfs
       # TFTP server implementation for the QRTR protocol; needed for WiFi on
       # some ath10k devices such as on RB1


### PR DESCRIPTION
In the future, we will be able to drop qrtr-tools and not rmtfs; this
was a mistake in the comment only.

See discussion in:
https://github.com/qualcomm-linux/qcom-deb-images/pull/25#discussion_r2060619773
