### PR TITLE
feat: add gnome-desktop variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
   debos expects relative pathnames)
 - `xfcedesktop`: install an Xfce desktop environment; default: console only
   environment
+- `gnomedesktop`: install a GNOME desktop environment; default: console only environment
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackage`: name of the kernel package to install from apt; defaults to

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -1,4 +1,5 @@
 {{- $xfcedesktop := or .xfcedesktop "false" }}
+{{- $gnomedesktop := or .gnomedesktop "false" }}
 {{- $localdebs := or .localdebs "none" }}
 {{- $aptlocalrepo := or .aptlocalrepo "none" }}
 {{- $kernelpackage := or .kernelpackage "linux-image-arm64" }}
@@ -9,6 +10,8 @@
 {{- $variantid := "console" }}
 {{- if eq $xfcedesktop "true" }}
 {{- $variantid = "xfce" }}
+{{- else if eq $gnomedesktop "true" }}
+{{- $variantid = "gnome" }}
 {{- end }}
 
 # Rename sid to unstable to reduce if/else complexity
@@ -353,6 +356,106 @@ actions:
       # audio: wireplumber for session integration, pipewire-pulse for chromium
       # and xfce4-pulseaudio-plugin, and pavucontrol as referenced from the
       # xfce pulse panel applet
+      - pavucontrol
+      - pipewire-pulse
+      - wireplumber
+      # camera: mostly supported through pipewire, but pull the qcam app
+      # and cam CLI tool from libcamera-tools; also install libcamera
+      # gstreamer plugins for for gstreamer based apps; ideally, cam and
+      # qcam would be packaged separately as to allow pulling the CLI
+      # version outside of the desktop list. libcamera-v4l2 provides a
+      # LD_PRELOAD library for compatiblity with apps relying on v4l2
+      # (similar to pipewire and pulse situation)
+      - gstreamer1.0-libcamera
+      - libcamera-tools
+      - libcamera-v4l2
+{{- end }}
+
+{{- if eq $gnomedesktop "true" }}
+
+# The following list of package is a manual selection from the gnome-core
+# metapackage from trixie with some pruning. The list of packages is longer in
+# forky, and needs to be revisited. Err out in the meantime.
+# See: https://github.com/qualcomm-linux/qcom-deb-images/issues/416
+{{- if ne $suite "trixie" }}
+# Call an unexisting template to err out of the recipe
+{{ template "ERR" }}
+{{- end }}
+
+
+  - action: apt
+    description: Install GNOME desktop
+    recommends: false
+    packages:
+      - plymouth-label- # we probably don't need a boot splash
+      # from gnome-core (meta-gnome3 source package in trixie)
+      # removing gnome-snapshot that would bring gstreamer1.0-plugins-bad
+      # removing gnome-connections that would bring libfreerdp3 -> libavcodec61 -> libx265
+      - gdm3
+      - gnome-backgrounds
+      - gnome-bluetooth-sendto
+      - gnome-control-center
+      - gnome-keyring
+      - gnome-menus
+      - gnome-session
+      - gnome-settings-daemon
+      - gnome-shell
+      - gnome-user-docs
+      - orca
+      - gnome-sushi
+      - tecla
+      - adwaita-icon-theme
+      - glib-networking
+      - gsettings-desktop-schemas
+      - baobab
+      - evince
+      - gnome-calculator
+      - gnome-calendar
+      - gnome-characters
+      - gnome-clocks
+      - gnome-terminal
+      - gnome-contacts
+      - gnome-disk-utility
+      - gnome-font-viewer
+      - gnome-logs
+      - gnome-maps
+      - gnome-software
+      - gnome-system-monitor
+      - gnome-text-editor
+      - gnome-weather
+      - nautilus
+      - simple-scan
+      - totem
+      - yelp
+      # Additional core dependencies from gnome-core
+      - cups
+      - evolution-data-server
+      - fonts-cantarell
+      - gstreamer1.0-packagekit
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-plugins-good
+      - gvfs-backends
+      - gvfs-fuse
+      - libatk-adaptor
+      - libcanberra-pulse
+      - libglib2.0-bin
+      - libpam-gnome-keyring
+      - pipewire-audio
+      - system-config-printer-common
+      - system-config-printer-udev
+      - zenity
+
+      # from task-desktop
+      - desktop-base
+      - xdg-utils
+      - fonts-symbola
+      - avahi-daemon
+      - libnss-mdns
+      # browser
+      - chromium
+      # bluetooth settings
+      - blueman
+      # audio: wireplumber for session integration, pipewire-pulse for chromium
       - pavucontrol
       - pipewire-pulse
       - wireplumber


### PR DESCRIPTION
This reuses the existing work for the XFCE variant, the difference is that task-gnome-desktop was not manually pruned down as I cannot think of specific packages to remove from it yet. GNOME is not known for being small on disk in the first place.

Due to this, the image size and the debos `--scratchsize` need to be bumped to 7GiB. The resulting root partition in disk-sdcard.img has 529MiB free space left out of 5.4 GiB.

The generated image was successfully boot-tested on qemu and a Thinkpad T14s. GDM asks for a password change and then the GNOME desktop can be used as expected.