### PR TITLE
mesa-unstable: update to 25.2.3-1

### DIFF
--- a/overlay-debs/mesa-unstable/mesa_25.2.2-1qcom1.yaml
+++ b/overlay-debs/mesa-unstable/mesa_25.2.2-1qcom1.yaml
@@ -1,4 +1,0 @@
-dsc_url: "https://snapshot.debian.org/archive/debian/20250904T083253Z/pool/main/m/mesa/mesa_25.2.2-1.dsc"
-dsc_sha256sum: "16c8d46ca277cc3ce4dbf63a8fb09e7b1368818e7a6399fed71b9316f7fb23e2"
-debdiff_file: "mesa_25.2.2-1qcom1.debdiff"
-suite: "trixie"

--- a/overlay-debs/mesa-unstable/mesa_25.2.3-1qcom1.debdiff
+++ b/overlay-debs/mesa-unstable/mesa_25.2.3-1qcom1.debdiff
@@ -2,15 +2,15 @@ diff -Nru mesa-25.2.0/debian/changelog mesa-25.2.0/debian/changelog
 --- mesa-25.2.0/debian/changelog	2025-08-07 14:08:04.000000000 +0300
 +++ mesa-25.2.0/debian/changelog	2025-05-29 20:16:02.000000000 +0300
 @@ -1,3 +1,9 @@
-+mesa (25.2.2-1qcom1) trixie; urgency=medium
++mesa (25.2.3-1qcom1) trixie; urgency=medium
 +
 +  * Rebuild for trixie.
 +
 + -- Loïc Minier <loic.minier@oss.qualcomm.com>  Thu, 29 May 2025 17:16:02 +0000
 +
- mesa (25.2.2-1) unstable; urgency=medium
+ mesa (25.2.3-1) unstable; urgency=medium
  
-   [ Simon McVittie ]
+   * New upstream release. (LP: #2122654)
 diff -Nru mesa-25.2.0/debian/control mesa-25.2.0/debian/control
 --- mesa-25.2.0/debian/control	2025-08-07 14:08:04.000000000 +0300
 +++ mesa-25.2.0/debian/control	2025-05-29 20:16:02.000000000 +0300

--- a/overlay-debs/mesa-unstable/mesa_25.2.3-1qcom1.yaml
+++ b/overlay-debs/mesa-unstable/mesa_25.2.3-1qcom1.yaml
@@ -1,0 +1,4 @@
+dsc_url: "https://snapshot.debian.org/archive/debian/20250918T143451Z/pool/main/m/mesa/mesa_25.2.3-1.dsc"
+dsc_sha256sum: "3b57e77178b3270c1fae53fecf910f5fb589b8d99560910c320b148ebd2f433b"
+debdiff_file: "mesa_25.2.3-1qcom1.debdiff"
+suite: "trixie"


### PR DESCRIPTION
Update mesa-unstable to the freshly uploaded Mesa 25.2.3-1.