### PR TITLE
feat: Audio support with Pipewire

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -75,10 +75,14 @@ actions:
       - fwupd
       # defaults to "systemd-sysv"; perhaps not needed
       - init
+      # Bluetooth audio support
+      - libspa-0.2-bluetooth
       # Ethernet, Wi-Fi, WWAN; built-in DHCP client
       - network-manager
       # standard networking files (/etc/hosts, /etc/services etc.)
       - netbase
+      # audio
+      - pipewire
       # Qualcomm Remote Filesystem Service; needed for WiFi on
       # some ath10k devices such as on RB1
       - rmtfs
@@ -210,6 +214,12 @@ actions:
       - libnss-mdns
       # browser
       - chromium
+      # audio: wireplumber for session integration, pipewire-pulse for chromium
+      # and xfce4-pulseaudio-plugin, and pavucontrol as referenced from the
+      # xfce pulse panel applet
+      - pavucontrol
+      - pipewire-pulse
+      - wireplumber
 {{- end }}
 
   - action: run


### PR DESCRIPTION
Add Pipewire and its Bluetooth plugins as an audio middleware. Add
corresponding desktop packages for Xfce session and panel integration, and for
Chromium. Fixes: #129.
