### PR TITLE
feat(ci/mainline): Bump to 6.18.0-g3f9f0252130e

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
     uses: ./.github/workflows/debos.yml
     with:
       mainline_kernel: true
-      kernelpackage: linux-image-6.18.0
+      kernelpackage: linux-image-6.18.0-g3f9f0252130e
 
   test-mainline-linux:
     uses: ./.github/workflows/lava-test.yml


### PR DESCRIPTION
Interim update to pickup on new kernel config fragment.
