### PR TITLE
fix(ci): Use new upload_artifacts_gcp step id

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -36,7 +36,7 @@ jobs:
   build-debos:
     name: Build and upload debos recipes
     outputs:
-      url: ${{ steps.upload_artifacts.outputs.url }}
+      url: ${{ steps.upload_artifacts_gcp.outputs.url }}
     runs-on: [self-hosted, qcom-u2404, arm64]
     container:
       image: public.ecr.aws/debian/debian:trixie


### PR DESCRIPTION
`id: upload_artifacts` was renamed to `upload_artifacts_gcp` while adding S3
support, but the id wasn't properly updated in the `build-debos` job.
