### PR TITLE
[DO NOT MERGE] Validate Debian workflow on QLI-AMI

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -2,8 +2,8 @@ name: Daily Build
 
 on:
   # run daily at 8:30am
-  schedule:
-    - cron: '30 8 * * *'
+  #schedule:
+  #  - cron: '30 8 * * *'
   # allow manual runs
   workflow_dispatch:
 
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build-daily:
     # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    if: github.repository == 'qualcomm-linux-stg/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/debos.yml
 
   test-daily:

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -144,11 +144,11 @@ jobs:
               disk-sdcard.img2 \
               flash_qrb2210-*
 
-      - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_artifacts
-        with:
-          path: debos-artifacts
+      # - name: Upload private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_artifacts
+      #   with:
+      #     path: debos-artifacts
 
       - name: Unpack rootfs to generate SBOM
         run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar.gz
@@ -193,11 +193,11 @@ jobs:
           mkdir -v sboms
           cp -av rootfs-sbom.*.gz sboms
 
-      - name: Upload SBOMs as private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_sbom_artifacts
-        with:
-          path: sboms
+      # - name: Upload SBOMs as private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_sbom_artifacts
+      #   with:
+      #     path: sboms
       - name: "Print output"
         env:
           build_url: ${{ steps.upload_artifacts.outputs.url }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,9 +2,9 @@ name: Build Linux kernel deb and debos image
 
 on:
   # run weekly on Monday at 8:30am
-  schedule:
-    - cron: '30 6 * * 1'
-  # allow manual runs
+  # schedule:
+  #   - cron: '30 6 * * 1'
+  # # allow manual runs
   workflow_dispatch:
 
 # implicitely set all other permissions to none
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build-linux-deb:
     # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    if: github.repository == 'qualcomm-linux-stg/qcom-deb-images' && github.ref == 'refs/heads/main'
     # for cross-builds
     runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
@@ -89,11 +89,11 @@ jobs:
           # perhaps help NFS sync
           sync
 
-      - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_artifacts
-        with:
-          path: artifacts
+      # - name: Upload private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_artifacts
+      #   with:
+      #     path: artifacts
 
   debos-mainline-linux:
     needs: build-linux-deb


### PR DESCRIPTION
AWS runner will be setup with newly crated QLI-AMI and GH workflow needs validation for end to end testing, before we deploy this AMI in production.

For validation, I have disable the CRON runs and as well upload artifacts to GCP.