### PR TITLE
feat: add main .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+disk-sdcard.img*
+disk-ufs.img*
+dtbs.tar.gz
+*.deb
+*.buildinfo
+*.changes
+rootfs.tar*
+fake-scratch.img.*


### PR DESCRIPTION
Running debos produces a lot of different files that pollutes git status. These files should never be versioned. Create a main .gitignore file to filter out:

- produced images
- produced rootfs
- produced debian artifacts