### PR TITLE
fix(monza): Add Monaco initramfs firmware overlay

### DIFF
--- a/.github/workflows/linux-daily-monza.yml
+++ b/.github/workflows/linux-daily-monza.yml
@@ -25,5 +25,7 @@ jobs:
       # updated hexagon-dsp-binaries with Monza support is integrated; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/298 and
       # https://github.com/linux-msm/hexagon-dsp-binaries/pull/59
-      debos_extra_args: '-t overlays:qsc-deb-releases,workaround-hexagon-dsp-binaries-monza'
+      # workaround-initramfs-firmware-monaco adds firmware to initramfs; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/258
+      debos_extra_args: '-t overlays:qsc-deb-releases,workaround-hexagon-dsp-binaries-monza,workaround-initramfs-firmware-monaco'
     secrets: inherit

--- a/debos-recipes/overlays/workaround-initramfs-firmware-monaco/etc/initramfs-tools/hooks/qcom-monaco-firmware
+++ b/debos-recipes/overlays/workaround-initramfs-firmware-monaco/etc/initramfs-tools/hooks/qcom-monaco-firmware
@@ -1,0 +1,40 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+
+# Workaround for https://github.com/qualcomm-linux/qcom-deb-images/issues/258
+# Add monaco-specific firmware files to initramfs so they are available before
+# the root filesystem is mounted. This is required for proper hardware
+# initialization during early boot.
+
+PREREQ=""
+prereqs()
+{
+	echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+	prereqs
+	exit 0
+	;;
+esac
+
+# shellcheck source=/dev/null
+. /usr/share/initramfs-tools/hook-functions
+# Begin real processing below this line
+
+# Add monaco-specific firmware files
+# These files are required for DSP and other hardware initialization
+for fw in \
+	/lib/firmware/qcom/qcs8300/adsp.mbn \
+	/lib/firmware/qcom/qcs8300/cdsp0.mbn \
+	/lib/firmware/qcom/qcs8300/gpdsp0.mbn \
+	/lib/firmware/qcom/qcs8300/qupv3fw.elf
+do
+	if [ ! -f "$fw" ]; then
+		echo "ERROR: Required firmware file not found: $fw" >&2
+		exit 1
+	fi
+	copy_file firmware "$fw"
+done


### PR DESCRIPTION
Add workaround-initramfs-firmware-monaco overlay to ensure
Monaco-specific firmware files are included in the initramfs.

Use this workaround for linux-daily-monza images.

See #258
