### PR TITLE
fix(ci): Generate JSON on a single line

### DIFF
--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           # json with list of relative filenames to LAVA templates
           J=$(find "${LAVA_CI}" -name '*.yaml' -print0 |
-                  jq -Rs '
+                  jq --compact-output --raw-input --slurp '
                       # split null-delimited list and remove last empty item
                       split("\u0000")[:-1]
                       # remove leading "ci/lava/"


### PR DESCRIPTION
jq defaults to pretty-printing on multiple lines, request compact output
to have the JSON on a single line, suitable for a GITHUB_OUTPUT variable
definition. Use this opportunity to use more human readable, longer form
flags.
