### PR TITLE
workflows: only upload private artifacts to S3

### DIFF
--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -92,7 +92,7 @@ jobs:
               --config "$CONFIG" --output-dir upload
 
       - name: Upload as private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
         with:
           path: upload
 

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -46,7 +46,7 @@ jobs:
   build-debos:
     name: Build and upload debos recipes
     outputs:
-      url: ${{ steps.upload_artifacts_gcp.outputs.url }}
+      url: ${{ steps.upload_artifacts_s3.outputs.url }}
     runs-on: [self-hosted, qcom-u2404, arm64]
     container:
       image: public.ecr.aws/debian/debian:trixie
@@ -173,16 +173,10 @@ jobs:
               disk-sdcard.img2 \
               flash_*_emmc
 
-      # upload to a cloud storage space accessible by LAVA and developers
-      - name: Upload private artifacts (GCP)
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_artifacts_gcp
-        with:
-          path: debos-artifacts
-
       # upload to a cloud storage space accessible by Axiom
       - name: Upload private artifacts (S3)
         uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        id: upload_artifacts_s3
         with:
           s3_bucket: qcom-prd-gh-artifacts
           # should be the default in that action, or ought to reuse BUILD_ID
@@ -239,7 +233,7 @@ jobs:
           path: sboms
       - name: "Print output"
         env:
-          build_url: ${{ steps.upload_artifacts_gcp.outputs.url }}
+          build_url: ${{ steps.upload_artifacts_s3.outputs.url }}
         run: |
           echo "Downloads URL: ${build_url}"
           echo "url=\"${build_url}\"" >> $GITHUB_OUTPUT

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -131,7 +131,7 @@ jobs:
           sync
 
       - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
         id: upload_artifacts
         with:
           path: artifacts

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -91,7 +91,7 @@ jobs:
           sync
 
       - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
         id: upload_artifacts
         with:
           path: artifacts

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_GITHUB_TOKEN
+          Authentication: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/flash-ufs.tar.gz"
     postprocess:
       docker:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_GITHUB_TOKEN
+          Authentication: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/flash-emmc.tar.gz"
     postprocess:
       docker:


### PR DESCRIPTION
Stop using GCP for storing private artifacts. Move all uploads to S3.