### PR TITLE
mesa-unstable: fix the debdiff

### DIFF
--- a/overlay-debs/mesa-unstable/mesa_25.2.1-1qcom1.debdiff
+++ b/overlay-debs/mesa-unstable/mesa_25.2.1-1qcom1.debdiff
@@ -1,7 +1,7 @@
 diff -Nru mesa-25.2.0/debian/changelog mesa-25.2.0/debian/changelog
 --- mesa-25.2.0/debian/changelog	2025-08-07 14:08:04.000000000 +0300
 +++ mesa-25.2.0/debian/changelog	2025-05-29 20:16:02.000000000 +0300
-@@ -1,3 +1,13 @@
+@@ -1,3 +1,11 @@
 +mesa (25.2.1-1qcom1) trixie; urgency=medium
 +
 +  * Rebuild for trixie.


### PR DESCRIPTION
I've updated the debdiff manually, but I didn't update the patch header, which results in the failure to apply the patch.

Fix the patch header in the debdiff.