### PR TITLE
ci: Add daily glymur build

### DIFF
--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -1,0 +1,23 @@
+name: Daily glymur linux build
+
+on:
+  # run daily at 10:30am
+  schedule:
+    - cron: '30 10 * * *'
+  # allow manual runs
+  workflow_dispatch:
+
+permissions:
+  checks: write # linux.yml
+  contents: read # linux.yml
+  packages: read # linux.yml
+  pull-requests: write # linux.yml
+
+jobs:
+  build:
+    # don't run cron from forks of the main repository or from other branches
+    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/linux.yml
+    with:
+      kernel_name: glymur
+    secrets: inherit

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,6 +85,9 @@ jobs:
             elif [ "$KERNEL_NAME" = "monza" ]; then
                 # use monza specific git repo + branch
                 EXTRA_ARGS="--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/monza"
+            elif [ "$KERNEL_NAME" = "glymur" ]; then
+                # use glymur specific git repo + branch
+                EXTRA_ARGS="--repo https://git.codelinaro.org/clo/linux-kernel/kernel-qcom.git --ref next-20260204-glymur"
             fi
             scripts/build-linux-deb.py $EXTRA_ARGS \
                 `ls kernel-configs/*.config | sort` \


### PR DESCRIPTION
This can be dropped once support is merged in qcom-next or linux-next,
so not covering it in README etc.
