### PR TITLE
Add mesa snapshot overlay

### DIFF
--- a/overlay-debs/mesa-snapshot/mesa-snapshot.sh
+++ b/overlay-debs/mesa-snapshot/mesa-snapshot.sh
@@ -39,6 +39,8 @@ mesa (${version}-0qcom1) testing; urgency=medium
     - debian/patches/path_max.diff: refresh
     - d/rules: dropped removal of mme_{fermi,tu104}_sim_hw_test
     - pull in NVK dependency, librust-rustc-hash-2-dev
+    - opt-in and enable several OpenCL drivers by default: asahi, freedreno and
+      radeonsi
   * Drop support for features removed upstream:
     - XA tracker, dropped packages: libxatracker2, libxatracker-dev.
     - D3D9 tracker, dropped packages libd3dadapter9-mesa,

--- a/overlay-debs/mesa-snapshot/mesa-snapshot.sh
+++ b/overlay-debs/mesa-snapshot/mesa-snapshot.sh
@@ -7,6 +7,7 @@ COMMIT=${COMMIT:-origin/main}
 
 set -e
 
+# shellcheck disable=SC2153 # DSC_FILE is guaranteed to be defined by build-deb.py
 DEB_FILE=${DSC_FILE%%.dsc}.debian.tar.xz
 ORIG_FILE=$(echo ${DSC_FILE} | sed -e 's/-.*/.orig.tar.xz/')
 

--- a/overlay-debs/mesa-snapshot/mesa-snapshot.sh
+++ b/overlay-debs/mesa-snapshot/mesa-snapshot.sh
@@ -47,6 +47,9 @@ mesa (${version}-0qcom1) testing; urgency=medium
   * Backport to trixie:
     - Build with LLVM 19 since LLVM 20 is not available in trixie.
     - d/control: regenerate
+  * Feature patches:
+    - d/p/35316.patch: freedreno: Add sampling support for RGB/BGR
+      24-bit component texture formats.
 
  -- Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>  Wed, 11 Jun 2025 14:58:50 +0300
 

--- a/overlay-debs/mesa-snapshot/mesa-snapshot.sh
+++ b/overlay-debs/mesa-snapshot/mesa-snapshot.sh
@@ -1,0 +1,66 @@
+#! /bin/sh
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+COMMIT=${COMMIT:-origin/main}
+
+set -e
+
+DEB_FILE=${DSC_FILE%%.dsc}.debian.tar.xz
+ORIG_FILE=$(echo ${DSC_FILE} | sed -e 's/-.*/.orig.tar.xz/')
+
+rm -rf mesa
+git clone --depth 1 https://gitlab.freedesktop.org/mesa/mesa
+
+cd mesa
+git fetch --depth 1 origin ${COMMIT##origin/}
+
+date=$(git log -1 --format=%cd --date=format:%Y%m%d ${COMMIT})
+subject=$(git log -1 --format="%h (\"%s\")" ${COMMIT})
+version=25.2.0~git${date}
+
+rm -rf ../mesa-${version}
+mkdir ../mesa-${version}
+git archive --format=tar HEAD | tar x -C ../mesa-${version}
+
+cd ../mesa-${version}
+
+rm -rf debian
+tar xJf ${DEB_FILE}
+
+cat >> debian/changelog.tmp << EOF
+mesa (${version}-0qcom1) testing; urgency=medium
+
+  * Build git version from ${date}, commit ${subject}
+    - d/libegl-mesa0.symbols: include GL interop symbols into, exported by
+      libEGL_mesa.so.0
+    - d/p/etnaviv-add-support-for-texelfetch.patch: drop, applied upstream
+    - debian/patches/path_max.diff: refresh
+    - d/rules: dropped removal of mme_{fermi,tu104}_sim_hw_test
+    - pull in NVK dependency, librust-rustc-hash-2-dev
+  * Drop support for features removed upstream:
+    - XA tracker, dropped packages: libxatracker2, libxatracker-dev.
+    - D3D9 tracker, dropped packages libd3dadapter9-mesa,
+      libd3dadapter9-mesa-dev.
+    - Clover, removed clover files from d/mesa-opencl-icd.install.
+  * Backport to trixie:
+    - Build with LLVM 19 since LLVM 20 is not available in trixie.
+    - d/control: regenerate
+
+ -- Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>  Wed, 11 Jun 2025 14:58:50 +0300
+
+EOF
+cat debian/changelog >> debian/changelog.tmp
+mv debian/changelog.tmp debian/changelog
+
+# orig.tar.xz generation skips all .git* files, drop them from the source dir too.
+rm -rf .git*
+
+debian/rules regen_control
+debian/rules clean
+debian/rules gentarball
+
+rm -rf ../mesa
+
+rm ${DSC_FILE} ${DEB_FILE} ${ORIG_FILE}*

--- a/overlay-debs/mesa-snapshot/mesa-snapshot.yaml
+++ b/overlay-debs/mesa-snapshot/mesa-snapshot.yaml
@@ -1,0 +1,7 @@
+dsc_url: "https://snapshot.debian.org/archive/debian/20250519T203618Z/pool/main/m/mesa/mesa_25.1.0-1.dsc"
+dsc_sha256sum: "d06c1b0ee300f096de2ac59a2e9583349ca79322612f4502baa5e78ff0be4290"
+debdiff_file: "mesa_25.2.0.debdiff"
+script: mesa-snapshot.sh
+suite: trixie
+env:
+  COMMIT: 7fd99c88b9cd5c0c8c1cb3e92383acac5cb8220b

--- a/overlay-debs/mesa-snapshot/mesa_25.2.0.debdiff
+++ b/overlay-debs/mesa-snapshot/mesa_25.2.0.debdiff
@@ -282,6 +282,22 @@ diff -Nru mesa-25.2.0-orig/debian/rules mesa-25.2.0/debian/rules
  export PATH:=/usr/lib/llvm-$(LLVM_VERSION)/bin/:$(PATH)
  
  export DEB_BUILD_MAINT_OPTIONS=optimize=-lto
+@@ -46,6 +46,7 @@
+ GALLIUM_DRIVERS = softpipe
+ VULKAN_DRIVERS =
+ VULKAN_LAYERS =
++RUSTICL_ENABLE =
+ 
+ confflags_SSE2 = -Dsse2=true
+ confflags_TEFLON = -Dteflon=false
+@@ -76,6 +77,7 @@
+   # Freedreno requires arm in addition
+   ifneq (,$(filter arm arm64,$(DEB_HOST_ARCH_CPU)))
+ 	GALLIUM_DRIVERS += freedreno
++	RUSTICL_ENABLE += freedreno
+   endif
+ 
+   # etnaviv, tegra, vc4 and v3d kernel support are only available on armhf and arm64
 @@ -92,8 +92,6 @@
    ifneq (,$(filter $(DEB_HOST_ARCH), amd64 i386 x32))
  	GALLIUM_DRIVERS += crocus i915 iris svga
@@ -291,6 +307,21 @@ diff -Nru mesa-25.2.0-orig/debian/rules mesa-25.2.0/debian/rules
    endif
  
    ifneq (,$(filter $(DEB_HOST_ARCH), amd64))
+@@ -111,12 +113,14 @@
+   ifneq (,$(filter $(DEB_HOST_ARCH), arm64 amd64 i386))
+ 	GALLIUM_DRIVERS += asahi
+ 	VULKAN_DRIVERS += asahi
++	RUSTICL_ENABLE += asahi
+   endif
+ 
+   # LLVM is required for building r300g, radeonsi and llvmpipe drivers.
+   # It's also required for building OpenCL support.
+   ifneq (,$(filter $(DEB_HOST_ARCH), $(LLVM_ARCHS)))
+ 	GALLIUM_DRIVERS += radeonsi zink llvmpipe
++	RUSTICL_ENABLE += radeonsi
+ 
+ 	# drop virtio from armel, it doesn't build
+ 	ifneq (,$(filter $(DEB_HOST_ARCH), armel))
 @@ -129,7 +127,6 @@
  
  	VULKAN_LAYERS += device-select intel-nullhw overlay
@@ -311,6 +342,18 @@ diff -Nru mesa-25.2.0-orig/debian/rules mesa-25.2.0/debian/rules
  	# gfxstream only builds on 64bit
  	ifeq ($(DEB_HOST_ARCH_BITS),64)
  		VULKAN_DRIVERS += gfxstream
+@@ -172,6 +176,11 @@
+ VULKAN_DRIVERS_LIST := $(subst $(space),$(comma),$(VULKAN_DRIVERS))
+ VULKAN_LAYERS := $(patsubst %,'%',$(VULKAN_LAYERS))
+ VULKAN_LAYERS_LIST := $(subst $(space),$(comma),$(VULKAN_LAYERS))
++RUSTICL_ENABLE := $(patsubst %,'%',$(RUSTICL_ENABLE))
++RUSTICL_ENABLE_LIST := $(subst $(space),$(comma),$(RUSTICL_ENABLE))
++ifneq (,$(filter $(DEB_HOST_ARCH), $(RUSTICL_ARCHS)))
++confflags_GALLIUM += -Dgallium-rusticl-enable-drivers="[$(RUSTICL_ENABLE_LIST)]"
++endif
+ 
+ confflags_GLES = -Dgles1=disabled -Dgles2=enabled
+ confflags_GALLIUM += -Dgallium-drivers="[$(GALLIUM_DRIVERS_LIST)]"
 @@ -205,7 +197,7 @@
  
  rewrite_wrap_files:

--- a/overlay-debs/mesa-snapshot/mesa_25.2.0.debdiff
+++ b/overlay-debs/mesa-snapshot/mesa_25.2.0.debdiff
@@ -1,0 +1,501 @@
+diff -Nru mesa-25.2.0-orig/debian/control mesa-25.2.0/debian/control
+--- mesa-25.2.0-orig/debian/control	2025-06-17 14:44:27.640693699 +0300
++++ mesa-25.2.0/debian/control	2025-06-17 14:56:54.236499287 +0300
+@@ -48,11 +48,11 @@
+  libelf-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+  libwayland-dev (>= 1.15.0) [linux-any],
+  libwayland-egl-backend-dev (>= 1.15.0) [linux-any],
+- llvm-20-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+- libclang-20-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+- libclang-cpp20-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+- libclc-20-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+- libclc-20 [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
++ llvm-19-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
++ libclang-19-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
++ libclang-cpp19-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
++ libclc-19-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
++ libclc-19 [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+  wayland-protocols (>= 1.34),
+  zlib1g-dev,
+  libglvnd-core-dev (>= 1.3.2),
+@@ -61,75 +61,18 @@
+  rustfmt [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x x32],
+  bindgen (>= 0.66.1~) [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x x32],
+  cbindgen [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x x32],
+- llvm-spirv-20 [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x x32],
+- libllvmspirvlib-20-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
++ llvm-spirv-19 [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x x32],
++ libllvmspirvlib-19-dev [amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32],
+  librust-paste-dev [amd64 arm64 armhf i386 ppc64 riscv64 x32],
++ librust-rustc-hash-2-dev [amd64 arm64 armhf i386 ppc64 riscv64 x32],
+  librust-syn-dev (>= 2.0.48) [amd64 arm64 armhf i386 ppc64 riscv64 x32],
++Build-Conflicts:
++ librust-rustc-hash-dev (<< 2.0) [amd64 arm64 armhf i386 ppc64 riscv64 x32],
+ Rules-Requires-Root: no
+ Vcs-Git: https://salsa.debian.org/xorg-team/lib/mesa.git
+ Vcs-Browser: https://salsa.debian.org/xorg-team/lib/mesa
+ Homepage: https://mesa3d.org/
+ 
+-Package: libxatracker2
+-Section: libs
+-Architecture: amd64 i386 x32
+-Depends:
+- ${shlibs:Depends},
+- ${misc:Depends},
+-Pre-Depends: ${misc:Pre-Depends}
+-Multi-Arch: same
+-Description: X acceleration library -- runtime
+- This package contains the XA (X acceleration) library.  It is used exclusively
+- by the X server to do render, copy and video acceleration.
+- .
+- XA is intended to be used by the vmware driver for virtualized X acceleration.
+-
+-Package: libxatracker-dev
+-Section: libdevel
+-Architecture: amd64 i386 x32
+-Depends:
+- libxatracker2 (= ${binary:Version}),
+- ${misc:Depends},
+-Multi-Arch: same
+-Description: X acceleration library -- development files
+- This package contains the XA (X acceleration) library.  It is used exclusively
+- by the X server to do render, copy and video acceleration.
+- .
+- XA is intended to be used by the vmware driver for virtualized X acceleration.
+- .
+- This package provides the development environment for compiling programs
+- against the xatracker library.
+-
+-Package: libd3dadapter9-mesa
+-Section: libs
+-Architecture: amd64 arm64 armel armhf i386
+-Depends:
+- ${shlibs:Depends},
+- ${misc:Depends},
+- libudev1 [linux-any],
+-Pre-Depends: ${misc:Pre-Depends}
+-Multi-Arch: same
+-Description: state-tracker for Direct3D9
+- This package contains a Gallium3D state tracker that implements the Direct3D9
+- API.  Combined with the gallium-nine branch of Wine, programs using D3D9 can
+- achieve native (or better) graphics performance.
+-
+-Package: libd3dadapter9-mesa-dev
+-Section: libdevel
+-Architecture: amd64 arm64 armel armhf i386
+-Depends:
+- libd3dadapter9-mesa (= ${binary:Version}),
+- libudev1 [linux-any],
+- ${misc:Depends},
+-Pre-Depends: ${misc:Pre-Depends}
+-Multi-Arch: same
+-Description: state-tracker for Direct3D9 -- development files
+- This package contains a Gallium3D state tracker that implements the Direct3D9
+- API.  Combined with the gallium-nine branch of Wine, programs using D3D9 can
+- achieve native (or better) graphics performance.
+- .
+- Development files
+-
+ Package: libgbm1
+ Section: libs
+ Architecture: linux-any
+@@ -374,7 +317,7 @@
+ Architecture: amd64 arm64 armel armhf i386 loong64 mips64el powerpc ppc64 ppc64el riscv64 s390x sparc64 x32
+ Pre-Depends: ${misc:Pre-Depends}
+ Depends:
+- libclc-20,
++ libclc-19,
+  ocl-icd-libopencl1 | libopencl1,
+  ${shlibs:Depends},
+  ${misc:Depends},
+diff -Nru mesa-25.2.0-orig/debian/control.in mesa-25.2.0/debian/control.in
+--- mesa-25.2.0-orig/debian/control.in	2025-06-17 14:40:24.097165626 +0300
++++ mesa-25.2.0/debian/control.in	2025-06-12 13:16:26.413310455 +0300
+@@ -64,72 +64,15 @@
+  llvm-spirv-@LLVM_VERSION@ [@RUSTICL_ARCHS@],
+  libllvmspirvlib-@LLVM_VERSION@-dev [@LLVM_ARCHS@],
+  librust-paste-dev [@NVK_ARCHS@],
++ librust-rustc-hash-2-dev [@NVK_ARCHS@],
+  librust-syn-dev (>= 2.0.48) [@NVK_ARCHS@],
++Build-Conflicts:
++ librust-rustc-hash-dev (<< 2.0) [@NVK_ARCHS@],
+ Rules-Requires-Root: no
+ Vcs-Git: https://salsa.debian.org/xorg-team/lib/mesa.git
+ Vcs-Browser: https://salsa.debian.org/xorg-team/lib/mesa
+ Homepage: https://mesa3d.org/
+ 
+-Package: libxatracker2
+-Section: libs
+-Architecture: amd64 i386 x32
+-Depends:
+- ${shlibs:Depends},
+- ${misc:Depends},
+-Pre-Depends: ${misc:Pre-Depends}
+-Multi-Arch: same
+-Description: X acceleration library -- runtime
+- This package contains the XA (X acceleration) library.  It is used exclusively
+- by the X server to do render, copy and video acceleration.
+- .
+- XA is intended to be used by the vmware driver for virtualized X acceleration.
+-
+-Package: libxatracker-dev
+-Section: libdevel
+-Architecture: amd64 i386 x32
+-Depends:
+- libxatracker2 (= ${binary:Version}),
+- ${misc:Depends},
+-Multi-Arch: same
+-Description: X acceleration library -- development files
+- This package contains the XA (X acceleration) library.  It is used exclusively
+- by the X server to do render, copy and video acceleration.
+- .
+- XA is intended to be used by the vmware driver for virtualized X acceleration.
+- .
+- This package provides the development environment for compiling programs
+- against the xatracker library.
+-
+-Package: libd3dadapter9-mesa
+-Section: libs
+-Architecture: @WINE_ARCHS@
+-Depends:
+- ${shlibs:Depends},
+- ${misc:Depends},
+- libudev1 [linux-any],
+-Pre-Depends: ${misc:Pre-Depends}
+-Multi-Arch: same
+-Description: state-tracker for Direct3D9
+- This package contains a Gallium3D state tracker that implements the Direct3D9
+- API.  Combined with the gallium-nine branch of Wine, programs using D3D9 can
+- achieve native (or better) graphics performance.
+-
+-Package: libd3dadapter9-mesa-dev
+-Section: libdevel
+-Architecture: @WINE_ARCHS@
+-Depends:
+- libd3dadapter9-mesa (= ${binary:Version}),
+- libudev1 [linux-any],
+- ${misc:Depends},
+-Pre-Depends: ${misc:Pre-Depends}
+-Multi-Arch: same
+-Description: state-tracker for Direct3D9 -- development files
+- This package contains a Gallium3D state tracker that implements the Direct3D9
+- API.  Combined with the gallium-nine branch of Wine, programs using D3D9 can
+- achieve native (or better) graphics performance.
+- .
+- Development files
+-
+ Package: libgbm1
+ Section: libs
+ Architecture: linux-any
+diff -Nru mesa-25.2.0-orig/debian/libd3dadapter9-mesa-dev.install mesa-25.2.0/debian/libd3dadapter9-mesa-dev.install
+--- mesa-25.2.0-orig/debian/libd3dadapter9-mesa-dev.install	2025-06-17 14:40:24.097196561 +0300
++++ mesa-25.2.0/debian/libd3dadapter9-mesa-dev.install	1970-01-01 02:00:00.000000000 +0200
+@@ -1,5 +0,0 @@
+-usr/lib/*/pkgconfig/d3d.pc
+-usr/include/d3dadapter/d3dadapter9.h
+-usr/include/d3dadapter/drm.h
+-usr/include/d3dadapter/present.h
+-
+diff -Nru mesa-25.2.0-orig/debian/libd3dadapter9-mesa.install mesa-25.2.0/debian/libd3dadapter9-mesa.install
+--- mesa-25.2.0-orig/debian/libd3dadapter9-mesa.install	2025-06-17 14:40:24.097203227 +0300
++++ mesa-25.2.0/debian/libd3dadapter9-mesa.install	1970-01-01 02:00:00.000000000 +0200
+@@ -1 +0,0 @@
+-usr/lib/*/d3d/d3dadapter9.so*
+diff -Nru mesa-25.2.0-orig/debian/libegl-mesa0.symbols mesa-25.2.0/debian/libegl-mesa0.symbols
+--- mesa-25.2.0-orig/debian/libegl-mesa0.symbols	2025-06-17 14:40:24.097217601 +0300
++++ mesa-25.2.0/debian/libegl-mesa0.symbols	2025-06-12 13:16:26.413310455 +0300
+@@ -1,2 +1,5 @@
+ libEGL_mesa.so.0 libegl-mesa0 #MINVER#
+  __egl_Main@Base 17.0.0~
++ MesaGLInteropEGLExportObject@Base 25.2.0~
++ MesaGLInteropEGLFlushObjects@Base 25.2.0~
++ MesaGLInteropEGLQueryDeviceInfo@Base 25.2.0~
+diff -Nru mesa-25.2.0-orig/debian/libxatracker2.install mesa-25.2.0/debian/libxatracker2.install
+--- mesa-25.2.0-orig/debian/libxatracker2.install	2025-06-17 14:40:24.097313948 +0300
++++ mesa-25.2.0/debian/libxatracker2.install	1970-01-01 02:00:00.000000000 +0200
+@@ -1 +0,0 @@
+-usr/lib/*/libxatracker.so.2*
+diff -Nru mesa-25.2.0-orig/debian/libxatracker2.symbols mesa-25.2.0/debian/libxatracker2.symbols
+--- mesa-25.2.0-orig/debian/libxatracker2.symbols	2025-06-17 14:40:24.097323635 +0300
++++ mesa-25.2.0/debian/libxatracker2.symbols	1970-01-01 02:00:00.000000000 +0200
+@@ -1,35 +0,0 @@
+-libxatracker.so.2 libxatracker2 #MINVER#
+- xa_composite_allocation@Base 0
+- xa_composite_check_accelerated@Base 0
+- xa_composite_done@Base 0
+- xa_composite_prepare@Base 0
+- xa_composite_rect@Base 0
+- xa_context_create@Base 0
+- xa_context_default@Base 0
+- xa_context_destroy@Base 0
+- xa_context_flush@Base 0
+- xa_copy@Base 0
+- xa_copy_done@Base 0
+- xa_copy_prepare@Base 0
+- xa_fence_destroy@Base 0
+- xa_fence_get@Base 0
+- xa_fence_wait@Base 0
+- xa_format_check_supported@Base 0
+- xa_solid@Base 0
+- xa_solid_done@Base 0
+- xa_solid_prepare@Base 0
+- xa_surface_create@Base 0
+- xa_surface_dma@Base 0
+- xa_surface_format@Base 0
+- xa_surface_from_handle2@Base 11.1.0~
+- xa_surface_from_handle@Base 0
+- xa_surface_handle@Base 0
+- xa_surface_map@Base 0
+- xa_surface_redefine@Base 0
+- xa_surface_ref@Base 0
+- xa_surface_unmap@Base 0
+- xa_surface_unref@Base 0
+- xa_tracker_create@Base 0
+- xa_tracker_destroy@Base 0
+- xa_tracker_version@Base 0
+- xa_yuv_planar_blit@Base 0
+diff -Nru mesa-25.2.0-orig/debian/libxatracker-dev.install mesa-25.2.0/debian/libxatracker-dev.install
+--- mesa-25.2.0-orig/debian/libxatracker-dev.install	2025-06-17 14:40:24.097307074 +0300
++++ mesa-25.2.0/debian/libxatracker-dev.install	1970-01-01 02:00:00.000000000 +0200
+@@ -1,5 +0,0 @@
+-usr/lib/*/libxatracker.so
+-usr/lib/*/pkgconfig/xatracker.pc
+-usr/include/xa_composite.h
+-usr/include/xa_context.h
+-usr/include/xa_tracker.h
+diff -Nru mesa-25.2.0-orig/debian/mesa-opencl-icd.install mesa-25.2.0/debian/mesa-opencl-icd.install
+--- mesa-25.2.0-orig/debian/mesa-opencl-icd.install	2025-06-17 14:40:24.097406806 +0300
++++ mesa-25.2.0/debian/mesa-opencl-icd.install	2025-06-12 13:16:26.415262201 +0300
+@@ -1,3 +0,0 @@
+-etc/OpenCL/vendors/mesa.icd
+-usr/lib/*/gallium-pipe/*.so
+-usr/lib/*/libMesaOpenCL*
+diff -Nru mesa-25.2.0-orig/debian/rules mesa-25.2.0/debian/rules
+--- mesa-25.2.0-orig/debian/rules	2025-06-17 14:40:24.097509038 +0300
++++ mesa-25.2.0/debian/rules	2025-06-12 13:16:26.415262201 +0300
+@@ -13,7 +13,7 @@
+ DEB_HOST_ARCH_CPU  ?= $(shell dpkg-architecture -qDEB_HOST_ARCH_CPU)
+ 
+ # for finding the correct llvm-config when meson doesn't know about it yet
+-LLVM_VERSION = 20
++LLVM_VERSION = 19
+ export PATH:=/usr/lib/llvm-$(LLVM_VERSION)/bin/:$(PATH)
+ 
+ export DEB_BUILD_MAINT_OPTIONS=optimize=-lto
+@@ -92,8 +92,6 @@
+   ifneq (,$(filter $(DEB_HOST_ARCH), amd64 i386 x32))
+ 	GALLIUM_DRIVERS += crocus i915 iris svga
+ 	VULKAN_DRIVERS += intel intel_hasvk
+-	# svga needs xa state tracker
+-	confflags_GALLIUM += -Dgallium-xa=enabled
+   endif
+ 
+   ifneq (,$(filter $(DEB_HOST_ARCH), amd64))
+@@ -129,7 +127,6 @@
+ 
+ 	VULKAN_LAYERS += device-select intel-nullhw overlay
+ 	confflags_GALLIUM += -Dllvm=enabled
+-	confflags_GALLIUM += -Dgallium-opencl=icd
+ 
+ 	# Build rusticl for archs where rustc is available
+ 	ifneq (,$(filter $(DEB_HOST_ARCH), $(RUSTICL_ARCHS)))
+@@ -141,11 +138,6 @@
+ 		VULKAN_DRIVERS += nouveau
+ 	endif
+ 
+-	# nine makes sense only on archs that build wine
+-	ifneq (,$(filter $(DEB_HOST_ARCH), $(WINE_ARCHS)))
+-		confflags_GALLIUM += -Dgallium-nine=true
+-	endif
+-
+ 	# gfxstream only builds on 64bit
+ 	ifeq ($(DEB_HOST_ARCH_BITS),64)
+ 		VULKAN_DRIVERS += gfxstream
+@@ -205,7 +197,7 @@
+ 
+ rewrite_wrap_files:
+ 	cp -r subprojects subprojects-save
+-	for crate in paste proc-macro2 quote syn unicode-ident; \
++	for crate in paste rustc-hash proc-macro2 quote syn unicode-ident; \
+ 	do \
+ 		export crate_namever=`basename $$MESON_PACKAGE_CACHE_DIR/$$crate-*`; \
+ 		sed -e"/source.*/d" -e"s,$${crate}-.*,$${crate_namever}," -i subprojects/$${crate}.wrap; \
+@@ -263,10 +255,6 @@
+ 	# use -f to ensure we notice disappearing files:
+ 	rm debian/tmp/usr/lib/*/libEGL_mesa.so
+ 	rm debian/tmp/usr/lib/*/libGLX_mesa.so
+-  ifneq (,$(filter $(DEB_HOST_ARCH), $(NVK_ARCHS)))
+-	rm debian/tmp/usr/bin/mme_fermi_sim_hw_test
+-	rm debian/tmp/usr/bin/mme_tu104_sim_hw_test
+-  endif
+ 	# use -f here though
+ 	rm -f debian/tmp/usr/lib/*/libgrl.a
+ 
+diff -Nru mesa-25.2.0-orig/debian/patches/etnaviv-add-support-for-texelfetch.patch mesa-25.2.0/debian/patches/etnaviv-add-support-for-texelfetch.patch
+--- mesa-25.2.0-orig/debian/patches/etnaviv-add-support-for-texelfetch.patch	2025-06-17 14:44:27.640952430 +0300
++++ mesa-25.2.0/debian/patches/etnaviv-add-support-for-texelfetch.patch	1970-01-01 02:00:00.000000000 +0200
+@@ -1,144 +0,0 @@
+-From da90fca6093dd58cc351b0ac624ea8c0d83a81f9 Mon Sep 17 00:00:00 2001
+-From: Christian Gmeiner <cgmeiner@igalia.com>
+-Date: Fri, 18 Apr 2025 23:35:20 +0200
+-Subject: [PATCH 1/3] etnaviv: isa: Add txf instruction
+-
+-This instruction is used to implement texelfetch.
+-
+-Blob generates such txf's for
+-dEQP-GLES3.functional.shaders.texture_functions.texelfetch.+
+-
+-Signed-off-by: Christian Gmeiner <cgmeiner@igalia.com>
+-Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34685>
+----
+- src/etnaviv/isa/etnaviv.xml      | 5 +++++
+- src/etnaviv/isa/tests/disasm.cpp | 1 +
+- 2 files changed, 6 insertions(+)
+-
+-diff --git a/src/etnaviv/isa/etnaviv.xml b/src/etnaviv/isa/etnaviv.xml
+-index a337c1e9d0762..42f551238bf1b 100644
+---- a/src/etnaviv/isa/etnaviv.xml
+-+++ b/src/etnaviv/isa/etnaviv.xml
+-@@ -1359,6 +1359,11 @@ SPDX-License-Identifier: MIT
+- 	<pattern pos="80">1</pattern> <!-- OPCODE_BIT6 -->
+- </bitset>
+- 
+-+<bitset name="txf" extends="#instruction-tex-src0-src1-src2">
+-+	<pattern low="0" high="5">001001</pattern> <!-- OPC -->
+-+	<pattern pos="80">1</pattern> <!-- OPCODE_BIT6 -->
+-+</bitset>
+-+
+- <bitset name="imadlo0" extends="#instruction-alu-src0-src1-src2">
+- 	<pattern low="0" high="5">001100</pattern> <!-- OPC -->
+- 	<pattern pos="80">1</pattern> <!-- OPCODE_BIT6 -->
+-diff --git a/src/etnaviv/isa/tests/disasm.cpp b/src/etnaviv/isa/tests/disasm.cpp
+-index aa027618aa40a..3d4ebec8a49be 100644
+---- a/src/etnaviv/isa/tests/disasm.cpp
+-+++ b/src/etnaviv/isa/tests/disasm.cpp
+-@@ -166,6 +166,7 @@ INSTANTIATE_TEST_SUITE_P(Opcodes, DisasmTest,
+-       disasm_state{ {0x00801036, 0x15400804, 0x01540050, 0x00000002}, "clamp0_max        t0.x___, u0.yyyy, u0.zzzz, void\n"},
+-       disasm_state{ {0x0080103b, 0x00001804, 0x40000000, 0x00400028}, "iaddsat.s32       t0.x___, t1.xxxx, void, -t2.xxxx\n"},
+-       disasm_state{ {0x01001008, 0x15400804, 0xd00100c0, 0x00000007}, "imod.u16          t0._y__, t0.yyyy, 1, void\n"},
+-+      disasm_state{ {0x07811009, 0x15001f20, 0x01ff00c0, 0x78021008}, "txf               t1, tex0.xyzw, t1.xyyy, t1.wwww, 4352\n", FLAG_FAILING_ASM},
+-       disasm_state{ {0x0080103c, 0x00001804, 0x40000140, 0x00000000}, "imullo0.s32       t0.x___, t1.xxxx, t2.xxxx, void\n"},
+-       disasm_state{ {0x00801000, 0x00001804, 0x40010140, 0x00000000}, "imulhi0.s32       t0.x___, t1.xxxx, t2.xxxx, void\n"},
+-       disasm_state{ {0x00801004, 0x00201804, 0x40010040, 0x00000000}, "idiv0.s16         t0.x___, t1.xxxx, t0.xxxx, void\n"},
+--- 
+-GitLab
+-
+-
+-From eefe486533eb58d3d1e81daa5abd16e63ee4c7a9 Mon Sep 17 00:00:00 2001
+-From: Christian Gmeiner <cgmeiner@igalia.com>
+-Date: Fri, 18 Apr 2025 23:37:19 +0200
+-Subject: [PATCH 2/3] etnaviv: nir: Legalize txf lod src
+-
+-The LOD must be a float, unlike the GLSL function, which expects an integer.
+-
+-Signed-off-by: Christian Gmeiner <cgmeiner@igalia.com>
+-Reviewed-by: Faith Ekstrand <faith.ekstrand@collabora.com>
+-Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34685>
+----
+- .../etnaviv/etnaviv_nir_lower_texture.c       | 25 +++++++++++++++++++
+- 1 file changed, 25 insertions(+)
+-
+-diff --git a/src/gallium/drivers/etnaviv/etnaviv_nir_lower_texture.c b/src/gallium/drivers/etnaviv/etnaviv_nir_lower_texture.c
+-index d0462ead016dc..d20d175da79a8 100644
+---- a/src/gallium/drivers/etnaviv/etnaviv_nir_lower_texture.c
+-+++ b/src/gallium/drivers/etnaviv/etnaviv_nir_lower_texture.c
+-@@ -26,6 +26,28 @@ lower_txs(nir_builder *b, nir_instr *instr, UNUSED void *data)
+-    return true;
+- }
+- 
+-+static bool
+-+legalize_txf_lod(nir_builder *b, nir_instr *instr, UNUSED void *data)
+-+{
+-+   if (instr->type != nir_instr_type_tex)
+-+      return false;
+-+
+-+   nir_tex_instr *tex = nir_instr_as_tex(instr);
+-+
+-+   if (tex->op != nir_texop_txf)
+-+      return false;
+-+
+-+   b->cursor = nir_before_instr(instr);
+-+
+-+   int lod_index = nir_tex_instr_src_index(tex, nir_tex_src_lod);
+-+   assert(lod_index >= 0);
+-+   nir_def *lod = tex->src[lod_index].src.ssa;
+-+
+-+   nir_src_rewrite(&tex->src[lod_index].src, nir_i2f32(b, lod));
+-+
+-+   return true;
+-+}
+-+
+- bool
+- etna_nir_lower_texture(nir_shader *s, struct etna_shader_key *key)
+- {
+-@@ -48,5 +70,8 @@ etna_nir_lower_texture(nir_shader *s, struct etna_shader_key *key)
+-    NIR_PASS(progress, s, nir_shader_instructions_pass, lower_txs,
+-          nir_metadata_control_flow, NULL);
+- 
+-+   NIR_PASS(progress, s, nir_shader_instructions_pass, legalize_txf_lod,
+-+      nir_metadata_control_flow, NULL);
+-+
+-    return progress;
+- }
+--- 
+-GitLab
+-
+-
+-From 614b66529de2832575cdb0c97581d0d5f791ed72 Mon Sep 17 00:00:00 2001
+-From: Christian Gmeiner <cgmeiner@igalia.com>
+-Date: Fri, 18 Apr 2025 23:42:14 +0200
+-Subject: [PATCH 3/3] etnaviv: nir: Add support for txf texture operation
+-
+-The src[2] value 0x1100 is set based on observed behavior of the blob driver,
+-though its exact meaning remains to be documented.
+-
+-Passes all dEQP-GLES3.functional.shaders.texture_functions.texelfetch.*
+-tests on GC7000.
+-
+-Signed-off-by: Christian Gmeiner <cgmeiner@igalia.com>
+-Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34685>
+----
+- src/gallium/drivers/etnaviv/etnaviv_compiler_nir_emit.c | 4 ++++
+- 1 file changed, 4 insertions(+)
+-
+-diff --git a/src/gallium/drivers/etnaviv/etnaviv_compiler_nir_emit.c b/src/gallium/drivers/etnaviv/etnaviv_compiler_nir_emit.c
+-index 08a5ab5fb7bc3..708f0788b580d 100644
+---- a/src/gallium/drivers/etnaviv/etnaviv_compiler_nir_emit.c
+-+++ b/src/gallium/drivers/etnaviv/etnaviv_compiler_nir_emit.c
+-@@ -212,6 +212,10 @@ etna_emit_tex(struct etna_compile *c, nir_texop op, unsigned texid, unsigned dst
+-    case nir_texop_txb: inst.opcode = ISA_OPC_TEXLDB; break;
+-    case nir_texop_txd: inst.opcode = ISA_OPC_TEXLDD; break;
+-    case nir_texop_txl: inst.opcode = ISA_OPC_TEXLDL; break;
+-+   case nir_texop_txf:
+-+      inst.opcode = ISA_OPC_TXF;
+-+      inst.src[2] = etna_immediate_int(0x1100);
+-+      break;
+-    default:
+-       compile_error(c, "Unhandled NIR tex type: %d\n", op);
+-    }
+--- 
+-GitLab
+-
+diff -Nru mesa-25.2.0-orig/debian/patches/path_max.diff mesa-25.2.0/debian/patches/path_max.diff
+--- mesa-25.2.0-orig/debian/patches/path_max.diff	2025-06-17 14:44:27.640961231 +0300
++++ mesa-25.2.0/debian/patches/path_max.diff	2025-06-17 14:44:55.205596046 +0300
+@@ -34,6 +34,6 @@
+ +#define PATH_MAX (4096)
+ +#endif
+ +
+- #define MODULE_PREFIX "pipe_"
+- 
+  static int (*backends[])(struct pipe_loader_device **, int) = {
++ #ifdef HAVE_LIBDRM
++    &pipe_loader_drm_probe,
+diff -Nru mesa-25.2.0-orig/debian/patches/series mesa-25.2.0/debian/patches/series
+--- mesa-25.2.0-orig/debian/patches/series	2025-06-17 14:44:27.640967846 +0300
++++ mesa-25.2.0/debian/patches/series	2025-06-17 14:45:04.690440415 +0300
+@@ -2,4 +2,3 @@
+ src_glx_dri_common.h.diff
+ disable_ppc64el_assembly.diff
+ drisw-Avoid-crashing-when-swrast_loader-NULL.patch
+-etnaviv-add-support-for-texelfetch.patch

--- a/overlay-debs/mesa-snapshot/mesa_25.2.0.debdiff
+++ b/overlay-debs/mesa-snapshot/mesa_25.2.0.debdiff
@@ -491,6 +491,263 @@ diff -Nru mesa-25.2.0-orig/debian/patches/path_max.diff mesa-25.2.0/debian/patch
   static int (*backends[])(struct pipe_loader_device **, int) = {
 + #ifdef HAVE_LIBDRM
 +    &pipe_loader_drm_probe,
+--- mesa-25.2.0-orig/debian/patches/35316.patch	2025-06-17 11:40:36.606796770 +0300
++++ mesa-25.2.0/debian/patches/35316.patch	2025-06-17 15:02:11.471138105 +0300
+@@ -0,0 +1,254 @@
++From: Lakshman Chandu Kondreddy <quic_lkondred@quicinc.com>
++Subject: freedreno: Add sampling support for RGB/BGR 24-bit component texture formats
++Origin: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/35316
++
++From e56ef6179653e0b5574d1b9648db25c9cf6e3a6e Mon Sep 17 00:00:00 2001
++From: "Petar G. Georgiev" <quic_petarg@quicinc.com>
++Date: Mon, 12 May 2025 11:49:06 +0530
++Subject: [PATCH 1/4] util: Add pack and unpack for R8G8B8/B8G8R8
++
++This helps in packing and unpacking the R8G8B8/B8G8R8
++pipe formats which are of uint8 type.
++
++Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
++Signed-off-by: Lakshman Chandu Kondreddy <quic_lkondred@quicinc.com>
++---
++ src/util/u_pack_color.h | 27 +++++++++++++++++++++++++++
++ 1 file changed, 27 insertions(+)
++
++diff --git a/src/util/u_pack_color.h b/src/util/u_pack_color.h
++index 7d5bf7f35457f..b646729fda540 100644
++--- a/src/util/u_pack_color.h
+++++ b/src/util/u_pack_color.h
++@@ -94,6 +94,16 @@ util_pack_color_ub(uint8_t r, uint8_t g, uint8_t b, uint8_t a,
++          uc->ui[0] = (b << 24) | (g << 16) | (r << 8) | 0xff;
++       }
++       return;
+++   case PIPE_FORMAT_R8G8B8_UNORM:
+++      {
+++         uc->ui[0] = (b << 16) | (g << 8) | r;
+++      }
+++      return;
+++   case PIPE_FORMAT_B8G8R8_UNORM:
+++      {
+++         uc->ui[0] = (r << 16) | (g << 8) | b;
+++      }
+++      return;
++    case PIPE_FORMAT_B5G6R5_UNORM:
++       {
++          uc->us = ((r & 0xf8) << 8) | ((g & 0xfc) << 3) | (b >> 3);
++@@ -219,6 +229,23 @@ util_unpack_color_ub(enum pipe_format format, union util_color *uc,
++          *a = (uint8_t) 0xff;
++       }
++       return;
+++   case PIPE_FORMAT_R8G8B8_UNORM:
+++      {
+++         uint32_t p = uc->ui[0];
+++         *r = (uint8_t) (p & 0xff);
+++         *g = (uint8_t) ((p >> 8) & 0xff);
+++         *b = (uint8_t) ((p >> 16) & 0xff);
+++         *a = (uint8_t) 0xff;
+++      }
+++      return;
+++   case PIPE_FORMAT_B8G8R8_UNORM:
+++      {
+++         uint32_t p = uc->ui[0];
+++         *r = (uint8_t) ((p >> 16) & 0xff);
+++         *g = (uint8_t) ((p >> 8) & 0xff);
+++         *b = (uint8_t) (p & 0xff);
+++         *a = (uint8_t) 0xff;
+++      }
++    case PIPE_FORMAT_B5G6R5_UNORM:
++       {
++          uint16_t p = uc->us;
++-- 
++GitLab
++
++
++From cd56b02b49047b27a4942e8c0ab8302b94101d67 Mon Sep 17 00:00:00 2001
++From: Rob Clark <rob.clark@oss.qualcomm.com>
++Date: Wed, 25 Jun 2025 10:39:24 -0700
++Subject: [PATCH 2/4] freedreno/layout: Support for NPoT formats
++
++Three component formats don't get UBWC, but do get their pitch aligned
++to the next PoT size.
++
++Signed-off-by: Rob Clark <rob.clark@oss.qualcomm.com>
++---
++ src/freedreno/fdl/fd6_layout.c | 55 +++++++++++++++++++++-------------
++ 1 file changed, 35 insertions(+), 20 deletions(-)
++
++diff --git a/src/freedreno/fdl/fd6_layout.c b/src/freedreno/fdl/fd6_layout.c
++index f4d6adfcb4625..d4cd785f63afe 100644
++--- a/src/freedreno/fdl/fd6_layout.c
+++++ b/src/freedreno/fdl/fd6_layout.c
++@@ -139,16 +139,22 @@ fdl6_layout(struct fdl_layout *layout, const struct fd_dev_info *info,
++    layout->layer_first = !is_3d;
++    layout->is_mutable = is_mutable;
++ 
++-   fdl6_get_ubwc_blockwidth(layout, &ubwc_blockwidth, &ubwc_blockheight);
++-
++-   /* For simplicity support UBWC only for 3D images without mipmaps,
++-    * most d3d11 games don't use mipmaps for 3D images.
++-    */
++-   if (depth0 > 1 && mip_levels > 1)
+++   if (!util_is_power_of_two_or_zero(layout->cpp)) {
+++      /* R8G8B8 and other 3 component formats don't get UBWC: */
+++      ubwc_blockwidth = ubwc_blockheight = 0;
++       layout->ubwc = false;
+++   } else {
+++      fdl6_get_ubwc_blockwidth(layout, &ubwc_blockwidth, &ubwc_blockheight);
++ 
++-   if (ubwc_blockwidth == 0)
++-      layout->ubwc = false;
+++      /* For simplicity support UBWC only for 3D images without mipmaps,
+++       * most d3d11 games don't use mipmaps for 3D images.
+++       */
+++      if (depth0 > 1 && mip_levels > 1)
+++         layout->ubwc = false;
+++
+++      if (ubwc_blockwidth == 0)
+++         layout->ubwc = false;
+++   }
++ 
++    assert(!force_ubwc || layout->ubwc);
++ 
++@@ -180,19 +186,28 @@ fdl6_layout(struct fdl_layout *layout, const struct fd_dev_info *info,
++    } else {
++       layout->base_align = 64;
++       layout->pitchalign = 0;
++-      /* align pitch to at least 16 pixels:
++-       * both turnip and galium assume there is enough alignment for 16x4
++-       * aligned gmem store. turnip can use CP_BLIT to work without this
++-       * extra alignment, but gallium driver doesn't implement it yet
++-       */
++-      if (layout->cpp > 4)
++-         layout->pitchalign = fdl_cpp_shift(layout) - 2;
++ 
++-      /* when possible, use a bit more alignment than necessary
++-       * presumably this is better for performance?
++-       */
++-      if (!explicit_layout)
++-         layout->pitchalign = fdl_cpp_shift(layout);
+++      if (util_is_power_of_two_or_zero(layout->cpp)) {
+++         /* align pitch to at least 16 pixels:
+++          * both turnip and galium assume there is enough alignment for 16x4
+++          * aligned gmem store. turnip can use CP_BLIT to work without this
+++          * extra alignment, but gallium driver doesn't implement it yet
+++          */
+++         if (layout->cpp > 4)
+++            layout->pitchalign = fdl_cpp_shift(layout) - 2;
+++
+++         /* when possible, use a bit more alignment than necessary
+++          * presumably this is better for performance?
+++          */
+++         if (!explicit_layout)
+++            layout->pitchalign = fdl_cpp_shift(layout);
+++      } else {
+++         /* 3 component formats have pitch aligned as their counterpart
+++          * 4 component formats
+++          */
+++         layout->cpp_shift = ffs(util_next_power_of_two(layout->cpp)) - 1;
+++         layout->pitchalign = layout->cpp_shift;
+++      }
++ 
++       /* not used, avoid "may be used uninitialized" warning */
++       heightalign = 1;
++-- 
++GitLab
++
++
++From 2837d27c4dce134231fc583a8c0d45e0ba22fe23 Mon Sep 17 00:00:00 2001
++From: "Petar G. Georgiev" <quic_petarg@quicinc.com>
++Date: Sat, 10 May 2025 01:04:49 +0530
++Subject: [PATCH 3/4] freedreno/fdl: Add support for RGB888/BGR888 pipe formats
++ in render buffer creation
++
++This enables the rendering of RGB/BGR 24-bit format buffers directly
++onto the framebuffer. For RGB888, support already exists for vertex and
++texture formats, so render buffer format support has been added. For
++BGR888, support for vertex, texture, and render buffer formats has been
++added. The internal format chosen for both RGB888 and BGR888 is GL_RGB8.
++
++Change-Id: I0557389dba05d3b44d7b935f02683df17e41fbd2
++Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
++Signed-off-by: Lakshman Chandu Kondreddy <quic_lkondred@quicinc.com>
++---
++ src/freedreno/fdl/fd6_format_table.c | 12 ++++++++----
++ 1 file changed, 8 insertions(+), 4 deletions(-)
++
++diff --git a/src/freedreno/fdl/fd6_format_table.c b/src/freedreno/fdl/fd6_format_table.c
++index 55d42538debd5..994c15c120e61 100644
++--- a/src/freedreno/fdl/fd6_format_table.c
+++++ b/src/freedreno/fdl/fd6_format_table.c
++@@ -121,12 +121,16 @@ static const struct fd6_format formats[PIPE_FORMAT_COUNT] = {
++    _TC(A4B4G4R4_UNORM, 4_4_4_4_UNORM,           XYZW),
++ 
++    /* 24-bit */
++-   VT_(R8G8B8_UNORM,   8_8_8_UNORM,             WZYX),
++-   VT_(R8G8B8_SNORM,   8_8_8_SNORM,             WZYX),
++-   VT_(R8G8B8_UINT,    8_8_8_UINT,              WZYX),
++-   VT_(R8G8B8_SINT,    8_8_8_SINT,              WZYX),
+++   VTC(R8G8B8_UNORM,   8_8_8_UNORM,             WZYX),
+++   VTC(R8G8B8_SNORM,   8_8_8_SNORM,             WZYX),
+++   VTC(R8G8B8_UINT,    8_8_8_UINT,              WZYX),
+++   VTC(R8G8B8_SINT,    8_8_8_SINT,              WZYX),
++    V__(R8G8B8_USCALED, 8_8_8_UINT,              WZYX),
++    V__(R8G8B8_SSCALED, 8_8_8_SINT,              WZYX),
+++   VTC(B8G8R8_UNORM,   8_8_8_UNORM,             WXYZ),
+++   VTC(B8G8R8_SNORM,   8_8_8_SNORM,             WXYZ),
+++   VTC(B8G8R8_UINT,    8_8_8_UINT,              WXYZ),
+++   VTC(B8G8R8_SINT,    8_8_8_SINT,              WXYZ),
++ 
++    /* 32-bit */
++    V__(R32_UNORM,   32_UNORM,                   WZYX),
++-- 
++GitLab
++
++
++From 31b49cf057c27f41a123e615092f00762caaf329 Mon Sep 17 00:00:00 2001
++From: "Petar G. Georgiev" <quic_petarg@quicinc.com>
++Date: Sat, 10 May 2025 01:11:24 +0530
++Subject: [PATCH 4/4] freedreno/a6xx: Add support for some NPOT block size
++ formats
++
++This enables support for sampler view and shader image for
++non power of two formats such as RGB888/BGR888.
++As the above mentioned formats are of 24 bit, block size
++for each format is 3. So added condition to check this.
++
++Change-Id: Ie48dfd4604ad9392fc655fd7a3b49c8c6a7a7229
++Co-Developed-by: Lakshman Chandu Kondreddy <quic_lkondred@quicinc.com>
++Signed-off-by: Petar G. Georgiev <quic_petarg@quicinc.com>
++Signed-off-by: Lakshman Chandu Kondreddy <quic_lkondred@quicinc.com>
++---
++ src/gallium/drivers/freedreno/a6xx/fd6_screen.cc | 13 ++++++++-----
++ 1 file changed, 8 insertions(+), 5 deletions(-)
++
++diff --git a/src/gallium/drivers/freedreno/a6xx/fd6_screen.cc b/src/gallium/drivers/freedreno/a6xx/fd6_screen.cc
++index 0b593cef4f4df..3f7387b6c345d 100644
++--- a/src/gallium/drivers/freedreno/a6xx/fd6_screen.cc
+++++ b/src/gallium/drivers/freedreno/a6xx/fd6_screen.cc
++@@ -67,11 +67,14 @@ fd6_screen_is_format_supported(struct pipe_screen *pscreen,
++    bool has_color = fd6_color_format(format, TILE6_LINEAR) != FMT6_NONE;
++    bool has_tex = fd6_texture_format_supported(screen->info, format, TILE6_LINEAR, false);
++ 
++-   if ((usage & (PIPE_BIND_SAMPLER_VIEW | PIPE_BIND_SHADER_IMAGE)) &&
++-       has_tex &&
++-       (target == PIPE_BUFFER ||
++-        util_is_power_of_two_or_zero(util_format_get_blocksize(format)))) {
++-      retval |= usage & (PIPE_BIND_SAMPLER_VIEW | PIPE_BIND_SHADER_IMAGE);
+++   if ((usage & PIPE_BIND_SHADER_IMAGE) && has_tex &&
+++       (target == PIPE_BUFFER || (util_format_get_blocksize(format) == 3)
+++        || util_is_power_of_two_or_zero(util_format_get_blocksize(format)))) {
+++      retval |= usage & PIPE_BIND_SHADER_IMAGE;
+++   }
+++
+++   if ((usage & PIPE_BIND_SAMPLER_VIEW) && has_tex) {
+++      retval |= usage & PIPE_BIND_SAMPLER_VIEW;
++    }
++ 
++    if (usage & PIPE_BIND_SHADER_IMAGE) {
++-- 
++GitLab
++
 diff -Nru mesa-25.2.0-orig/debian/patches/series mesa-25.2.0/debian/patches/series
 --- mesa-25.2.0-orig/debian/patches/series	2025-06-17 14:44:27.640967846 +0300
 +++ mesa-25.2.0/debian/patches/series	2025-06-17 14:45:04.690440415 +0300
@@ -499,3 +756,4 @@ diff -Nru mesa-25.2.0-orig/debian/patches/series mesa-25.2.0/debian/patches/seri
  disable_ppc64el_assembly.diff
  drisw-Avoid-crashing-when-swrast_loader-NULL.patch
 -etnaviv-add-support-for-texelfetch.patch
++35316.patch

--- a/scripts/build-deb.py
+++ b/scripts/build-deb.py
@@ -59,8 +59,24 @@ with tempfile.TemporaryDirectory() as temp_dir:
         )
     print("✅ Checksum of original source package matched.")
 
-    # Unpack the source package
-    subprocess.run(['dpkg-source', '-x', dsc_file], cwd=temp_dir, check=True)
+    script = config.get('script')
+    if script:
+        if not os.path.isabs(script):
+            config_dir = os.path.dirname(args.config)
+            script = os.path.abspath(os.path.join(config_dir, script))
+
+        env = os.environ.copy()
+        env['DSC_FILE'] = dsc_file
+        env.update(config.get('env', {}))
+
+        subprocess.run(script, cwd=temp_dir, check=True, env=env)
+
+        print("✅ Successfully executed the script.")
+    else:
+        # Unpack the source package
+        subprocess.run(['dpkg-source', '-x', dsc_file],
+                       cwd=temp_dir,
+                       check=True)
 
     # Find the unpacked directory
     unpacked_dirs = [


### PR DESCRIPTION
In order to evaluate upstream Mesa on the RB1 board, package the snapshot of the Mesa development tree. This package will go away once Mesa 25.2 gets released and enters Debian experimental or unstable.