### PR TITLE
workflows: build-overlay-deb: Install git

### DIFF
--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -75,7 +75,12 @@ jobs:
           # install dependencies
           DEBIAN_FRONTEND=noninteractive \
               apt -y install --no-install-recommends \
-                  python3 devscripts patch python3-yaml debian-keyring
+                  debian-keyring \
+                  devscripts \
+                  git \
+                  patch \
+                  python3 \
+                  python3-yaml
           # create output dir
           mkdir -v upload
           chmod a+rw upload


### PR DESCRIPTION
Make git available for scripts that generate source packages, e.g.
mesa-snapshot.
