### PR TITLE
u-boot: Update path to fwupd metadata file

### DIFF
--- a/scripts/build-u-boot-rb1.sh
+++ b/scripts/build-u-boot-rb1.sh
@@ -114,4 +114,4 @@ rm -f "${CABINET_OUTPUT}"
 fwupdtool build-cabinet \
     "${CABINET_OUTPUT}" \
     "${CAPSULE_OUTPUT}" \
-    board/qualcomm/u-boot-cap.metainfo.xml
+    board/qualcomm/rb1/u-boot-cap.metainfo.xml


### PR DESCRIPTION
This file was moved to a board specific subdirectory.

Did a test build to confirm the fix.
