### PR TITLE
fix: Drop leftover TODO to use buildid in images

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -29,7 +29,7 @@ permissions:
   contents: read # actions/checkout
 
 env:
-  # image build id; used for SBOM generation; TODO: should be used in image metadata too
+  # image build id; used for SBOM generation
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:


### PR DESCRIPTION
Was addressed as part of #146
