### PR TITLE
ci: auto detect kernel package

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -89,11 +89,17 @@ jobs:
       - name: Build rootfs with debos
         run: |
           set -ux
+          if [ "${{ inputs.mainline_kernel }}" = true -a "${{ inputs.kernelpackage }}" = auto ]; then
+              kernelpackage="$(find local-apt-repo/linux-deb-latest -type f -name 'linux-image-*' -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_)"
+          else
+              kernelpackage="${{ inputs.kernelpackage }}"
+          fi
+
           debos \
               -t overlays:'${{ inputs.overlays }}' \
               -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
-              -t kernelpackage:'${{ inputs.kernelpackage }}' \
+              -t kernelpackage:"$kernelpackage" \
               -t "buildid:${BUILD_ID}" \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-rootfs.yaml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
     uses: ./.github/workflows/debos.yml
     with:
       mainline_kernel: true
-      kernelpackage: linux-image-6.19.0-rc3-g8640b74557fc
+      kernelpackage: auto
 
   test-mainline-linux:
     uses: ./.github/workflows/lava-test.yml


### PR DESCRIPTION
Add support to request the automatic detection and use of the kernel matching the pattern linux-image-* that is present in the local directory of extra debs, and use this from the linux.yml workflow.

This saves us having to manually keep linux.yml in sync with the latest upstream tag.

Discussion in #216

Since this is workflow related, it's difficult to test, so I've done that in #216 already by hacking the branch name. This branch and PR is (nearly; I made a minor tweak) the same, missing the hack, and should be good to merge to main.