### PR TITLE
fix(kernel): Enable SCSI_VIRTIO for QEMU

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,6 +65,7 @@ jobs:
                 libdw-dev libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev \
                 debhelper-compat kmod python3 rsync coreutils
             scripts/build-linux-deb.sh \
+                kernel-configs/qemu-boot.config \
                 kernel-configs/qcom-imsdk.config \
                 kernel-configs/systemd-boot.config
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To build flashable assets for all supported boards, follow these steps:
 
 1. (optional) build a local Linux kernel deb from mainline with a recommended config fragment
     ```bash
-    scripts/build-linux-deb.sh kernel-configs/qcom-imsdk.config kernel-configs/systemd-boot.config
+    scripts/build-linux-deb.sh kernel-configs/qemu-boot.config kernel-configs/qcom-imsdk.config kernel-configs/systemd-boot.config
     ```
 
 1. build tarballs of the root filesystem and DTBs

--- a/kernel-configs/qemu-boot.config
+++ b/kernel-configs/qemu-boot.config
@@ -1,0 +1,4 @@
+# CONFIG_SCSI_VIRTIO is not enabled in the upstream defconfig but it is needed
+# when running qemu with such a backend, e.g. for testing or for the run-qemu
+# script
+CONFIG_SCSI_VIRTIO=m


### PR DESCRIPTION
Make sure mainline kernels with defconfig + config fragments boot under
QEMU for tests or the reference run-qemu script. Fixes: #180.
