### PR TITLE
CI: Use new WAIT_TIME support for wlan-smoke-test for rb3gen2/rb1

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -51,6 +51,8 @@ actions:
     timeout:
       minutes: 3
 - test:
+    timeout:
+      minutes: 5
     definitions:
     - from: git
       name: "smoke-test"
@@ -65,6 +67,7 @@ actions:
       repository: https://github.com/linaro/test-definitions.git
       parameters:
         SKIP_INSTALL: "True"
+        WAIT_TIME: 60
 - command:
     name: network_turn_on
 context:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -52,6 +52,8 @@ actions:
     timeout:
       minutes: 3
 - test:
+    timeout:
+      minutes: 5
     definitions:
     - from: git
       name: "smoke-test"
@@ -66,6 +68,7 @@ actions:
       repository: https://github.com/linaro/test-definitions.git
       parameters:
         SKIP_INSTALL: "True"
+        WAIT_TIME: 60
 - command:
     name: network_turn_on
 context:


### PR DESCRIPTION
The wlan interface on rb3gen2 is slow to appear after boot, so use
the new support in test-definitions to wait 60 seconds until it
does. Use same wait for RB1 just in case.

Also add a timeout to the test action so that it does not use a default,
as our new wait time could exceed that default.

Fixes: #254