### PR TITLE
refactor(ci/debos): Avoid extra staging copy

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -154,15 +154,11 @@ jobs:
           # create a directory for the current run
           dir="debos-artifacts"
           mkdir -v "${dir}"
-          # compress output files before staging them
-          gzip --keep rootfs.tar
-          gzip --keep disk-ufs.img
-          gzip --keep disk-sdcard.img
-          # copy output files
-          cp -av rootfs.tar.gz "${dir}"
+          # compress output files into the staging directory
+          gzip -c rootfs.tar >"${dir}/rootfs.tar.gz"
+          gzip -c disk-ufs.img >"${dir}/disk-ufs.img.gz"
+          gzip -c disk-sdcard.img >"${dir}/disk-sdcard.img.gz"
           cp -av dtbs.tar.gz "${dir}"
-          cp -av disk-ufs.img.gz "${dir}"
-          cp -av disk-sdcard.img.gz "${dir}"
           # create tarballs with support for all UFS and all eMMC boards
           tar -cvzf "${dir}"/flash-ufs.tar.gz \
               disk-ufs.img1 \
@@ -221,10 +217,11 @@ jobs:
       - name: Stage SBOMs for publishing
         run: |
           set -ux
-          gzip rootfs-sbom.*
           dir="sboms"
           mkdir -v sboms
-          cp -av rootfs-sbom.*.gz sboms
+          for f in rootfs-sbom.*; do
+              gzip -c "$f" >"${dir}/${f}.gz"
+          done
 
       - name: Upload SBOMs as private artifacts
         uses: qualcomm-linux/upload-private-artifact-action@aws-v4


### PR DESCRIPTION
There is no need for the compressed assets except for upload, so just compress them directly into the staging directory.

Cherry-picked from #314 and merged the fixup commit into the original one.