### PR TITLE
Linux deb: Fix config fragment usage

### DIFF
--- a/scripts/build-linux-deb.sh
+++ b/scripts/build-linux-deb.sh
@@ -74,7 +74,7 @@ done
 # the command-line as these might be relative pathnames
 cd linux
 
-if [ -r kernel/configs/local.config]; then
+if [ -r kernel/configs/local.config ]; then
     make ARCH=arm64 "${CONFIG}" local.config
 else
     make ARCH=arm64 "${CONFIG}"


### PR DESCRIPTION
Fix a typo testing whether there is a local config fragment. This is
nasty in that it won't fail even under `set -e` as it's under an if
statement.
