### PR TITLE
ci: Fix Debian user/password in LAVA template

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -33,10 +33,15 @@ actions:
 - boot:
     auto_login:
       login_prompt: 'login:'
-      username: root
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - sudo su
     method: minimal
     prompts:
     - root@debian
+    - debian@debian
     timeout:
       minutes: 3
 - test:


### PR DESCRIPTION
Update auto_login section in LAVA template to match debian image settings.