### PR TITLE
fix: mount /boot/efi with restrictive fmask/dmask

### DIFF
--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -82,3 +82,10 @@ def test_password_reset_required(vm):
     vm.expect_exact("Retype new password:")
     vm.send("new password\r\n")
     vm.expect_exact("debian@debian:~$")
+
+    # The /boot/efi/loader/random-seed file should not be readable to users
+    # https://github.com/qualcomm-linux/qcom-deb-images/issues/279
+    vm.send("journalctl | grep 'is world accessible, which is a security hole' || echo not found\r\n")
+    # Need to match twice because of the serial echo of the command above
+    vm.expect_exact("not found")
+    vm.expect_exact("not found")

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -50,6 +50,24 @@ actions:
     mountpoints:
       - mountpoint: /boot/efi/
         partition: esp
+        # Copy options from what systemd does when mounting a discoverable EFI partition:
+        # https://github.com/qualcomm-linux/qcom-deb-images/pull/309
+        #
+        # Restrict fmask/dmask to prevent user access to /boot/efi/loader/random-seed
+        # used by systemd-boot:
+        # https://github.com/qualcomm-linux/qcom-deb-images/issues/279
+        options:
+          - nosuid
+          - nodev
+          - noexec
+          - relatime
+          - nosymfollow
+          - fmask=0177
+          - dmask=0077
+          - codepage=437
+          - iocharset=iso8859-1
+          - shortname=mixed
+          - errors=remount-ro
       - mountpoint: /
         partition: root
 


### PR DESCRIPTION
systemd-boot creates a /boot/efi/loader/randon-seed file that should not be accessible by users. Yet, because the backing filesystem is FAT32, by default everyone can read files when the filesystem is mounted.

Add fmask and dmask options to the generated /etc/fstab to deny read access to regular users when /boot is mounted.

This is a draft for now as it is an attempt but currently do not remove the warning when generating the image. Maybe it is because debos creates the /etc/fstab file correctly, but mounts it without using the fmask and dmask options regardless, leading to security warnings when generating the image.

Need to investigate if the message disappears when the command is run from a live system, and to maybe create an issue regarding debos itself if the passed options are not respected when building the image.

See #279 for context.