### PR TITLE
workflows: debos: Drop concurrency

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -25,11 +25,6 @@ on:
 permissions:
   contents: read # actions/checkout
 
-# cancel in progress builds for this workflow triggered by the same ref
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   # image build id; used for SBOM generation; TODO: should be used in image metadata too
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
This is duplicating concurrency already defined in workflows including
debos.yml, resulting in GitHub warnings such as "Canceling since a
deadlock was detected for concurrency group: 'Build Linux kernel deb and
debos image-refs/heads/main' between a top level workflow and
'debos-mainline-linux'".
