### PR TITLE
Move debos build into separate workflow file

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -1,0 +1,15 @@
+name: Daily Build
+
+on:
+  # run daily at 8:30am
+  schedule:
+    - cron: '30 8 * * *'
+  # allow manual runs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-daily:
+    uses: ./.github/workflows/debos.yml

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,0 +1,12 @@
+name: Build on PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-pr:
+    uses: ./.github/workflows/debos.yml
+

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -1,0 +1,12 @@
+name: Build on push to branch
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-daily:
+    uses: ./.github/workflows/debos.yml

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -1,17 +1,11 @@
 name: Build debos recipe
 
 on:
-  # run on pull requests to the main branch
-  pull_request:
-    branches: [main]
-  # run on pushes to the main branch
-  push:
-    branches: [main]
-  # run daily at 8:30am
-  schedule:
-    - cron: '30 8 * * *'
-  # allow manual runs
-  workflow_dispatch:
+  workflow_call:
+    outputs:
+      artifacts_url:
+        description: "URL to retrieve build artifacts"
+        value: ${{ jobs.build-debos.outputs.url }}
 
 # only need permission to read repository; implicitely set all other
 # permissions to none
@@ -31,6 +25,8 @@ concurrency:
 
 jobs:
   build-debos:
+    outputs:
+      url: ${{ steps.upload_artifacts.outputs.url }}
     runs-on: [self-hosted, arm64, debbuilder]
     container:
       image: debian:trixie
@@ -98,6 +94,7 @@ jobs:
                  debos-recipes/qualcomm-linux-debian-flash.yaml
 
       - name: Upload artifacts to fileserver space for builds
+        id: upload_artifacts
         run: |
           set -ux
           # curl will be used to talk to fileserver; should be installed by
@@ -123,4 +120,5 @@ jobs:
           # instruct fileserver to publish this directory
           url="${FILESERVER_URL}/${BUILD_ID}/"
           curl -X POST -H 'Accept: text/event-stream' "${url}"
+          echo "url=\"${url}\"" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Start moving the build logic into separated files to copy the method of meta-qcom to run PR builds/tests with repo secrets.