### PR TITLE
ci: Switch to AWS container registry

### DIFF
--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -15,7 +15,7 @@ jobs:
         arch: [amd64, arm64]
     runs-on: [self-hosted, qcom-u2404, "${{ matrix.arch }}"]
     container:
-      image: debian:trixie
+      image: public.ecr.aws/debian/debian:trixie
       options: --privileged  # Required for chroot creation
     steps:
       - name: Update OS packages

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -36,7 +36,7 @@ jobs:
       url: ${{ steps.upload_artifacts.outputs.url }}
     runs-on: [self-hosted, qcom-u2404, arm64]
     container:
-      image: debian:trixie
+      image: public.ecr.aws/debian/debian:trixie
       volumes:
         - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
       options: --privileged

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
     # alternative for native builds, but overkill to do both
     #runs-on: [self-hosted, qcom-u2404, arm64]
     container:
-      image: debian:trixie
+      image: public.ecr.aws/debian/debian:trixie
       volumes:
         - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
     steps:

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -32,7 +32,7 @@ jobs:
     # alternative for native builds, but overkill to do both
     #runs-on: [self-hosted, qcom-u2404, arm64]
     container:
-      image: debian:trixie
+      image: public.ecr.aws/debian/debian:trixie
       volumes:
         - /efs/qli/metaqcom/gh-runners/quic-yocto/downloads:/fileserver-downloads
     steps:


### PR DESCRIPTION
GitHub self-hosted runners are located in AWS and will benefit from
using ECR for performance and cost-savings.
