### PR TITLE
feat(debos/flash): Update to r1.0_00116.0 boot fw

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -51,10 +51,10 @@ actions:
     "ptool_platforms" (list "qcs6490-rb3gen2/ufs")
     "boot_binaries_download" (dict
         "description" "QCM6490 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00114.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00116.0/qcm6490-le-1-0/common/build/ufs/bin/QCM6490_bootbinaries.zip"
         "name" "qcm6490_boot-binaries"
         "filename" "qcm6490_boot-binaries.zip"
-        "sha256sum" "3bfc7748493e4ac8d8ad77db5c132b5301195ce02d377c62171332a81901f552"
+        "sha256sum" "ad5434f1afd2f801e63266d75c97425d1fea22b2edc67b6f5a0f472ca55844ed"
     )
     "cdt_download" (dict
         "description" "RB3 Gen2 Vision Kit CDT"
@@ -74,10 +74,10 @@ actions:
     "ptool_platforms" (list "qcs8300-ride-sx/ufs")
     "boot_binaries_download" (dict
         "description" "QCS8300 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00114.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00116.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
         "name" "qcs8300_boot-binaries"
         "filename" "qcs8300_boot-binaries.zip"
-        "sha256sum" "2067015d9a96d7e009ffec3a42bb7f88a659eb96c6b9e6f9df849af222a8f0e3"
+        "sha256sum" "e7a22f9a7ddae92e6e307afdd9f06608ddd3b0ac7f2e4994bacfb51729e8337f"
     )
     "cdt_download" (dict
         "description" "QCS8300 Ride SX EVK CDT"
@@ -95,10 +95,10 @@ actions:
     "ptool_platforms" (list "iq-8275-evk/emmc" "iq-8275-evk/ufs")
     "boot_binaries_download" (dict
         "description" "QCS8300 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00114.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00116.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
         "name" "qcs8300_boot-binaries"
         "filename" "qcs8300_boot-binaries.zip"
-        "sha256sum" "2067015d9a96d7e009ffec3a42bb7f88a659eb96c6b9e6f9df849af222a8f0e3"
+        "sha256sum" "e7a22f9a7ddae92e6e307afdd9f06608ddd3b0ac7f2e4994bacfb51729e8337f"
     )
     "cdt_download" (dict
         "description" "IQ-8275 EVK CDT"
@@ -116,10 +116,10 @@ actions:
     "ptool_platforms" (list "qcs8275-monza/emmc")
     "boot_binaries_download" (dict
         "description" "QCS8300 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00114.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00116.0/qcs8300-le-1-0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
         "name" "qcs8300_boot-binaries"
         "filename" "qcs8300_boot-binaries.zip"
-        "sha256sum" "2067015d9a96d7e009ffec3a42bb7f88a659eb96c6b9e6f9df849af222a8f0e3"
+        "sha256sum" "e7a22f9a7ddae92e6e307afdd9f06608ddd3b0ac7f2e4994bacfb51729e8337f"
     )
     "cdt_download" (dict
         "description" "Monza CDT"
@@ -139,10 +139,10 @@ actions:
     "ptool_platforms" (list "qcs9100-ride-sx/ufs")
     "boot_binaries_download" (dict
         "description" "QCS9100 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00114.0/qcs9100-le-1-0/common/build/ufs/bin/QCS9100_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00116.0/qcs9100-le-1-0/common/build/ufs/bin/QCS9100_bootbinaries.zip"
         "name" "qcs9100_boot-binaries"
         "filename" "qcs9100_boot-binaries.zip"
-        "sha256sum" "963d54a9e9a3ef29c6933b3d71faa035b72df07cc36f42c14c39ed5f47878026"
+        "sha256sum" "f19724eab9571b97087933b60a0b75246537fda5ef75a97e6d5dee4020ef59a2"
     )
     "cdt_download" (dict
         "description" "QCS9100 Ride Rev3 EVK CDT"


### PR DESCRIPTION
Updates to QCM6490, QCS8300 and QCS9100 boot binaries.

QCS8300 (Monaco):
- Fixes boot and recovery issues including EDL entry failures, SEC watchdog
  enablement, and HLOS recovery paths.
- Enables deep sleep and DSP‑specific power optimizations to meet power and
  thermal targets.
- Hardens TZ and security with PIL authentication/reset handling and
  security-review fixes.
- Improves DSP and storage stability by addressing quantum, DSQB, and
  RAMdump-related failures.

QCS9100 (Lemans):
- Resolves critical DDR PASS1/SDI PASS1 regressions to stabilize early
  memory initialization.
- Optimizes power and performance through sleep target tuning, deep sleep
  enablement, and DSP PM updates.
- Improves DSP and audio stability with crash fixes, SRM updates, and
  AP-ADSP shared memory changes.
- Fixes storage and RAMdump failures, improving crash recovery reliability.

QCM6490 (Kodiak):
- Improves UEFI boot stability via TLMM/XPU fixes, PCIe RP tuning, log
  overload fixes, and problematic DXE disables.
- Enhances NVMe usability by enabling Fastboot flashing, improving
  enumeration, and fixing boot-order handling.
- Strengthens security with TZ image signing, OEM-only QTEE signing, and
  PKCS11 hardening.
- Fixes RAMdump, watchdog, and crash/debug issues to improve recoverability
  and post‑mortem analysis.
