### PR TITLE
fix(image): handle dtb_dir being a symlink

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -93,7 +93,7 @@ actions:
       latest_kernel="$(
           linux-version list | linux-version sort --reverse | head -1)"
       dtb_path="/usr/lib/linux-image-${latest_kernel}"
-      cp -RT "$dtb_path" "/boot/efi/dtb"
+      cp -LRT "$dtb_path" "/boot/efi/dtb"
 
   - action: run
     description: Create task to grow root filesystem on first boot


### PR DESCRIPTION
If the build uses a standard Debian kernel then the dtb_dir is a symlink (which points to /usr/lib/modules/$(uname -r)/dtb. Having it as a symlink makes cp -RT choke on it. Add -L to the params to make cp dereference symlinks.