### PR TITLE
https by default

### DIFF
--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -61,7 +61,7 @@ jobs:
           if [ "${suite}" = experimental ]; then
               # special extra args for experimental
               debootstrap_suite='unstable'
-              extra_repo='--extra-repository=deb   http://deb.debian.org/debian  experimental main'
+              extra_repo='--extra-repository=deb   https://deb.debian.org/debian  experimental main'
               chroot_prefix='--chroot-prefix=experimental'
           fi
           sudo sbuild-createchroot --include=eatmydata,ccache \

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ FAKEMACHINE_BACKEND = $(shell [ -c /dev/kvm ] && echo kvm || echo qemu)
 DEBOS_OPTS := --fakemachine-backend $(FAKEMACHINE_BACKEND) --memory 1GiB --scratchsize 4GiB
 DEBOS := debos $(DEBOS_OPTS)
 
-# Use http_proxy from the environment, or apt's http_proxy if set, to speed up
-# builds.
+# Use http_proxy and https_proxy from the environment, or apt's configs if set,
+# to speed up builds.
 http_proxy ?= $(shell apt-config dump --format '%v%n' Acquire::http::Proxy)
-export http_proxy
+https_proxy ?= $(shell apt-config dump --format '%v%n' Acquire::https::Proxy)
+export http_proxy https_proxy
+
+print:
+	echo $(https_proxy)
 
 all: disk-ufs.img.gz disk-sdcard.img.gz
 

--- a/debos-recipes/overlays/apt-sources/etc/apt/sources.list.d/debian.sources
+++ b/debos-recipes/overlays/apt-sources/etc/apt/sources.list.d/debian.sources
@@ -1,20 +1,20 @@
 # Debian archive
 Types: deb
-URIs: http://deb.debian.org/debian/
+URIs: https://deb.debian.org/debian/
 Suites: trixie
 Components: main contrib non-free non-free-firmware
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
 # Debian stable updates
 Types: deb
-URIs: http://deb.debian.org/debian/
+URIs: https://deb.debian.org/debian/
 Suites: trixie-updates
 Components: main contrib non-free non-free-firmware
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
 # Debian security updates
 Types: deb
-URIs: http://deb.debian.org/debian-security/
+URIs: https://deb.debian.org/debian-security/
 Suites: trixie-security
 Components: main contrib non-free non-free-firmware
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

--- a/debos-recipes/overlays/backports/etc/apt/sources.list.d/debian-backports.sources
+++ b/debos-recipes/overlays/backports/etc/apt/sources.list.d/debian-backports.sources
@@ -1,6 +1,6 @@
 # Debian backports
 Types: deb
-URIs: http://deb.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: trixie-backports
 Components: main contrib non-free non-free-firmware
 Enabled: yes

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -16,7 +16,7 @@ actions:
       - contrib
       - non-free
       - non-free-firmware
-    mirror: http://deb.debian.org/debian
+    mirror: https://deb.debian.org/debian
     variant: minbase
 
 {{- if ne $aptlocalrepo "none" }}


### PR DESCRIPTION
Review http vs https usage in the project and use https where it makes sense.
- **fix!(debos): Use https for APT by default**
- **fix(ci): Bootstrap chroots with https**
- **feat(Makefile): Also set https_proxy**

This is particularly important in the context of compliance as http:// might be seen as insecure, or at least lacking confidentiality.

Fixes: #290