### PR TITLE
fix(debos/rootfs) Fix YAML syntax

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -319,7 +319,7 @@ actions:
 
   - action: run
     description: Install local debs from /root/
-    chroot: yes
+    chroot: true
     command: |
       set -eux
       apt -y install /root/*.deb


### PR DESCRIPTION
The 'chroot' argument requires a boolean (true/false) and will error out when encountering 'yes'.

```
koen@rogue:/build/qualcomm/qcom-deb-images$ debos --fakemachine-backend qemu --cpus=4 --memory 2GiB --scratchsize 4GiB -t localdebs:local-debs/ debos-recipes/qualcomm-linux-debian-rootfs.yaml  -t kernelpackage:linux-image-6.19.0-g17b440c46fd2
2026/02/26 13:13:14 [215:13] cannot unmarshal string into Go struct field Recipe.Actions of type bool
  213 |   - action: run
  214 |     description: Install local debs from /root/
> 215 |     chroot: yes
                    ^
```