### PR TITLE
UNO Q support

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -171,6 +171,19 @@ actions:
     "dtb" "qcom/qrb2210-rb1.dtb"
 )}}
 {{- end }}
+{{- $boards = append $boards (dict
+    "name" "qrb2210-arduino-imola"
+    "silicon_family" "qcm2290"
+    "ptool_platforms" (list "qrb2210-unoq/emmc-16GB")
+    "boot_binaries_download" (dict
+        "description" "UNO Q boot binaries"
+        "url" "https://downloads.arduino.cc/debian-im/unoq-bootloader-emmc-linux-251020.zip"
+        "name" "qrb2210-arduino-imola_boot-binaries"
+        "filename" "qrb2210-arduino-imola_boot-binaries.zip"
+        "sha256sum" "c606e95d0107f8c58d0dd9494e00624d1db7c4361cca20513bc78ef02ca28dd1"
+    )
+    "dtb" "qcom/qrb2210-arduino-imola.dtb"
+)}}
 
 {{- range $board := $boards }}
   - action: download


### PR DESCRIPTION
Changes to add support for UNO Q:
- **feat(debos/flash): Update to ptool d46b04b**
- **feat(debos/flash): Use boot.img from boot binaries**
- **feat(debos/flash): Add support for UNO Q (16GB)**
