### PR TITLE
workflows: build-overlay-deb: Install dh, build-essential

### DIFF
--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -75,8 +75,10 @@ jobs:
           # install dependencies
           DEBIAN_FRONTEND=noninteractive \
               apt -y install --no-install-recommends \
+                  build-essential \
                   debian-keyring \
                   devscripts \
+                  dh \
                   git \
                   patch \
                   python3 \


### PR DESCRIPTION
The mesa-snapshot script expects these to run the clean target.

This should ideally be prepared in a clean, well defined environment as
other packages might expect other build-deps for clean. However, the
build itself is run in a clean sbuild.
