### PR TITLE
feat: include debugcc in rootfs

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -169,6 +169,8 @@ actions:
     packages:
       - alsa-utils
       - clinfo
+      # used to debug clock issues
+      - debugcc
       - device-tree-compiler
       - docker.io
       - i2c-tools


### PR DESCRIPTION
This package is now available in trixie-backports and has been requested to debug clock issues.

Closes: #223