### PR TITLE
workflows: debos: Update to 6.16.1-qcom1+

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -14,7 +14,7 @@ on:
       kernelpackage:
         description: Name of kernel package to use
         type: string
-        default: linux-image-6.16.0-qcom2+
+        default: linux-image-6.16.1-qcom1+
 
     outputs:
       artifacts_url:


### PR DESCRIPTION
Test booted on RB1; at least serial, eMMC, USB and WiFi worked.
