### PR TITLE
workflows: scan all shell scripts

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -51,12 +51,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install ShellCheck
-        run: sudo apt update && sudo apt -y install shellcheck
+        run: sudo apt update && sudo apt -y install shellcheck file
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Run ShellCheck
-        run: shellcheck scripts/*.sh
-
+        run: |
+          # Run shellcheck against all files outside .git/ that `file` reports
+          # as text/x-shellscript
+          find . -path ./.git -prune -o -print0 | \
+            xargs -0n1 sh -c 'test "$(file --brief --mime-type "$1")" = "text/x-shellscript" && printf "%s\000" "$1"' -- | \
+            xargs -0t shellcheck


### PR DESCRIPTION
Instead of just scripts/*.sh, scan all scripts found in the repository using `file`.

I didn't find a widely accepted mechanism to do this so settled on using `file`. The script is at least not too long to follow, doesn't introduce any external dependency, and is careful to avoid errors from unusual characters in filenames (eg. backslash escapes and carriage returns) to try and be safe against all inputs.

If this pattern works, we could extend it to the other lint checks in this file.