### PR TITLE
ci: lava: fix flashing path for tarballs

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -14,7 +14,7 @@ actions:
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
         - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-rb3gen2-vision-kit" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-qcs6490-rb3gen2-vision-kit" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
       minutes: 5

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -15,7 +15,7 @@ actions:
         - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
         - echo "STORAGE=emmc" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-rb1" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-qrb2210-rb1" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
       minutes: 5


### PR DESCRIPTION
After change in platform names caused by introduction of ptool, LAVA jobs fail because of wrong path in the tarball. This patch adjusts the name of the directory so the flashing can now succeed.