### PR TITLE
ci: fix LAVA job templates with password change prompt

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -37,11 +37,17 @@ actions:
       password_prompt: 'Password'
       password: debian
       login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
       - sudo su
     method: minimal
     prompts:
     - root@debian
     - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
     timeout:
       minutes: 3
 - test:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -38,11 +38,17 @@ actions:
       password_prompt: 'Password'
       password: debian
       login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
       - sudo su
     method: minimal
     prompts:
     - root@debian
     - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
     timeout:
       minutes: 3
 - test:


### PR DESCRIPTION
Update LAVA job templates for the case when password has to be changed at the first login attempt. This patch should only be merged after #74