### PR TITLE
Set workflow default kernel to linux-image-arm64

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -26,15 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         suite: [trixie, forky]
-        kernelpackage: [default-ci, linux-image-arm64]
         exclude:
           - suite: trixie
-            kernelpackage: linux-image-arm64
           - suite: forky
-            kernelpackage: default-ci
     uses: ./.github/workflows/debos.yml
     with:
       suite: ${{ matrix.suite }}
-      kernelpackage: ${{ matrix.kernelpackage }}
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -17,16 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         suite: [trixie, forky]
-        kernelpackage: [default-ci, linux-image-arm64]
         exclude:
           - suite: trixie
-            kernelpackage: linux-image-arm64
           - suite: forky
-            kernelpackage: default-ci
     uses: ./.github/workflows/debos.yml
     with:
       suite: ${{ matrix.suite }}
-      kernelpackage: ${{ matrix.kernelpackage }}
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
   test:

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -17,7 +17,7 @@ on:
           linux-image-arm64) or name of a EFS kernel package directory
           (e.g. efs/mainline)
         type: string
-        default: default-ci
+        default: ''
       debos_extra_args:
         description: Extra arguments to pass to debos (e.g. -t dtb:qcom/some.dtb)
         type: string
@@ -107,12 +107,6 @@ jobs:
             # if kernel package is from EFS, determine actual package name
             efs/*)
               kernel_package="$(find local-apt-repo/kernel -type f -name 'linux-image-*' -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_)"
-              ;;
-            default-ci)
-              # the package name will be passed to APT which interprets the trailing
-              # plus sign in the package name as a request to install the package, so
-              # use two plus signs
-              kernel_package="linux-image-6.16.7-qcom1++"
               ;;
           esac
 


### PR DESCRIPTION
Drop the default kernel specification from debos.yml. This causes the default in the rootfs debos recipe to be used, which is linux-image-arm64, to be fulfilled from debian-backports.

The previous kernel of linux-image-6.16.7-qcom1+ fails fastrpc_test, but it does work from linux-image-arm64. Further, that kernel has fallen behind because it required manual updates.