### PR TITLE
feat!: Change default user and hostname to qcom

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -236,6 +236,7 @@ jobs:
         env:
           build_url: ${{ steps.upload_artifacts_s3.outputs.url }}
         run: |
+          echo '⚠️ Username and password are now "qcom"'
           echo "Downloads URL: ${build_url}"
           echo "url=\"${build_url}\"" >> $GITHUB_OUTPUT
           echo "${build_url}" > build_url

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ NB: It's also possible to run qdl from the host while the board is not connected
 
 #### Login
 
-Once the image has booted, you can log in as the `debian` user, with the
-default `debian` password. The image should then ask you to change this default
+Once the image has booted, you can log in as the `qcom` user, with the
+default `qcom` password. The image should then ask you to change this default
 password to a safe one.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 A collection of recipes to build Qualcomm Linux images for deb based
 operating systems.
 
+⚠️ Username and password are now "qcom"
+
 The main goal of this project is to provide mainline-centric images for
 Qualcomm® IoT platforms as to demonstrate the state of upstream open source
 software, help developers getting started, and support continuous development

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -33,18 +33,18 @@ actions:
 - boot:
     auto_login:
       login_prompt: 'login:'
-      username: debian
+      username: qcom
       password_prompt: 'Password'
-      password: debian
+      password: qcom
       login_commands:
-      - "debian"
+      - "qcom"
       - "new password"
       - "new password"
       - sudo su
     method: minimal
     prompts:
-    - root@debian
-    - debian@debian
+    - root@qcom
+    - qcom@qcom
     - "Current password"
     - "New password"
     - "Retype new password"

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -34,18 +34,18 @@ actions:
 - boot:
     auto_login:
       login_prompt: 'login:'
-      username: debian
+      username: qcom
       password_prompt: 'Password'
-      password: debian
+      password: qcom
       login_commands:
-      - "debian"
+      - "qcom"
       - "new password"
       - "new password"
       - sudo su
     method: minimal
     prompts:
-    - root@debian
-    - debian@debian
+    - root@qcom
+    - qcom@qcom
     - "Current password"
     - "New password"
     - "Retype new password"

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -69,19 +69,19 @@ def test_password_reset_required(vm):
     # https://github.com/qualcomm-linux/qcom-deb-images/issues/69
 
     # This takes a minute or two on a ThinkPad T14s Gen 6 Snapdragon
-    vm.expect_exact("debian login:", timeout=240)
+    vm.expect_exact("qcom login:", timeout=240)
 
-    vm.send("debian\r\n")
+    vm.send("qcom\r\n")
     vm.expect_exact("Password:")
-    vm.send("debian\r\n")
+    vm.send("qcom\r\n")
     vm.expect_exact("You are required to change your password immediately")
     vm.expect_exact("Current password:")
-    vm.send("debian\r\n")
+    vm.send("qcom\r\n")
     vm.expect_exact("New password:")
     vm.send("new password\r\n")
     vm.expect_exact("Retype new password:")
     vm.send("new password\r\n")
-    vm.expect_exact("debian@debian:~$")
+    vm.expect_exact("qcom@qcom:~$")
 
     # The /boot/efi/loader/random-seed file should not be readable to users
     # https://github.com/qualcomm-linux/qcom-deb-images/issues/279

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -4,6 +4,8 @@
 {{- $kernelpackage := or .kernelpackage "linux-image-arm64" }}
 {{- $overlays := or .overlays "qsc-deb-releases" }}
 {{- $buildid := or .buildid "" }}
+{{- $username := or .username "qcom" }}
+{{- $hostname := or .hostname "qcom" }}
 
 {{- $variantid := "console" }}
 {{- if eq $xfcedesktop "true" }}
@@ -121,16 +123,16 @@ actions:
       - wpasupplicant
 
   - action: run
-    description: Set hostname to "debian"
+    description: Set hostname to "{{ $hostname }}"
     chroot: true
     command: |
       set -eux
-      echo debian >/etc/hostname
+      echo {{ $hostname }} >/etc/hostname
       # /etc/hosts is created by netbase
-      sed -i "1s/^/127.0.1.1	debian\n/" /etc/hosts
+      sed -i "1s/^/127.0.1.1\t{{ $hostname }}\n/" /etc/hosts
 
   - action: run
-    description: Add a "debian" user, add it to sudoers and various groups
+    description: Add a "{{ $username }}" user, add it to sudoers and various groups
     chroot: true
     command: |
       set -eux
@@ -140,17 +142,17 @@ actions:
       # from the serial console, over SSH, or in containers - where the desktop
       # session has not updated ACLs to the device nodes
       useradd --create-home --shell /bin/bash --user-group \
-          --groups adm,audio,fastrpc,render,sudo,users,video debian
-      # set password to "debian"
-      echo debian:debian | chpasswd
+          --groups adm,audio,fastrpc,render,sudo,users,video {{ $username }}
+      # set password to "{{ $username }}"
+      echo {{ $username }}:{{ $username }} | chpasswd
       # password must be changed on first login
-      chage --lastday 0 debian
+      chage --lastday 0 {{ $username }}
       # add to sudoers
       mkdir -v --mode 755 --parents /etc/sudoers.d
       # subshell to override umask
       (
         umask 226
-        echo "debian ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-debos
+        echo "{{ $username }} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-debos
       )
 
   # NB: Recommends pull in way too many packages, and we don't need to follow
@@ -206,7 +208,7 @@ actions:
     chroot: true
     command: |
       set -eux
-      usermod -a -G docker debian
+      usermod -a -G docker {{ $username }}
 
 {{- if eq $xfcedesktop "true" }}
   # this should ideally be task-xfce-desktop, but this pulls too many apps;


### PR DESCRIPTION
For consistency in docs and CI, use qcom as default user, password, and hostname, no matter the distro.

Cherry-picked from #314, and added missing update to README with the new user/password.