### PR TITLE
Ptool update to bring Lemans EVK support

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -228,13 +228,13 @@ actions:
           skip_board=true
           echo "Skipping board {{ $board.name }}: not in target list"
       fi
-{{- if $board.dtb }}
-      # set skip_board if board has a dtb and dtb isn't present
+
+      # set skip_board if board dtb isn't present
       if ! grep -Fxq "{{ $board.dtb }}" "${dtbs_file}"; then
           skip_board=true
           echo "Skipping board {{ $board.name }}: dtb not available"
       fi
-{{- end }}
+
 
       # unpack boot binaries
       mkdir -v build/{{ $board.name }}_boot-binaries
@@ -389,7 +389,6 @@ actions:
       fi
   {{- end }}
 
-  {{- if $board.dtb }}
       if [ "${skip_board}" = false ]; then
           # generate a dtb.bin FAT partition with just a single dtb for the
           # current board; long-term this should really be a set of dtbs and
@@ -410,7 +409,6 @@ actions:
           mcopy -vmp -i "${dtb_bin}" "build/{{ $board.dtb }}" \
               ::/combined-dtb.dtb
       fi
-  {{- end }}
 {{- end }}
 
       # cleanup


### PR DESCRIPTION
Update ptool to the latest git commit to get support for the latest boards. Take advantage of the new flag to set build-id.

Add support for Lemans EVK, also known as IQ-9075 EVK (was RB8). Confusingly, this QCS9075 EVK is using the QCS9100 boot binaries.