### PR TITLE
fix(README): add missing foreign architecture instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Building a Linux kernel deb requires the following build-dependencies:
 apt -y install git crossbuild-essential-arm64 make flex bison bc libdw-dev libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev debhelper-compat kmod python3 rsync coreutils
 ```
 
+Note that to install `libssl-dev:arm64` on a non-arm64 host, you will need to
+enable arm64 as a foreign architecture first by running
+`dpkg --add-architecture arm64 && apt update`.
+
 ## Usage
 
 To build flashable assets for all supported boards, follow these steps:


### PR DESCRIPTION
The `.github/workflows/linux.yml` file adds arm64 as a foreign architecture if the host is not arm64, but this step is not explained in the README, resulting in an error trying to install `libssl-dev:arm64` on an amd64 host.

Add a new paragraph to explain how to add the remote architecture as most users are probably going to build the image on an amd64 host.