### PR TITLE
workflows: fix dependency name in build-on-push

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/lava-schema-check.yml
   test:
     uses: ./.github/workflows/test.yml
-    needs: [build, schema-check]
+    needs: [build-daily, schema-check]
     secrets: inherit
     with:
       url: ${{ needs.build.outputs.artifacts_url }}


### PR DESCRIPTION
Test job depends on build, but there was a mistake in the dependency name. This patches fixes the dependency to proper name.