### PR TITLE
rmtfs: add delta to fix wifi crash on shutdown

### DIFF
--- a/overlay-debs/rmtfs/rmtfs_1.1-3qcom1.debdiff
+++ b/overlay-debs/rmtfs/rmtfs_1.1-3qcom1.debdiff
@@ -1,0 +1,66 @@
+diff -Nru rmtfs-1.1/debian/changelog rmtfs-1.1/debian/changelog
+--- rmtfs-1.1/debian/changelog	2025-05-19 11:18:34.000000000 +0100
++++ rmtfs-1.1/debian/changelog	2025-07-24 17:19:35.000000000 +0100
+@@ -1,3 +1,10 @@
++rmtfs (1.1-3qcom1) trixie; urgency=medium
++
++  * d/p/0002-rmtfs.service-Fix-start-stop-ordering-between-rmtfs-.patch: fix
++    wifi driver crash on reboot by ensuring correct service ordering.
++
++ -- Robie Basak <robibasa@qti.qualcomm.com>  Thu, 24 Jul 2025 17:19:35 +0100
++
+ rmtfs (1.1-3) unstable; urgency=medium
+ 
+   * d/control: only build for ARMv7+
+diff -Nru rmtfs-1.1/debian/patches/0002-rmtfs.service-Fix-start-stop-ordering-between-rmtfs-.patch rmtfs-1.1/debian/patches/0002-rmtfs.service-Fix-start-stop-ordering-between-rmtfs-.patch
+--- rmtfs-1.1/debian/patches/0002-rmtfs.service-Fix-start-stop-ordering-between-rmtfs-.patch	1970-01-01 01:00:00.000000000 +0100
++++ rmtfs-1.1/debian/patches/0002-rmtfs.service-Fix-start-stop-ordering-between-rmtfs-.patch	2025-07-24 17:19:28.000000000 +0100
+@@ -0,0 +1,42 @@
++From 5b214f61b9b82998bf13f4bfd16fe4e2cd29c086 Mon Sep 17 00:00:00 2001
++From: Loic Poulain <loic.poulain@oss.qualcomm.com>
++Date: Tue, 10 Jun 2025 14:58:52 +0200
++Subject: [PATCH] rmtfs.service: Fix start/stop ordering between rmtfs and
++ NetworkManager
++
++Since rmtfs typically provides resources for wireless and modem-related
++processors, it's important to ensure that this service starts before
++and stops after NetworkManager.
++
++On platforms like QCOM RB1, this sequencing prevents the Wi-Fi interface(s)
++from being left in a dangling state while NetworkManager attempts to tear
++down the interface(s):
++https://github.com/qualcomm-linux/qcom-deb-images/issues/40#issuecomment-2944265370
++
++The 'Before' dependency directive is ignored if NetworkManager is disabled or absent.
++
++Signed-off-by: Loic Poulain <loic.poulain@oss.qualcomm.com>
++
++Origin: backport, https://github.com/linux-msm/rmtfs/commit/5b214f61b9b82998bf13f4bfd16fe4e2cd29c086
++Bug: https://github.com/linux-msm/rmtfs/pull/24
++Bug-qcom: https://github.com/qualcomm-linux/qcom-deb-images/issues/40
++Last-Update: 2025-07-24
++---
++ rmtfs-dir.service.in | 1 +
++ rmtfs.service.in     | 1 +
++ 2 files changed, 2 insertions(+)
++
++diff --git a/rmtfs.service.in b/rmtfs.service.in
++index abd12df..2dc08df 100644
++--- a/rmtfs.service.in
+++++ b/rmtfs.service.in
++@@ -1,5 +1,6 @@
++ [Unit]
++ Description=Qualcomm remotefs service
+++Before=NetworkManager.service
++ 
++ [Service]
++ ExecStart=RMTFS_PATH/rmtfs -r -P -s
++-- 
++2.48.1
++
+diff -Nru rmtfs-1.1/debian/patches/series rmtfs-1.1/debian/patches/series
+--- rmtfs-1.1/debian/patches/series	2025-05-19 11:18:34.000000000 +0100
++++ rmtfs-1.1/debian/patches/series	2025-07-24 17:13:29.000000000 +0100
+@@ -1 +1,2 @@
+ 0001-rmtfs.service.in-Remove-dependency-on-qrtr-ns.servic.patch
++0002-rmtfs.service-Fix-start-stop-ordering-between-rmtfs-.patch

--- a/overlay-debs/rmtfs/rmtfs_1.1-3qcom1.yaml
+++ b/overlay-debs/rmtfs/rmtfs_1.1-3qcom1.yaml
@@ -1,0 +1,4 @@
+dsc_url: "https://snapshot.debian.org/archive/debian/20250724T172356Z/pool/main/r/rmtfs/rmtfs_1.1-3.dsc"
+dsc_sha256sum: "600df007ef07ea5e72b5a301086eec77d721871b365dfcabed64f23d1f3084f8"
+debdiff_file: "rmtfs_1.1-3qcom1.debdiff"
+suite: "trixie"


### PR DESCRIPTION
From upstream fix: https://github.com/linux-msm/rmtfs/commit/5b214f61b9b82998bf13f4bfd16fe4e2cd29c086

Closes: #40