### PR TITLE
Fix weekly CI builds for U-Boot and Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,17 +77,9 @@ jobs:
           export BUILD_DIR="/fileserver-downloads/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
           cp -av artifacts/* "${BUILD_DIR}"
-
           # create or update linux-deb-latest symlink
           mkdir -vp /fileserver-downloads/qcom-deb-images
-          (
-              cd /fileserver-downloads/qcom-deb-images
-              # remove what used to be a directory and create/update symlink to
-              # point to latest build
-              rm -rvf linux-latest
-              rm -rvf linux-deb-latest
-              ln -svf "../${BUILD_ID}" linux-deb-latest
-          )
+          ln -svf "../${BUILD_ID}" /fileserver-downloads/qcom-deb-images/linux-deb-latest
           # perhaps help NFS sync
           sync
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,19 +62,21 @@ jobs:
                 debhelper-compat kmod python3 rsync coreutils
             scripts/build-linux-deb.sh kernel-configs/systemd-boot.config
 
-      - name: Upload results to fileserver
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stage artifacts for upload
         run: |
           set -ux
           # dcmd from devscripts will be used to parse .changes file
           apt -y install --no-install-recommends devscripts
-          # python3-requests is used by publish_aritfacts.py
-          apt -y install python3-requests
-          # copy to fileserver builds and downloads directories
+          # stage artifacts in a directory
+          mkdir -v artifacts
+          cp -av `dcmd *.changes` artifacts
+
+      - name: Upload results to fileserver space for downloads
+        run: |
+          set -ux
           export BUILD_DIR="/fileserver-downloads/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
-          cp -av `dcmd *.changes` "${BUILD_DIR}"
+          cp -av artifacts/* "${BUILD_DIR}"
 
           # create or update linux-deb-latest symlink
           mkdir -vp /fileserver-downloads/qcom-deb-images
@@ -88,8 +90,10 @@ jobs:
           )
           # perhaps help NFS sync
           sync
-          # instruct fileserver to publish this directory
-          export URL="${FILESERVER_URL}/${BUILD_ID}/"
-          .github/workflows/publish_artifacts.py
-          echo Image available at: ${URL}
+
+      - name: Upload private artifacts
+        uses: qualcomm-linux/upload-private-artifact-action@v1
+        id: upload_artifacts
+        with:
+          path: artifacts
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
     # for cross-builds
     runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
-    #runs-on: [self-hosted, arm64, debbuilder]
+    #runs-on: [self-hosted, qcom-u2404, arm64]
     container:
       image: debian:trixie
       volumes:

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -26,7 +26,7 @@ jobs:
     # for cross-builds
     runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
-    #runs-on: [self-hosted, arm64, debbuilder]
+    #runs-on: [self-hosted, qcom-u2404, arm64]
     container:
       image: debian:trixie
       volumes:

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -70,9 +70,19 @@ jobs:
       - name: Upload results to fileserver space for downloads
         run: |
           set -ux
-          export BUILD_DIR="/fileserver-downloads/qcom-deb-images/u-boot-rb1-latest"
+          export BUILD_DIR="/fileserver-downloads/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
           cp -av artifacts/* "${BUILD_DIR}"
+
+          # create or update u-boot-rb1-latest symlink
+          mkdir -vp /fileserver-downloads/qcom-deb-images
+          (
+              cd /fileserver-downloads/qcom-deb-images
+              # remove what used to be a directory and create/update symlink to
+              # point to latest build
+              rm -rvf u-boot-rb1-latest
+              ln -svf "../${BUILD_ID}" u-boot-rb1-latest
+          )
           # perhaps help NFS sync
           sync
 

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -53,16 +53,10 @@ jobs:
                 libssl-dev gnutls-dev xxd coreutils gzip mkbootimg
             scripts/build-u-boot-rb1.sh
 
-      - name: Upload results to fileserver
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stage artifacts for upload
         run: |
           set -ux
-          # python3-requests is used by publish_aritfacts.py
-          apt -y install python3-requests
-
-          export BUILD_DIR="/fileserver-downloads/qcom-deb-images/u-boot-rb1-latest"
-          mkdir -vp ${BUILD_DIR}
+          mkdir -v artifacts
           cp -av \
               u-boot/u-boot-nodtb.bin.gz \
               u-boot/dts/upstream/src/arm64/qcom/qrb2210-rb1.dtb \
@@ -71,10 +65,20 @@ jobs:
               u-boot/rb1-boot.img \
               u-boot/u-boot-cap.bin \
               u-boot/u-boot.cab \
-              ${BUILD_DIR}
+              artifacts
+
+      - name: Upload results to fileserver space for downloads
+        run: |
+          set -ux
+          export BUILD_DIR="/fileserver-downloads/qcom-deb-images/u-boot-rb1-latest"
+          mkdir -vp "${BUILD_DIR}"
+          cp -av artifacts/* "${BUILD_DIR}"
           # perhaps help NFS sync
           sync
-          # instruct fileserver to publish this directory
-          export URL="${FILESERVER_URL}/${BUILD_ID}/"
-          .github/workflows/publish_artifacts.py
-          echo Image available at: ${URL}
+
+      - name: Upload private artifacts
+        uses: qualcomm-linux/upload-private-artifact-action@v1
+        id: upload_artifacts
+        with:
+          path: artifacts
+


### PR DESCRIPTION
Fix weekly and cleanup weekly workflows to use upload-private-artifact action
- **workflows: Update comments for native builds**
- **workflows: Use upload-private-artifact-action**
- **workflows: u-boot: Keep older builds**
- **workflows: linux: Remove transition code**
