### PR TITLE
fix(debos/rootfs): use uefi-boot-image-dtb from backports

### DIFF
--- a/debos-recipes/overlays/backports/etc/apt/preferences.d/debian-backports.pref
+++ b/debos-recipes/overlays/backports/etc/apt/preferences.d/debian-backports.pref
@@ -1,6 +1,6 @@
 # for binary packages built from these source packages, score the version from
 # Debian backports higher as to get hardware enabled or better hardware support
 
-Package: src:alsa-ucm-conf:any src:firmware-free:any src:firmware-nonfree:any src:linux:any src:linux-signed-arm64:any src:mesa:any
+Package: src:alsa-ucm-conf:any src:firmware-free:any src:firmware-nonfree:any src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
 Pin: release n=trixie-backports
 Pin-Priority: 900


### PR DESCRIPTION
linux-images from trixie-backports break uefi-boot-image-dtb << 5~, while trixie has version 3. Because of this if the user used Debian kernels for the image creation, the image will be removed, breaking the DTB installation step (because there are no kernels left in the image).

Pin uefi-boot-image-dtb to the version in backports to match the kernel.