### PR TITLE
workflows: linux: Allow writing test results

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,7 @@ on:
 
 # implicitely set all other permissions to none
 permissions:
+  checks: write # test.yml
   contents: read # actions/checkout debos.yml test.yml
   packages: read # test.yml
   pull-requests: write # test.yml


### PR DESCRIPTION
test.yml requires checks write, so provide that.

GitHub is now smarter about not even starting the workflow is permissions aren't met.
