### PR TITLE
ci: Add daily monza build

### DIFF
--- a/.github/workflows/linux-daily-monza.yml
+++ b/.github/workflows/linux-daily-monza.yml
@@ -1,0 +1,23 @@
+name: Daily monza linux build
+
+on:
+  # run daily at 6:30am
+  schedule:
+    - cron: '30 5 * * *'
+  # allow manual runs
+  workflow_dispatch:
+
+permissions:
+  checks: write # linux.yml
+  contents: read # linux.yml
+  packages: read # linux.yml
+  pull-requests: write # linux.yml
+
+jobs:
+  build:
+    # don't run cron from forks of the main repository or from other branches
+    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/linux.yml
+    with:
+      kernel_name: monza
+    secrets: inherit

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,6 +82,9 @@ jobs:
             elif [ "$KERNEL_NAME" = "qcom-next" ]; then
                 # use qcom-next specific config fragment, and git repo + branch
                 EXTRA_ARGS="--qcom-next prune.config qcom.config"
+            elif [ "$KERNEL_NAME" = "monza" ]; then
+                # use monza specific git repo + branch
+                EXTRA_ARGS="--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/monza"
             fi
             scripts/build-linux-deb.py `ls kernel-configs/*.config | sort` \
                 $EXTRA_ARGS


### PR DESCRIPTION
This can be dropped once support is merged in qcom-next or linux-next,
so not covering it in README etc.
