### PR TITLE
CI: increase deploy (flasher) timeouts for rb1 and rb3gen2

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -28,7 +28,7 @@ actions:
       overlay:
         url: downloads://overlay.tar.gz
     timeout:
-      minutes: 5
+      minutes: 20
     to: flasher
 - boot:
     auto_login:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -29,7 +29,7 @@ actions:
       overlay:
         url: downloads://overlay.tar.gz
     timeout:
-      minutes: 5
+      minutes: 20
     to: flasher
 - boot:
     auto_login:


### PR DESCRIPTION
There was not enough headroom in the deployment timeouts for growing image sizes, so increase from 5 to 20 mins.