### PR TITLE
fix: Bump image size to 6GiB

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -124,11 +124,11 @@ jobs:
           # qemu backend also requires to set scratchsize, otherwise the
           # whole build is done from memory and the out of memory killer
           # gets triggered
-          debos -b qemu --scratchsize 4GiB -t imagetype:ufs \
+          debos -b qemu --scratchsize 6GiB -t imagetype:ufs \
               ${DEBOS_EXTRA_ARGS} \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-image.yaml
-          debos -b qemu --scratchsize 4GiB -t imagetype:sdcard \
+          debos -b qemu --scratchsize 5GiB -t imagetype:sdcard \
               ${DEBOS_EXTRA_ARGS} \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-image.yaml

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ By default, debos will try to pick a fast build backend. It will prefer to use i
 
 To build large images, the debos resource defaults might not be sufficient. Consider raising the default debos memory and scratchsize settings. This should provide a good set of minimum defaults:
 ```bash
-debos --fakemachine-backend qemu --memory 1GiB --scratchsize 4GiB debos-recipes/qualcomm-linux-debian-image.yaml
+debos --fakemachine-backend qemu --memory 1GiB --scratchsize 6GiB debos-recipes/qualcomm-linux-debian-image.yaml
 ```
 
 #### Options for debos recipes
@@ -140,7 +140,7 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 For the image recipe:
 - `dtb`: override the firmware provided device tree with one from the Linux kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override
 - `imagetype`: either `ufs` (the default) or `sdcard`; UFS images are named disk-ufs.img and use 4096-byte sectors and SD card images are named disk-sdcard.img and use 512-byte sectors
-- `imagesize`: set the output disk image size; default: `4GiB`
+- `imagesize`: set the output disk image size; default: `6GiB`
 
 For the flash recipe:
 - `u_boot_rb1`: prebuilt U-Boot binary for RB1 in Android boot image format -- see below (NB: debos expects relative pathnames)

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -1,5 +1,5 @@
 {{- $dtb := or .dtb "firmware" }}
-{{- $imagesize := or .imagesize "4.5GiB" }}
+{{- $imagesize := or .imagesize "6GiB" }}
 {{- $imagetype := or .imagetype "ufs" }}
 {{- $image := printf "disk-%s.img" $imagetype }}
 


### PR DESCRIPTION
Addition of hexagon-dsp-binaries as part of AI stack makes the rootfs
significantly larger. Bump the image size to accomodate this and a
future GNOME flavor. Update scratchsize correspondingly.
