### PR TITLE
feat(Makefile): add clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,9 @@ test: disk-ufs.img
 	# rootfs/ is a build artifact, so should not be scanned for tests
 	py.test-3 --ignore=rootfs
 
+.PHONY: clean
+clean:
+	rm -f disk-ufs.img*
+	rm -f disk-sdcard.img*
+	rm -f rootfs.tar*
+	rm -f dtbs.tar.gz


### PR DESCRIPTION
After the introduction of a .gitignore, one might need to reset their
repository in a clean state and `git clean -fd` does not work anymore.

Add a `clean` target to the Makefile to remove most likely produced
artifacts that users want to remove to reset the repository in a mostly
clean target.