### PR TITLE
ci: fix auth headers in LAVA job templates

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_S3_TOKEN
+          Authorization: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/flash-ufs.tar.gz"
     postprocess:
       docker:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_S3_TOKEN
+          Authorization: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/flash-emmc.tar.gz"
     postprocess:
       docker:


### PR DESCRIPTION
After moving to S3 the header should be "Authorization". This patch fixes the header in LAVA job templates.