### PR TITLE
fix(ci/glymur): Flag to skip QEMU tests

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -21,6 +21,11 @@ on:
         description: Extra arguments to pass to debos (e.g. -t dtb:qcom/some.dtb)
         type: string
         default: ''
+      # useful if for some reason the kernel/image can't start in QEMU
+      skip_qemu_tests:
+        description: Skip QEMU tests
+        type: boolean
+        default: false
 
     outputs:
       artifacts_url:
@@ -245,6 +250,7 @@ jobs:
           name: build_url
           path: build_url
       - name: Invoke test runner
+        if: ${{ !inputs.skip_qemu_tests }}
         run: |
            # This is currently a clone of Makefile's "test" target to avoid any
            # unexpected interactions with triggering depending build targets.

--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -22,4 +22,6 @@ jobs:
       kernel_name: glymur
       build_linux_deb_extra_args: '--repo https://git.codelinaro.org/clo/linux-kernel/kernel-qcom.git --ref next-20260204-glymur'
       debos_extra_args: '-t dtb:qcom/glymur-crd.dtb'
+      # we hardcode the DT, and that's not compatible with the QEMU machine model
+      skip_qemu_tests: true
     secrets: inherit

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: ''
+      skip_qemu_tests:
+        description: Skip QEMU tests
+        required: false
+        type: boolean
+        default: false
   # allow manual runs
   workflow_dispatch:
     inputs:
@@ -132,6 +137,7 @@ jobs:
     with:
       kernelpackage: fileserver/${{ inputs.kernel_name || 'mainline' }}
       debos_extra_args: ${{ inputs.debos_extra_args }}
+      skip_qemu_tests: ${{ inputs.skip_qemu_tests || false }}
 
   test-linux-deb:
     uses: ./.github/workflows/lava-test.yml


### PR DESCRIPTION
The Glymur daily build hardcodes the target DT, and that prevents QEMU
from starting. Add a flag to skip QEMU tests and use it for that build.
