### PR TITLE
Add support for more boards

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -129,7 +129,9 @@ jobs:
           tar -cvf "${dir}"/flash-ufs.tar.gz \
               disk-ufs.img1 \
               disk-ufs.img2 \
-              flash_qcs6490-*
+              flash_qcs6490-* \
+              flash_qcs8300-* \
+              flash_qcs9100-*
           tar -cvf "${dir}"/flash-emmc.tar.gz \
               disk-sdcard.img1 \
               disk-sdcard.img2 \

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -14,41 +14,73 @@ actions:
     filename: qcom-ptool.tar.gz
     unpack: true
 
+{{- $boards := list }}
+{{- if eq $build_qcm6490 "true" }}
+{{- $boards = append $boards (dict
+    "name" "qcs6490-rb3gen2-vision-kit"
+    "silicon_family" "qcm6490"
+    "platform" "qcs6490-rb3gen2"
+    "boot_binaries_download" (dict
+        "description" "QCM6490 boot binaries"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00095.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip"
+        "name" "qcm6490_boot-binaries"
+        "filename" "qcm6490_boot-binaries.zip"
+        "sha256sum" "9c100d7b184ecf0ab9c4be71a8bb7c243fdc79a64380ca3025024dd2b14c5078"
+    )
+    "cdt_download" (dict
+        "description" "RB3 Gen2 Vision Kit CDT"
+        "url" "https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-vision-kit.zip"
+        "name" "qcs6490-rb3gen2-vision-kit_cdt"
+        "filename" "qcs6490-rb3gen2-vision-kit_cdt.zip"
+        "sha256sum" "a339e297b454c4dc3805fe8cd11d6d8dcb801aa8f0c2dc691561c2785019fa3c"
+    )
+    "cdt_filename" "cdt_vision_kit.bin"
+    "dtb" "qcom/qcs6490-rb3gen2.dtb"
+    "disk_image_type" "ufs"
+)}}
+{{- end }}
 {{- if eq $build_rb1 "true" }}
-  # TODO: consider switching to https://releases.linaro.org/96boards/rb1/qualcomm/firmware/RB1_firmware_20231124-v4.zip instead
-  - action: download
-    description: Download RB1 rescue image
-    url: https://releases.linaro.org/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip
-    name: qrb2210-rb1_rescue-image.zip
-    filename: qrb2210-rb1_rescue-image.zip
-  - action: run
-    description: Verify download
-    chroot: false
-    command: echo c75b6c63eb24c8ca36dad08ba4d4e93f3f4cd7dce60cf1b6dfb5790dc181cc3d ${ROOTDIR}/../qrb2210-rb1_rescue-image.zip|sha256sum --strict -c -
+{{- $boards = append $boards (dict
+    "name" "qrb2210-rb1"
+    "silicon_family" "qcm2290"
+    "platform" "qrb2210-rb1"
+    "boot_binaries_download" (dict
+        "description" "RB1 rescue image"
+        "url" "https://releases.linaro.org/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip"
+        "name" "qrb2210-rb1_rescue-image"
+        "filename" "qrb2210-rb1_rescue-image.zip"
+        "sha256sum" "c75b6c63eb24c8ca36dad08ba4d4e93f3f4cd7dce60cf1b6dfb5790dc181cc3d"
+    )
+    "disk_image_type" "sdcard"
+    "u_boot_file" .u_boot_rb1
+)}}
 {{- end }}
 
-{{- if eq $build_qcm6490 "true" }}
+{{- range $board := $boards }}
   - action: download
-    description: Download QCM6490 boot binaries
-    url: https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00095.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip
-    name: qcm6490_boot-binaries
-    filename: qcm6490_boot-binaries.zip
+    description: Download of {{ $board.boot_binaries_download.description }}
+    url: {{ $board.boot_binaries_download.url }}
+    name: {{ $board.boot_binaries_download.name }}
+    filename: {{ $board.boot_binaries_download.filename }}
   - action: run
-    description: Verify download
+    description: Verify SHA256 sum of {{ $board.boot_binaries_download.description }}
     chroot: false
-    command: echo 9c100d7b184ecf0ab9c4be71a8bb7c243fdc79a64380ca3025024dd2b14c5078 ${ROOTDIR}/../qcm6490_boot-binaries.zip|sha256sum --strict -c -
-{{- end }}
-
-{{- if eq $build_qcm6490 "true" }}
+    command:
+      echo "{{ $board.boot_binaries_download.sha256sum }} ${ROOTDIR}/../{{ $board.boot_binaries_download.filename }}" |
+          sha256sum --strict -c -
+  {{- if $board.cdt_download }}
   - action: download
-    description: Download RB3 Gen2 Vision Kit CDT
-    url: https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-vision-kit.zip
-    name: qcs6490-rb3gen2-vision-kit_cdt
-    filename: qcs6490-rb3gen2-vision-kit_cdt.zip
+    description: Download of {{ $board.cdt_download.description }}
+    url: {{ $board.cdt_download.url }}
+    name: {{ $board.cdt_download.name }}
+    filename: {{ $board.cdt_download.filename }}
   - action: run
-    description: Verify download
+    description: Verify SHA256 sum of {{ $board.cdt_download.description }}
     chroot: false
-    command: echo a339e297b454c4dc3805fe8cd11d6d8dcb801aa8f0c2dc691561c2785019fa3c ${ROOTDIR}/../qcs6490-rb3gen2-vision-kit_cdt.zip|sha256sum --strict -c -
+    command:
+      echo "{{ $board.cdt_download.sha256sum }} ${ROOTDIR}/../{{ $board.cdt_download.filename }}" |
+          sha256sum --strict -c -
+  {{- end }}
 {{- end }}
 
   - action: run
@@ -62,18 +94,20 @@ actions:
       # path to unpacked qcom-ptool tarball
       QCOM_PTOOL="${ROOTDIR}/../qcom-ptool.tar.gz.d/qcom-ptool-main"
 
-{{- if eq $build_rb1 "true" }}
-      ## silicon family: qcm2290
-      # use RB1 rescue image as there are no qcm2290 boot binaries published
-      unzip -j "${ROOTDIR}/../qrb2210-rb1_rescue-image.zip" \
-          -d build/qrb2210-rb1_rescue-image
+{{- range $board := $boards }}
+      ### board: {{ $board.name }}
+      ### platform: {{ $board.platform }}
+      ### silicon family: {{ $board.silicon_family }}
 
-      ### platform: qrb2210-rb1
+      # unpack boot binaries
+      unzip -j "${ROOTDIR}/../{{ $board.boot_binaries_download.filename }}" \
+          -d build/{{ $board.name }}_boot-binaries
+
       # generate partition files
-      mkdir -v build/qrb2210-rb1_partitions
+      mkdir -v build/{{ $board.platform }}_partitions
       (
-          cd build/qrb2210-rb1_partitions
-          conf="${QCOM_PTOOL}/platforms/qrb2210-rb1/partitions.conf"
+          cd build/{{ $board.platform }}_partitions
+          conf="${QCOM_PTOOL}/platforms/{{ $board.platform }}/partitions.conf"
           "${QCOM_PTOOL}/gen_partition.py" -i "$conf" \
               -o ptool-partitions.xml
           # partitions.conf sets --type=emmc, nand or ufs
@@ -85,12 +119,12 @@ actions:
           "${QCOM_PTOOL}/ptool.py" -x ptool-partitions.xml
       )
 
-      #### board: qrb2210-rb1
-      flash_dir="${ARTIFACTDIR}/flash_qrb2210-rb1"
+      # create board-specific flash directory
+      flash_dir="${ARTIFACTDIR}/flash_{{ $board.name }}"
       rm -rf "${flash_dir}"
       mkdir -v "${flash_dir}"
       # copy platform partition files
-      cp --preserve=mode,timestamps -v build/qrb2210-rb1_partitions/* \
+      cp --preserve=mode,timestamps -v build/{{ $board.platform }}_partitions/* \
           "${flash_dir}"
       # remove BLANK_GPT and WIPE_PARTITIONS files as it's common for people
       # to run "qdl rawprogram*.xml", mistakingly including these; perhaps
@@ -100,7 +134,7 @@ actions:
       rm -v "${flash_dir}"/rawprogram*_WIPE_PARTITIONS.xml
       # copy silicon family boot binaries; these shouldn't ship partition
       # files, but make sure not to accidentally clobber any such file
-      find build/qrb2210-rb1_rescue-image \
+      find build/{{ $board.name }}_boot-binaries \
           -not -name 'gpt_*' \
           -not -name 'patch*.xml' \
           -not -name 'rawprogram*.xml' \
@@ -116,96 +150,28 @@ actions:
               -or -name '*.mbn' \
           \) \
           -exec cp --preserve=mode,timestamps -v '{}' "${flash_dir}" \;
-      # copy RB1 U-Boot binary to boot.img;
+      {{- if $board.u_boot_file }}
+      # copy U-Boot binary to boot.img;
       # qcom-ptool/platforms/*/partitions.conf uses filename=boot.img
       # boot_a and boot_b partitions
-      cp --preserve=mode,timestamps -v "${ARTIFACTDIR}/{{- .u_boot_rb1 -}}" \
+      cp --preserve=mode,timestamps -v "${ARTIFACTDIR}/{{ $board.u_boot_file }}" \
           "${flash_dir}/boot.img"
+      {{- end }}
 
-      # update flashing files for ESP image;
-      # qcom-ptool/platforms/*/partitions.conf uses filename=efi.bin for the
-      # ESP partition on EFI capable platforms
-      sed -i '/label="efi"/s#filename="[^"]*"#filename="../disk-sdcard.img1"#' \
-          "${flash_dir}"/rawprogram*.xml
-
-      # update flashing files for rootfs image;
-      # qcom-ptool/platforms/*/partitions.conf uses filename=rootfs.img for the
-      # rootfs partition
-      sed -i \
-          '/label="rootfs"/s#filename="[^"]*"#filename="../disk-sdcard.img2"#' \
-          "${flash_dir}"/rawprogram*.xml
-
-      # TODO: there is currently no dtb.bin alike system with the RB1 firmware
-
-      # TODO: currently not providing CDT; it's present in
-      # RB1_firmware_20231124-v4.zip but not in
-      # rb1-bootloader-emmc-linux-47528.zip
-{{- end }}
-
-{{- if eq $build_qcm6490 "true" }}
-      ## silicon family: qcm6490
-      # unpack boot binaries
-      unzip -j "${ROOTDIR}/../qcm6490_boot-binaries.zip" \
-          -d build/qcm6490_boot-binaries
-
-      ### platform: qcs6490-rb3gen2
-      # generate partition files
-      mkdir -v build/qcs6490-rb3gen2_partitions
-      (
-          cd build/qcs6490-rb3gen2_partitions
-          conf="${QCOM_PTOOL}/platforms/qcs6490-rb3gen2/partitions.conf"
-          "${QCOM_PTOOL}/gen_partition.py" -i "$conf" \
-              -o ptool-partitions.xml
-          # partitions.conf sets --type=emmc, nand or ufs
-          if grep -F '^--disk --type=ufs ' "${conf}"; then
-              touch flash-ufs
-          elif grep -F '^--disk --type=emmc ' "${conf}"; then
-              touch flash-emmc
-          fi
-          "${QCOM_PTOOL}/ptool.py" -x ptool-partitions.xml
-      )
-      #### board qcs6490-rb3gen2-vision-kit
-      flash_dir="${ARTIFACTDIR}/flash_qcs6490-rb3gen2-vision-kit"
-      rm -rf "${flash_dir}"
-      mkdir -v "${flash_dir}"
-      # copy platform partition files
-      cp --preserve=mode,timestamps -v build/qcs6490-rb3gen2_partitions/* \
-          "${flash_dir}"
-      # remove BLANK_GPT and WIPE_PARTITIONS files as it's common for people
-      # to run "qdl rawprogram*.xml", mistakingly including these; perhaps
-      # ptool should have a flag not to generate these; note that there are
-      # wipe_rawprogram*.xml files still
-      rm -v "${flash_dir}"/rawprogram*_BLANK_GPT.xml
-      rm -v "${flash_dir}"/rawprogram*_WIPE_PARTITIONS.xml
-      # copy silicon family boot binaries; these shouldn't ship partition
-      # files, but make sure not to accidentally clobber any such file
-      find build/qcm6490_boot-binaries \
-          -not -name 'gpt_*' \
-          -not -name 'patch*.xml' \
-          -not -name 'rawprogram*.xml' \
-          -not -name 'wipe*.xml' \
-          -not -name 'zeros_*' \
-          \( \
-              -name LICENSE \
-              -or -name Qualcomm-Technologies-Inc.-Proprietary \
-              -or -name 'prog_*' \
-              -or -name '*.bin' \
-              -or -name '*.elf' \
-              -or -name '*.fv' \
-              -or -name '*.mbn' \
-          \) \
-          -exec cp --preserve=mode,timestamps -v '{}' "${flash_dir}" \;
+      {{- if $board.cdt_download }}
       # unpack board CDT
-      unzip -j "${ROOTDIR}/../qcs6490-rb3gen2-vision-kit_cdt.zip" \
-          -d build/qcs6490-rb3gen2-vision-kit_cdt
+      unzip -j "${ROOTDIR}/../{{ $board.cdt_download.filename }}" \
+          -d build/{{ $board.name }}_cdt
       # copy just the CDT data; no partition or flashing files
-      cp --preserve=mode,timestamps -v build/qcs6490-rb3gen2-vision-kit_cdt/cdt_vision_kit.bin \
+      cp --preserve=mode,timestamps -v build/{{ $board.name }}_cdt/{{ $board.cdt_filename }} \
           "${flash_dir}"
 
       # update flashing files for CDT
-      sed -i '/label="cdt"/s/filename=""/filename="cdt_vision_kit.bin"/' \
+      sed -i '/label="cdt"/s/filename=""/filename="{{ $board.cdt_filename }}"/' \
           "${flash_dir}"/rawprogram*.xml
+      {{- end }}
 
+      {{- if $board.dtb }}
       # generate a dtb.bin FAT partition with just a single dtb for the current
       # board; long-term this should really be a set of dtbs and overlays as to
       # share dtb.bin across boards
@@ -218,28 +184,24 @@ actions:
       # in these and hold the target device tree, which is 4096 KiB sized
       # blocks for mkfs.vfat's last argument
       mkfs.vfat -S 4096 -C "${dtb_bin}" 4096
-      # RB3 Gen2 Vision Kit will probably have a more specific DTB (see
-      # <20241204100003.300123-6-quic_vikramsa@quicinc.com> on lore.kernel.org)
-      # but for now use the core kit one
-      dtb="qcom/qcs6490-rb3gen2.dtb"
       # extract board device tree from the root filesystem provided tarball
-      tar -C build -xvf "${ARTIFACTDIR}/dtbs.tar.gz" "${dtb}"
+      tar -C build -xvf "${ARTIFACTDIR}/dtbs.tar.gz" "{{ $board.dtb }}"
       # copy into the FAT as combined-dtb.dtb
-      mcopy -vmp -i "${dtb_bin}" "build/${dtb}" ::/combined-dtb.dtb
-
+      mcopy -vmp -i "${dtb_bin}" "build/{{ $board.dtb }}" ::/combined-dtb.dtb
       # (NB: flashing files already expect "dtb.bin" as a filename)
+      {{- end }}
 
       # update flashing files for ESP image;
       # qcom-ptool/platforms/*/partitions.conf uses filename=efi.bin for the
       # ESP partition on EFI capable platforms
-      sed -i '/label="efi"/s#filename="[^"]*"#filename="../disk-ufs.img1"#' \
+      sed -i '/label="efi"/s#filename="[^"]*"#filename="../disk-{{ $board.disk_image_type }}.img1"#' \
           "${flash_dir}"/rawprogram*.xml
 
       # update flashing files for rootfs image;
       # qcom-ptool/platforms/*/partitions.conf uses filename=rootfs.img for the
       # rootfs partition
       sed -i \
-          '/label="rootfs"/s#filename="[^"]*"#filename="../disk-ufs.img2"#' \
+          '/label="rootfs"/s#filename="[^"]*"#filename="../disk-{{ $board.disk_image_type }}.img2"#' \
           "${flash_dir}"/rawprogram*.xml
 {{- end }}
 

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -100,8 +100,12 @@ actions:
       ### silicon family: {{ $board.silicon_family }}
 
       # unpack boot binaries
-      unzip -j "${ROOTDIR}/../{{ $board.boot_binaries_download.filename }}" \
-          -d build/{{ $board.name }}_boot-binaries
+      mkdir -v build/{{ $board.name }}_boot-binaries
+      unzip "${ROOTDIR}/../{{ $board.boot_binaries_download.filename }}" \
+          -d build/{{ $board.name }}_boot-binaries/unpack
+      # strip top directories
+      mv build/{{ $board.name }}_boot-binaries/unpack/*/* build/{{ $board.name }}_boot-binaries
+      rmdir -v build/{{ $board.name }}_boot-binaries/unpack/* build/{{ $board.name }}_boot-binaries/unpack
 
       # generate partition files
       mkdir -v build/{{ $board.platform }}_partitions
@@ -160,7 +164,7 @@ actions:
 
       {{- if $board.cdt_download }}
       # unpack board CDT
-      unzip -j "${ROOTDIR}/../{{ $board.cdt_download.filename }}" \
+      unzip "${ROOTDIR}/../{{ $board.cdt_download.filename }}" \
           -d build/{{ $board.name }}_cdt
       # copy just the CDT data; no partition or flashing files
       cp --preserve=mode,timestamps -v build/{{ $board.name }}_cdt/{{ $board.cdt_filename }} \

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -1,4 +1,5 @@
 {{- $build_qcm6490 := or .build_qcm6490 "true" }}
+{{- $build_qcs8300 := or .build_qcs8300 "true" }}
 {{- $build_qcs9100 := or .build_qcs9100 "true" }}
 {{- $build_rb1 := "false" -}}
 {{- if .u_boot_rb1 -}}
@@ -37,6 +38,30 @@ actions:
     )
     "cdt_filename" "cdt_vision_kit.bin"
     "dtb" "qcom/qcs6490-rb3gen2.dtb"
+    "disk_image_type" "ufs"
+)}}
+{{- end }}
+{{- if eq $build_qcs8300 "true" }}
+{{- $boards = append $boards (dict
+    "name" "qcs8300-ride"
+    "silicon_family" "qcs8300"
+    "platform" "qcs8300-ride-sx"
+    "boot_binaries_download" (dict
+        "description" "QCS8300 boot binaries"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00095.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "name" "qcs8300_boot-binaries"
+        "filename" "qcs8300_boot-binaries.zip"
+        "sha256sum" "463ffd7f20d243a5673ac49d744c8a35a3ab2067c3588be2741c2e6551f5a8f5"
+    )
+    "cdt_download" (dict
+        "description" "QCS8300 Ride SX EVK CDT"
+        "url" "https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS8300/cdt/ride-sx.zip"
+        "name" "qcs8300-ride-sx_cdt"
+        "filename" "qcs8300-ride-sx_cdt.zip"
+        "sha256sum" "d7fc667372b28383a36d586333097d84b9d9c104f4dd1845d33904e2d6b39f80"
+    )
+    "cdt_filename" "cdt_ride_sx.bin"
+    "dtb" "qcom/qcs8300-ride.dtb"
     "disk_image_type" "ufs"
 )}}
 {{- end }}

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -1,4 +1,5 @@
 {{- $build_qcm6490 := or .build_qcm6490 "true" }}
+{{- $build_qcs9100 := or .build_qcs9100 "true" }}
 {{- $build_rb1 := "false" -}}
 {{- if .u_boot_rb1 -}}
 {{- $build_rb1 = "true" }}
@@ -36,6 +37,30 @@ actions:
     )
     "cdt_filename" "cdt_vision_kit.bin"
     "dtb" "qcom/qcs6490-rb3gen2.dtb"
+    "disk_image_type" "ufs"
+)}}
+{{- end }}
+{{- if eq $build_qcs9100 "true" }}
+{{- $boards = append $boards (dict
+    "name" "qcs9100-ride-r3"
+    "silicon_family" "qcs9100"
+    "platform" "qcs9100-ride-sx"
+    "boot_binaries_download" (dict
+        "description" "QCS9100 boot binaries"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00095.0/qcs9100-le-1-0/common/build/ufs/bin/QCS9100_bootbinaries.zip"
+        "name" "qcs9100_boot-binaries"
+        "filename" "qcs9100_boot-binaries.zip"
+        "sha256sum" "c201c9e966a706c9e76685ff4298f0940958c4d4877299eee1248ef26b809aa0"
+    )
+    "cdt_download" (dict
+        "description" "QCS9100 Ride Rev3 EVK CDT"
+        "url" "https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx_v3.zip"
+        "name" "qcs9100-ride-sx-v3_cdt"
+        "filename" "qcs9100-ride-sx-v3_cdt.zip"
+        "sha256sum" "377a8405899ac82199deaf70bca3648c15b924a3fcef8f109555e661ed70f4b9"
+    )
+    "cdt_filename" "cdt_ride_sx.bin"
+    "dtb" "qcom/qcs9100-ride-r3.dtb"
     "disk_image_type" "ufs"
 )}}
 {{- end }}

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -305,6 +305,7 @@ actions:
           ls -d "$ROOTDIR"/usr/lib/linux-image-* | sort -V | tail -1)"
       tar -C "${latest_kernel}" -cvzf "$ARTIFACTDIR/dtbs.tar.gz" \
           qcom/qcs6490-rb3gen2.dtb \
+          qcom/qcs9100-ride-r3.dtb \
           qcom/qrb2210-rb1.dtb
 
   - action: pack

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -305,6 +305,7 @@ actions:
           ls -d "$ROOTDIR"/usr/lib/linux-image-* | sort -V | tail -1)"
       tar -C "${latest_kernel}" -cvzf "$ARTIFACTDIR/dtbs.tar.gz" \
           qcom/qcs6490-rb3gen2.dtb \
+          qcom/qcs8300-ride.dtb \
           qcom/qcs9100-ride-r3.dtb \
           qcom/qrb2210-rb1.dtb
 


### PR DESCRIPTION
Changes to debos recipes to have a more scalable board support approach and add
support for a couple more boards:
- IQ-9 Beta EVK (QCS9100 Ride Rev3 EVK)
- IQ-8 Beta EVK (QCS8300 Ride SX EVK)

Commits:
- **refactor: debos: data-driven flash recipe**
- **fix: debos: Only strip top directories from zips**
- **feat: debos: Add support for IQ-9 Beta EVK**
- **feat: debos: Add support for IQ-8 Beta EVK**
