### PR TITLE
feat(debos/rootfs): Add ethtool

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -173,6 +173,8 @@ actions:
       - debugcc
       - device-tree-compiler
       - docker.io
+      # force link speed; useful when autoneg is broken
+      - ethtool
       - i2c-tools
       - locales
       - mesa-opencl-icd


### PR DESCRIPTION
On dev boards it can be useful to have ethtool to set the link speed,
particularly when autoneg is broken.

Fixes: #266
