### PR TITLE
mesa-snapshot: bump the commit id to c1ba062a3066

### DIFF
--- a/overlay-debs/mesa-snapshot/mesa-snapshot.yaml
+++ b/overlay-debs/mesa-snapshot/mesa-snapshot.yaml
@@ -4,4 +4,4 @@ debdiff_file: "mesa_25.2.0.debdiff"
 script: mesa-snapshot.sh
 suite: trixie
 env:
-  COMMIT: 7fd99c88b9cd5c0c8c1cb3e92383acac5cb8220b
+  COMMIT: c1ba062a30669aa57e371440fca4bfa00a1b45c3


### PR DESCRIPTION
- rusticl: use image_copy_buffer
- zink: enable ioopt by default
- tu: Remove now-redundant tu_trace_render_pass_start()
- rusticl: Fix work group size validation
- freedreno/a6xx: Fix thread calc for dummy kernels
- ir3/isa: ignore bit 54 in alias encoding
- rusticl/formats: support cl_ext_image_unorm_int_2_101010
- rusticl/formats: support CL_UNORM_INT_101010_2
- rusticl/queue: fix wrong_self_convention and needless_borrow clippy warnings
- ci: separate hidden jobs to -inc yml files
- nir: Split lower_vote_eq into int/float versions