### PR TITLE
ci: switch to AWS container registry

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -27,7 +27,7 @@ jobs:
       url: ${{ steps.upload_artifacts.outputs.url }}
     runs-on: [self-hosted, qcom-u2404, arm64]
     container:
-      image: debian:trixie
+      image: public.ecr.aws/debian/debian:trixie
       volumes:
         - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
       options: --privileged


### PR DESCRIPTION
As per AWS environment its recommended to use AWS Hosted docker hub instead of Public docker hub such as "docker.io", so updating the container registry.
