### PR TITLE
fix(ci): Bump download and overall timeouts by 180mn

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -17,7 +17,7 @@ actions:
         - echo "DEVICE_TYPE=debian-qcs6490-rb3gen2-vision-kit" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 20
+      minutes: 200
     to: downloads
 - deploy:
     images:
@@ -73,5 +73,5 @@ tags:
 - cambridge-lab
 timeouts:
   job:
-    minutes: 30
+    minutes: 210
 visibility: public

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -18,7 +18,7 @@ actions:
         - echo "DEVICE_TYPE=debian-qrb2210-rb1" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
-      minutes: 20
+      minutes: 200
     to: downloads
 - deploy:
     images:
@@ -72,5 +72,5 @@ metadata:
 priority: 50
 timeouts:
   job:
-    minutes: 30
+    minutes: 210
 visibility: public


### PR DESCRIPTION
Currently timing out at 20-25% when downloading, so multiplying the 20mn by 5 and and doubling that to give us a buffer.
