### PR TITLE
linux: Add new libdw-dev build-dep

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,7 +59,7 @@ jobs:
             fi
             # install build-dependencies; TODO: --no-install-recommends
             apt -y install git crossbuild-essential-arm64 make flex bison bc \
-                libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev \
+                libdw-dev libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev \
                 debhelper-compat kmod python3 rsync coreutils
             scripts/build-linux-deb.sh kernel-configs/systemd-boot.config
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ apt -y install git crossbuild-essential-arm64 make bison flex bc libssl-dev gnut
 
 Building a Linux kernel deb requires the following build-dependencies:
 ```bash
-apt -y install git crossbuild-essential-arm64 make flex bison bc libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev debhelper-compat kmod python3 rsync coreutils
+apt -y install git crossbuild-essential-arm64 make flex bison bc libdw-dev libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev debhelper-compat kmod python3 rsync coreutils
 ```
 
 ## Usage

--- a/scripts/build-linux-deb.sh
+++ b/scripts/build-linux-deb.sh
@@ -24,8 +24,9 @@ packages="git"
 # will pull gcc-aarch64-linux-gnu; should pull a native compiler on arm64 and
 # a cross-compiler on other architectures
 packages="${packages} crossbuild-essential-arm64"
-# linux build-dependencies
-packages="${packages} make flex bison bc libelf-dev libssl-dev libssl-dev:arm64"
+# linux build-dependencies; see linux/scripts/package/mkdebian
+packages="${packages} make flex bison bc libdw-dev libelf-dev libssl-dev"
+packages="${packages} libssl-dev:arm64"
 # linux build-dependencies for debs
 packages="${packages} dpkg-dev debhelper-compat kmod python3 rsync"
 # for nproc


### PR DESCRIPTION
libdw-dev:native was added to Build-Depends-Arch in
657f96cb7c06a2ef85d166f1b055baeb6511c324 and is needed to build linux
debs now.
