### PR TITLE
fix(ci/monza): Workaround missing firmware entry

### DIFF
--- a/.github/workflows/linux-daily-monza.yml
+++ b/.github/workflows/linux-daily-monza.yml
@@ -21,4 +21,9 @@ jobs:
     with:
       kernel_name: monza
       build_linux_deb_extra_args: '--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/monza'
+      # workaround-hexagon-dsp-binaries-monza can be dropped once an
+      # updated hexagon-dsp-binaries with Monza support is integrated; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/298 and
+      # https://github.com/linux-msm/hexagon-dsp-binaries/pull/59
+      debos_extra_args: '-t overlays:qsc-deb-releases,workaround-hexagon-dsp-binaries-monza'
     secrets: inherit

--- a/debos-recipes/overlays/workaround-hexagon-dsp-binaries-monza/usr/share/hexagon-dsp/conf.d/hexagon-dsp-binaries-arduino-monza.yaml
+++ b/debos-recipes/overlays/workaround-hexagon-dsp-binaries-monza/usr/share/hexagon-dsp/conf.d/hexagon-dsp-binaries-arduino-monza.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+machines:
+  Arduino Monza:
+    DSP_LIBRARY_PATH: qcs8300/Qualcomm/QCS8300-RIDE/dsp


### PR DESCRIPTION
Add hexagon-dsp-binaries overlay file in Monza daily build to workaround
missing firmware links.

Changes to hexagon-dsp-binaries were sent upstream in this PR:
https://github.com/linux-msm/hexagon-dsp-binaries/pull/59

Fixes: #298
