### PR TITLE
feat(overlay): Add pipewire without APT-X

### DIFF
--- a/overlay-debs/pipewire-no-aptx/pipewire_1.4.2-1~qcom1.debdiff
+++ b/overlay-debs/pipewire-no-aptx/pipewire_1.4.2-1~qcom1.debdiff
@@ -1,0 +1,41 @@
+diff -Nru pipewire-1.4.2/debian/changelog pipewire-1.4.2/debian/changelog
+--- pipewire-1.4.2/debian/changelog	2025-04-14 14:04:20.000000000 +0000
++++ pipewire-1.4.2/debian/changelog	2025-10-10 17:37:25.000000000 +0000
+@@ -1,3 +1,9 @@
++pipewire (1.4.2-1~qcom1) trixie; urgency=medium
++
++  * Drop libfreeaptx build-deb and configure with APT-X codec disabled.
++
++ -- Loïc Minier <loic.minier@oss.qualcomm.com>  Fri, 10 Oct 2025 17:37:25 +0000
++
+ pipewire (1.4.2-1) unstable; urgency=medium
+ 
+   * New upstream release
+diff -Nru pipewire-1.4.2/debian/control pipewire-1.4.2/debian/control
+--- pipewire-1.4.2/debian/control	2025-04-14 14:04:20.000000000 +0000
++++ pipewire-1.4.2/debian/control	2025-10-10 17:37:25.000000000 +0000
+@@ -18,7 +18,6 @@
+                libebur128-dev,
+                libffado-dev,
+                libfftw3-dev,
+-               libfreeaptx-dev,
+                libglib2.0-dev,
+                libgstreamer-plugins-base1.0-dev,
+                libgstreamer1.0-dev,
+diff -Nru pipewire-1.4.2/debian/ld.so.conf.d/pipewire-jack-aarch64-linux-gnu.conf pipewire-1.4.2/debian/ld.so.conf.d/pipewire-jack-aarch64-linux-gnu.conf
+--- pipewire-1.4.2/debian/ld.so.conf.d/pipewire-jack-aarch64-linux-gnu.conf	1970-01-01 00:00:00.000000000 +0000
++++ pipewire-1.4.2/debian/ld.so.conf.d/pipewire-jack-aarch64-linux-gnu.conf	2025-10-10 17:37:25.000000000 +0000
+@@ -0,0 +1 @@
++/usr/lib/aarch64-linux-gnu/pipewire-0.3/jack/
+diff -Nru pipewire-1.4.2/debian/rules pipewire-1.4.2/debian/rules
+--- pipewire-1.4.2/debian/rules	2025-04-14 14:04:20.000000000 +0000
++++ pipewire-1.4.2/debian/rules	2025-10-10 17:37:25.000000000 +0000
+@@ -68,7 +68,7 @@
+ 		-Davahi=enabled \
+ 		-Dbluez5-backend-native-mm=enabled \
+ 		-Dbluez5-codec-aac=disabled \
+-		-Dbluez5-codec-aptx=enabled \
++		-Dbluez5-codec-aptx=disabled \
+ 		-Dbluez5-codec-lc3=enabled \
+ 		-Dbluez5-codec-lc3plus=disabled \
+ 		-Dbluez5-codec-ldac=$(BLUEZ5_CODEC_LDAC) \

--- a/overlay-debs/pipewire-no-aptx/pipewire_1.4.2-1~qcom1.yaml
+++ b/overlay-debs/pipewire-no-aptx/pipewire_1.4.2-1~qcom1.yaml
@@ -1,0 +1,4 @@
+dsc_url: "https://snapshot.debian.org/archive/debian-debug/20250414T210501Z/pool/main/p/pipewire/pipewire_1.4.2-1.dsc"
+dsc_sha256sum: "602242d6287b6813c9c3f04307b438ad12cc257e5d7703afe22ace8b41b3645f"
+debdiff_file: "pipewire_1.4.2-1~qcom1.debdiff"
+suite: "trixie"


### PR DESCRIPTION
This is an example debdiff to build pipewiere without libfreeaptx.
