### PR TITLE
ci: Move to new self-hosted runners

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -28,11 +28,11 @@ jobs:
   build-debos:
     outputs:
       url: ${{ steps.upload_artifacts.outputs.url }}
-    runs-on: [self-hosted, arm64, debbuilder]
+    runs-on: [self-hosted, qcom-u2404, arm64]
     container:
       image: debian:trixie
       volumes:
-        - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
+        - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
       options: --privileged
     steps:
       # make sure we have latest packages first, to get latest fixes and to

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,13 +28,13 @@ concurrency:
 jobs:
   build-linux-deb:
     # for cross-builds
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
     #runs-on: [self-hosted, arm64, debbuilder]
     container:
       image: debian:trixie
       volumes:
-        - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
+        - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -25,13 +25,13 @@ concurrency:
 jobs:
   build-u-boot-rb1:
     # for cross-builds
-    runs-on: [self-hosted, x86]
+    runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
     #runs-on: [self-hosted, arm64, debbuilder]
     container:
       image: debian:trixie
       volumes:
-        - /srv/gh-runners/quic-yocto/downloads:/fileserver-downloads
+        - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We have a new set of self-hosted runners that IT is providing. This change updates the labels to choose the correct self-hosted work along with updating the mount points for the persistent NFS volume