### PR TITLE
fix: Fix image size bump to 6GiB

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -133,7 +133,7 @@ jobs:
               ${DEBOS_EXTRA_ARGS} \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-image.yaml
-          debos -b qemu --scratchsize 5GiB -t imagetype:sdcard \
+          debos -b qemu --scratchsize 6GiB -t imagetype:sdcard \
               ${DEBOS_EXTRA_ARGS} \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-image.yaml

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # To build large images, the debos resource defaults are not sufficient. These
 # provide defaults that work for us as universally as we can manage.
 FAKEMACHINE_BACKEND = $(shell [ -c /dev/kvm ] && echo kvm || echo qemu)
-DEBOS_OPTS := --fakemachine-backend $(FAKEMACHINE_BACKEND) --memory 1GiB --scratchsize 4GiB
+DEBOS_OPTS := --fakemachine-backend $(FAKEMACHINE_BACKEND) --memory 1GiB --scratchsize 6GiB
 DEBOS := debos $(DEBOS_OPTS)
 
 # Use http_proxy from the environment, or apt's http_proxy if set, to speed up


### PR DESCRIPTION
Address a couple of places that were leftover when bumping imagesize to
6GiB.
