### PR TITLE
debos: flash: v75 of boot binaries for QCM6490

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -24,7 +24,7 @@ actions:
 
   - action: download
     description: Download QCM6490 boot binaries
-    url: https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00058.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip
+    url: https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00075.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip
     name: qcm6490_boot-binaries
     filename: qcm6490_boot-binaries.zip
 


### PR DESCRIPTION
From Qualcomm Linux 1.4

Known changes:
- Boot KPI optimizations
- Update memmap holes dynamically as conventional memory
- Minor bug fixes
- Supporting 32-bit OEM ID
