### PR TITLE
feat(debos/flash)!: Updates for qcom-ptool 8aed61b

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To build flashable assets for all supported boards, follow these steps:
     #debos -t u_boot_rb1:u-boot/rb1-boot.img debos-recipes/qualcomm-linux-debian-flash.yaml
 
     # (optional) build only a subset of boards:
-    #debos -t target_boards:qcs615-adp-air-sa6155p,qcs6490-rb3gen2-vision-kit debos-recipes/qualcomm-linux-debian-flash.yaml
+    #debos -t target_boards:qcs615-ride,qcs6490-rb3gen2-vision-kit debos-recipes/qualcomm-linux-debian-flash.yaml
     ```
 
 1. enter Emergency Download Mode (see section below) and flash the resulting images with QDL
@@ -137,7 +137,7 @@ For the image recipe:
 
 For the flash recipe:
 - `u_boot_rb1`: prebuilt U-Boot binary for RB1 in Android boot image format -- see below (NB: debos expects relative pathnames)
-- `target_boards`: comma-separated list of board names to build (default: `all`). Accepted values are the board names defined in the flash recipe, e.g. `qcs615-adp-air-sa6155p`, `qcs6490-rb3gen2-vision-kit`, `qcs8300-ride`, `qcs9100-ride-r3`, `qrb2210-rb1`.
+- `target_boards`: comma-separated list of board names to build (default: `all`). Accepted values are the board names defined in the flash recipe, e.g. `qcs615-ride`, `qcs6490-rb3gen2-vision-kit`, `qcs8300-ride`, `qcs9100-ride-r3`, `qrb2210-rb1`.
 
 Note: Boards whose required device tree (.dtb) is not present in `dtbs.tar.gz` are automatically skipped during flash asset generation.
 
@@ -158,7 +158,7 @@ debos -t imagetype:sdcard debos-recipes/qualcomm-linux-debian-image.yaml
 
 # build flash assets for a subset of boards
 # (see flash recipe for accepted board names)
-debos -t target_boards:qcs615-adp-air-sa6155p,qcs6490-rb3gen2-vision-kit debos-recipes/qualcomm-linux-debian-flash.yaml
+debos -t target_boards:qcs615-ride,qcs6490-rb3gen2-vision-kit debos-recipes/qualcomm-linux-debian-flash.yaml
 ```
 
 ### Flashing tips

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -15,7 +15,7 @@ architecture: arm64
 actions:
   - action: download
     description: Download qcom-ptool
-    url: https://github.com/qualcomm-linux/qcom-ptool/archive/8ed8d47982228e4fe21fdc670318fc083d8e7614.tar.gz
+    url: https://github.com/qualcomm-linux/qcom-ptool/archive/8aed61b36ad793d021438452f3ebfce726c5629f.tar.gz
     name: qcom-ptool
     filename: qcom-ptool.tar.gz
     unpack: true
@@ -23,9 +23,9 @@ actions:
 {{- $boards := list }}
 {{- if eq $build_qcs615 "true" }}
 {{- $boards = append $boards (dict
-    "name" "qcs615-adp-air-sa6155p"
+    "name" "qcs615-ride"
     "silicon_family" "qcs615"
-    "platform" "qcs615-adp-air/ufs"
+    "platform" "qcs615-ride/ufs"
     "boot_binaries_download" (dict
         "description" "QCS615 boot binaries"
         "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00096.0/qcs615-le-1-0/common/build/common/bin/QCS615_bootbinaries.zip"
@@ -36,8 +36,8 @@ actions:
     "cdt_download" (dict
         "description" "QCS615 Ride CDT"
         "url" "https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS615/cdt/ADP_AIR_SA6155P_V2.zip"
-        "name" "qcs615-adp-air_cdt"
-        "filename" "qcs615-adp-air_cdt.zip"
+        "name" "qcs615-ride_cdt"
+        "filename" "qcs615-ride_cdt.zip"
         "sha256sum" "37d99eb113e286400bce0d70aa12a74d05f93d01f045bf67e7a46b3c606c8fd0"
     )
     "cdt_filename" "cdt_adp_air_sa6155p.bin"


### PR DESCRIPTION
New ptool adds a contents.xml file for qcm6490-idp and renames
qcs615-adp-air to qcs615-ride.

Match the renamed qcs615-ride in the list of supported boards.
