### PR TITLE
chore: Update upload-private-artifact-action@aws v3

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -164,7 +164,7 @@ jobs:
 
       # upload to a cloud storage space accessible by Axiom
       - name: Upload private artifacts (S3)
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v2
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v3
         with:
           s3_bucket: qcom-prd-gh-artifacts
           # should be the default in that action, or ought to reuse BUILD_ID


### PR DESCRIPTION
New version prevents hitting API rate limits.
