### PR TITLE
workflows: test: Fix BUILD_URL env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
+    env:
+      BUILD_URL: ${{ inputs.url }}
     steps:
-      - env:
-          BUILD_URL: ${{ inputs.url }}
       - name: Clone repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
BUILD_URL was not properly defined for a single step, and BUILD_URL is
used across multiple steps of that job, so define it properly and at the
job level.
