### PR TITLE
workflows: u-boot: Add fwupd as build-dep

### DIFF
--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -50,7 +50,7 @@ jobs:
             set -ux
             # install build-dependencies
             apt -y install git crossbuild-essential-arm64 make bison flex bc \
-                libssl-dev gnutls-dev xxd coreutils gzip mkbootimg
+                libssl-dev gnutls-dev xxd coreutils gzip mkbootimg fwupd
             scripts/build-u-boot-rb1.sh
 
       - name: Stage artifacts for upload


### PR DESCRIPTION
Needed to run "fwupdtool build-cabinet".

Was missed when updating the script.
