### PR TITLE
mesa: update to 25.2.4-1

### DIFF
--- a/overlay-debs/mesa-unstable/mesa_25.2.3-1qcom1.yaml
+++ b/overlay-debs/mesa-unstable/mesa_25.2.3-1qcom1.yaml
@@ -1,4 +1,0 @@
-dsc_url: "https://snapshot.debian.org/archive/debian/20250918T143451Z/pool/main/m/mesa/mesa_25.2.3-1.dsc"
-dsc_sha256sum: "3b57e77178b3270c1fae53fecf910f5fb589b8d99560910c320b148ebd2f433b"
-debdiff_file: "mesa_25.2.3-1qcom1.debdiff"
-suite: "trixie"

--- a/overlay-debs/mesa-unstable/mesa_25.2.4-1~qcom1.debdiff
+++ b/overlay-debs/mesa-unstable/mesa_25.2.4-1~qcom1.debdiff
@@ -2,15 +2,15 @@ diff -Nru mesa-25.2.0/debian/changelog mesa-25.2.0/debian/changelog
 --- mesa-25.2.0/debian/changelog	2025-08-07 14:08:04.000000000 +0300
 +++ mesa-25.2.0/debian/changelog	2025-05-29 20:16:02.000000000 +0300
 @@ -1,3 +1,9 @@
-+mesa (25.2.3-1qcom1) trixie; urgency=medium
++mesa (25.2.4-1~qcom1) trixie; urgency=medium
 +
 +  * Rebuild for trixie.
 +
 + -- Loïc Minier <loic.minier@oss.qualcomm.com>  Thu, 29 May 2025 17:16:02 +0000
 +
- mesa (25.2.3-1) unstable; urgency=medium
+ mesa (25.2.4-1) unstable; urgency=medium
  
-   * New upstream release. (LP: #2122654)
+   * New upstream release.
 diff -Nru mesa-25.2.0/debian/control mesa-25.2.0/debian/control
 --- mesa-25.2.0/debian/control	2025-08-07 14:08:04.000000000 +0300
 +++ mesa-25.2.0/debian/control	2025-05-29 20:16:02.000000000 +0300

--- a/overlay-debs/mesa-unstable/mesa_25.2.4-1~qcom1.yaml
+++ b/overlay-debs/mesa-unstable/mesa_25.2.4-1~qcom1.yaml
@@ -1,0 +1,4 @@
+dsc_url: "https://snapshot.debian.org/archive/debian-debug/20251003T204607Z/pool/main/m/mesa/mesa_25.2.4-1.dsc"
+dsc_sha256sum: "d33136ebe5fe28c72ffafacd60b72d798358506f7bce53ee18698f6f035b58ce"
+debdiff_file: "mesa_25.2.4-1~qcom1.debdiff"
+suite: "trixie"


### PR DESCRIPTION
Update mesa-unstable to the freshly uploaded Mesa 25.2.4-1. Use the version with tilde in it to make sure that it's lower than the version in unstable.