### PR TITLE
ci: add rb1 test job template

### DIFF
--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -1,0 +1,70 @@
+actions:
+- deploy:
+    images:
+      image:
+        headers:
+          Authentication: Q_GITHUB_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}"
+    postprocess:
+      docker:
+        image: ghcr.io/foundriesio/lava-lmp-sign:main
+        steps:
+        - export IMAGE_PATH=$PWD
+        - cp overlay*.tar.gz overlay.tar.gz
+        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "STORAGE=emmc" >> $IMAGE_PATH/flash.settings
+        - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-rb1" >> $IMAGE_PATH/flash.settings
+        - cat $IMAGE_PATH/flash.settings
+    timeout:
+      minutes: 5
+    to: downloads
+- deploy:
+    images:
+      image:
+        url: downloads://{{BUILD_FILE_NAME}}
+      settings:
+        url: downloads://flash.settings
+      overlay:
+        url: downloads://overlay.tar.gz
+    timeout:
+      minutes: 5
+    to: flasher
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - sudo su
+    method: minimal
+    prompts:
+    - root@debian
+    - debian@debian
+    timeout:
+      minutes: 3
+- test:
+    definitions:
+    - from: git
+      name: "smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a"
+- command:
+    name: network_turn_on
+context:
+  lava_test_results_dir: /home/lava-%s
+  test_character_delay: 10
+device_type: qrb2210-rb1
+job_name: boot test (rb1) {{GITHUB_RUN_ID}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+timeouts:
+  job:
+    minutes: 15
+visibility: public


### PR DESCRIPTION
Add LAVA test job for RB1. The job only does minimal flashing and boot test.