### PR TITLE
fix(ci): Bump lava-action timeouts to 240mn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
           cat "${{ matrix.target }}"
 
       - name: Submit ${{ matrix.target }}
-        timeout-minutes: 20
+        timeout-minutes: 240
         uses: foundriesio/lava-action@v6
         with:
           lava_token: ${{ secrets.LAVATOKEN }}


### PR DESCRIPTION
This goes above the highest timeout of our ci/*/*.yaml jobs.
