### PR TITLE
Install FastRPC by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ debos --fakemachine-backend qemu --memory 1GiB --scratchsize 4GiB debos-recipes/
 A few options are provided in the debos recipes; for the root filesystem recipe:
 - `localdebs`: path to a directory with local deb packages to install (NB: debos expects relative pathnames)
 - `xfcedesktop`: install an Xfce desktop environment; default: console only environment
+- `overlays`: a `,`-separated list of rootfs overlays to add from `debos-recipes/overlays/`. Defaults to `qsc-deb-releases` to add our overlay apt repository that contains some package delta that isn't fully upstreamed and backported to trixie in Debian yet.
 
 For the image recipe:
 - `dtb`: override the firmware provided device tree with one from the Linux kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -2,6 +2,7 @@
 {{- $localdebs := or .localdebs "none" }}
 {{- $aptlocalrepo := or .aptlocalrepo "none" }}
 {{- $kernelpackage := or .kernelpackage "linux-image-arm64" }}
+{{- $overlays := or .overlays "qsc-deb-releases" }}
 {{- $buildid := or .buildid "" }}
 
 architecture: arm64
@@ -52,8 +53,8 @@ actions:
     description: Add Debian backports APT configuration
     source: overlays/backports
 
-{{- if .overlays }}
-{{- range $overlay := split "," .overlays }}
+{{- if $overlays }}
+{{- range $overlay := split "," $overlays }}
   - action: overlay
     description: Apply overlay {{$overlay}}
     source: overlays/{{$overlay}}

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -87,6 +87,8 @@ actions:
       - dosfstools
       # ext4 tools, notably e2fsck for the root filesystem
       - e2fsprogs
+      # fastrpc support. fastrpc-tests pulls in the required stack
+      - fastrpc-tests
       # fwupd tools, enable OTA EFI firmware capsule updates
       - fwupd
       # defaults to "systemd-sysv"; perhaps not needed
@@ -134,7 +136,7 @@ actions:
       # from the serial console, over SSH, or in containers - where the desktop
       # session has not updated ACLs to the device nodes
       useradd --create-home --shell /bin/bash --user-group \
-          --groups adm,audio,render,sudo,users,video debian
+          --groups adm,audio,fastrpc,render,sudo,users,video debian
       # set password to "debian"
       echo debian:debian | chpasswd
       # password must be changed on first login


### PR DESCRIPTION
Now that we have hexagon-dsp-binaries and fastrpc packaging in trixie-overlay, install them by default.

Once https://github.com/qualcomm-linux/qcom-deb-images/pull/277 is landed, this should mean that `fastrpc_test` passes by default.