### PR TITLE
feat: add missing Lenovo T14s firmware in initramfs

### DIFF
--- a/debos-recipes/overlays/workaround-t14s-initramfs-firmware/etc/initramfs-tools/hooks/lenovo-t14s.hook
+++ b/debos-recipes/overlays/workaround-t14s-initramfs-firmware/etc/initramfs-tools/hooks/lenovo-t14s.hook
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+PREREQ=""
+prereqs()
+{
+	echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+	prereqs
+	exit 0
+	;;
+esac
+
+# shellcheck source=/dev/null
+. /usr/share/initramfs-tools/hook-functions
+# Begin real processing below this line
+
+# Add missing firmware required by the ADSP driver for eg. battery management
+for f in /usr/lib/firmware/qcom/x1e80100/LENOVO/21N1/*
+do
+	copy_file firmware "$f"
+done
+
+
+# Uncomment the following for GPU accel support in initramfs
+# by having the Adreno firmware available.
+#
+# This is not a strict requirement, as the display will still work without the
+# GPU firmware for eg. full-disk encryption password prompt.
+#copy_file firmware /usr/lib/firmware/qcom/gen70500_sqe.fw
+#copy_file firmware /usr/lib/firmware/qcom/gen70500_gmu.bin

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -299,6 +299,21 @@ actions:
       - kmod
       - linux-base
 
+  # Some firmware is needed early in the initramfs for ADSP, eg. on the Lenovo T14s.
+  # These firmware files are not automatically included because they are
+  # dynamically found from the device-tree instead of being statically loaded
+  # in the driver.
+  #
+  # Install an initramfs-tools hook prior to the kernel package to make sure
+  # the initramfs contains such firmware when it is generated.
+  #
+  # See also:
+  # - https://github.com/qualcomm-linux/qcom-deb-images/issues/258
+  # - https://github.com/dracut-ng/dracut-ng/pull/2266
+  - action: overlay
+    description: Install extra firmware hook for initramfs
+    source: overlays/workaround-t14s-initramfs-firmware
+
   - action: apt
     description: Install kernel and firmware packages
     recommends: true


### PR DESCRIPTION
Add missing firmware into initramfs to make the sound and battery work on Lenovo T14s.

Closes: #258