### PR TITLE
Add initial GNU make Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# DEBOS_OPTS can be overridden with:
+#     make DEBOS_OPTS=... all
+
+# To build large images, the debos resource defaults are not sufficient. These
+# provide defaults that work for us as universally as we can manage.
+FAKEMACHINE_BACKEND = $(shell [ -c /dev/kvm ] && echo kvm || echo qemu)
+DEBOS_OPTS := --fakemachine-backend $(FAKEMACHINE_BACKEND) --memory 1GiB --scratchsize 4GiB
+DEBOS := debos $(DEBOS_OPTS)
+
+# Use http_proxy from the environment, or apt's http_proxy if set, to speed up
+# builds.
+http_proxy ?= $(shell apt-config dump --format '%v%n' Acquire::http::Proxy)
+export http_proxy
+
+all: disk-ufs.img.gz disk-sdcard.img.gz
+
+rootfs.tar.gz: debos-recipes/qualcomm-linux-debian-rootfs.yaml
+	$(DEBOS) $<
+
+disk-ufs.img.gz: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar.gz
+	$(DEBOS) $<
+
+disk-sdcard.img.gz: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar.gz
+	$(DEBOS) -t imagetype:sdcard $<
+
+.PHONY: all


### PR DESCRIPTION
We have a fairly complicated build process in qcom-deb-images, as evidenced by the current README.md. Giving developers a one-command build instead means:

1. Simplified instructions for developers, or in other words, moving instructions for manual entry from README.md into automated invocation via the build system.

2. Automated dependency/rebuild tracking, reducing the instances where a full rebuild is required, or the easiest option, during development iteration.

3. Building only what is necessary for a given target.

4. The opportunity to move towards running CI before submission in a PR, rather than CI being entirely defined inside .github/workflows/ and therefore inaccessible for running locally.

This is too complex to attempt all at once. Instead I'm doing it in multiple small steps, and this is the first step. Overall, my plan is:

1. Introduce a basic Makefile that works.

2. Per item, implement in the Makefile what CI requires that is already implemented in .github/workflows/.

3. Per item, replace complex build invocation steps made directly from .github/workflows/ with calls to the Makefile instead.

4. Once the elements covered by README.md are all covered, I'll update the instructions to use the Makefile instead.

Note that CI for the Makefile should therefore not be necessary to implement directly; it'll happen step by step as CI is moved into it through step 3 above. If there are gaps in CI coverage that the Makefile does cover, then we can implement those as separate CI items to call from .github/workflows/ as we wish.

In time, this should make .github/workflows/ simpler, and encode our knowledge of how to invoke the various tools (including debos) into the source tree itself, rather than via manual instructions in README.md that are also duplicated in .github/workflows/