### PR TITLE
workflows: Fix updating symlinks to directories

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,7 +79,7 @@ jobs:
           cp -av artifacts/* "${BUILD_DIR}"
           # create or update linux-deb-latest symlink
           mkdir -vp /fileserver-downloads/qcom-deb-images
-          ln -svf "../${BUILD_ID}" /fileserver-downloads/qcom-deb-images/linux-deb-latest
+          ln -fnsv "../${BUILD_ID}" /fileserver-downloads/qcom-deb-images/linux-deb-latest
           # perhaps help NFS sync
           sync
 

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -81,7 +81,7 @@ jobs:
               # remove what used to be a directory and create/update symlink to
               # point to latest build
               rm -rvf u-boot-rb1-latest
-              ln -svf "../${BUILD_ID}" u-boot-rb1-latest
+              ln -fnsv "../${BUILD_ID}" u-boot-rb1-latest
           )
           # perhaps help NFS sync
           sync


### PR DESCRIPTION
In weekly workflows, we upload new builds to their own directory and
then update a symlink pointing to the latest one. The symlink update
logic is currently broken.

Updating symlink to directories requires an extra flag to ln. Without
the flag, if a symlink already exists and points to a directory, a new
symlink is created under that directory instead of updating the symlink.

This is not attempting to fix the leftover symlinks on the fileserver
side, these will be garbage collected over time.
