### PR TITLE
feat(kernel-configs): USB audio and webcams

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,7 +66,8 @@ jobs:
                 debhelper-compat kmod python3 rsync coreutils
             scripts/build-linux-deb.sh \
                 kernel-configs/qcom-imsdk.config \
-                kernel-configs/systemd-boot.config
+                kernel-configs/systemd-boot.config \
+                kernel-configs/usb-test-devices.config
 
       - name: Stage artifacts for upload
         run: |

--- a/kernel-configs/usb-test-devices.config
+++ b/kernel-configs/usb-test-devices.config
@@ -1,0 +1,16 @@
+# it's convenient to use generic USB devices for testing, but these are
+# not enabled in the defconfig; this config fragment adds basic support
+# for USB audio devices and USB webcams
+
+# USB Audio Class driver
+CONFIG_SND_USB_AUDIO=m
+
+# Media subsystem
+CONFIG_MEDIA_SUPPORT=y
+# USB media device support
+CONFIG_MEDIA_USB_SUPPORT=y    # USB media device support
+# UVC driver
+CONFIG_USB_VIDEO_CLASS=y
+# V4L2 core support
+CONFIG_VIDEO_DEV=y
+


### PR DESCRIPTION
Add a config fragment to enable support for USB audio devices and USB
webcams on top of arm64 defconfig; this is useful for testing;
fixes: #73
