### PR TITLE
feat: add ethtool in rootfs

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -173,6 +173,8 @@ actions:
       - debugcc
       - device-tree-compiler
       - docker.io
+      # used to debug ethernet speed auto-neg issues
+      - ethtool
       - i2c-tools
       - locales
       - mesa-opencl-icd


### PR DESCRIPTION
ethtool can be quite useful when investigating some autoneg issues regarding ethernet speeds

Closes: #266