### PR TITLE
ci/schemacheck.py: use BSD-3-Clause instead of MIT

### DIFF
--- a/ci/schemacheck.py
+++ b/ci/schemacheck.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
-# SPDX-License-Identifier: MIT
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
 import os
 import sys


### PR DESCRIPTION
Running the `reuse lint` tool reports two different licenses being used in the project, while the README states that the whole project is BSD-3-Clause.

This file was added to the repository by a Qualcomm contributor, update its copyright notice and SPDX-License-Identifier to match the rest of the repository.

The spacing between the shebang and the license notice was automatically added by `reuse annotate`, so it is believed to be a good practise to split the two by an empty line.