### PR TITLE
Fix mainline branch builds to not require changes for mainline movements

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -89,11 +89,17 @@ jobs:
       - name: Build rootfs with debos
         run: |
           set -ux
+          if [ "${{ inputs.mainline_kernel }}" = true -a "${{ inputs.kernelpackage }}" = auto ]; then
+              kernelpackage="$(find local-apt-repo/linux-deb-latest -type f -name 'linux-image-*' -not -name '*dbg*'|xargs basename|cut -f1 -d_)"
+          else
+              kernelpackage="${{ inputs.kernelpackage }}"
+          fi
+
           debos \
               -t overlays:'${{ inputs.overlays }}' \
               -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
-              -t kernelpackage:'${{ inputs.kernelpackage }}' \
+              -t kernelpackage:"$kernelpackage" \
               -t "buildid:${BUILD_ID}" \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-rootfs.yaml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build-linux-deb:
     # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/fix-mainline-builds'
     # for cross-builds
     runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
@@ -101,7 +101,7 @@ jobs:
     uses: ./.github/workflows/debos.yml
     with:
       mainline_kernel: true
-      kernelpackage: linux-image-6.19.0-rc1
+      kernelpackage: auto
 
   test-mainline-linux:
     uses: ./.github/workflows/lava-test.yml


### PR DESCRIPTION
For discussion. Would this make commits like 84989c2ea3fdbc18b36f739f84ae014ed45257f7 unnecessary? I used this repository rather than my own in order to run the workflow (including a hack to turn off the `main` branch checker). Results: https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/20339660861

Is this a reasonable approach to the general problem, or am I missing something? If the former, I can clean up.