### PR TITLE
feat: remove rootfs.tar compression/decompression step

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -140,6 +140,8 @@ jobs:
           # create a directory for the current run
           dir="debos-artifacts"
           mkdir -v "${dir}"
+          # compress output files before staging them
+          gzip --keep rootfs.tar rootfs.tar.gz
           # copy output files
           cp -av rootfs.tar.gz "${dir}"
           cp -av dtbs.tar.gz "${dir}"
@@ -172,7 +174,7 @@ jobs:
           path: debos-artifacts
 
       - name: Unpack rootfs to generate SBOM
-        run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar.gz
+        run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar
 
       # Syft is not packaged in Debian; it's available as a binary tarball or
       # as container image from upstream; it's available on arm64 and x86

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ export http_proxy
 
 all: disk-ufs.img.gz disk-sdcard.img.gz
 
-rootfs.tar.gz: debos-recipes/qualcomm-linux-debian-rootfs.yaml
+rootfs.tar: debos-recipes/qualcomm-linux-debian-rootfs.yaml
 	$(DEBOS) $<
 
-disk-ufs.img disk-ufs.img.gz: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar.gz
+disk-ufs.img disk-ufs.img.gz: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar
 	$(DEBOS) $<
 
-disk-sdcard.img.gz: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar.gz
+disk-sdcard.img.gz: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar
 	$(DEBOS) -t imagetype:sdcard $<
 
 test: disk-ufs.img

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -9,8 +9,7 @@ sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
 actions:
   - action: unpack
     description: Unpack root filesystem
-    compression: gz
-    file: rootfs.tar.gz
+    file: rootfs.tar
 
 {{- if ne $dtb "firmware" }}
   - action: run

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -365,8 +365,8 @@ actions:
 
   - action: pack
     description: Create root filesystem tarball
-    file: rootfs.tar.gz
-    compression: gz
+    file: rootfs.tar
+    compression: none
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
gzip compression only uses a single core, and we are decompressing the rootfs right after when building an image taking the rootfs as its input.

On my build machine, here are the timings saved:

- compression: 128 s
- decompression: 48 s

The Makefile rules are updated to reflect the change.

The CI workflow is updated to compress the rootfs before staging it as an artifact for upload, saving some bandwidth and storage space only where it seems necessary.

This commit is the first work regarding trying to reduce the number of compression/decompression cycles described in #246.