### PR TITLE
feat(Makefile): Add kernel build integration and local APT repo support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-# DEBOS_OPTS can be overridden with:
-#     make DEBOS_OPTS=... all
-# USE_CONTAINER can be set to yes/no/auto (default: auto)
-#     make USE_CONTAINER=yes all    # Force container use
-#     make USE_CONTAINER=no all     # Force native debos
+# Key variables (override on the command line):
+#   DEBOS_OPTS="..."           - override debos options
+#   USE_CONTAINER=yes/no/auto  - control container use (default: auto)
+#   DEBOS_ARGS="..."           - pass extra arguments to debos
+#   KERNEL_REPO/KERNEL_REF     - kernel source for 'make kernel-deb'
+#   KERNEL_PACKAGE             - kernel package name (auto-detected from local-apt-repo/)
 
 # To build large images, the debos resource defaults are not sufficient. These
 # provide defaults that work for us as universally as we can manage.
 FAKEMACHINE_BACKEND = $(shell [ -c /dev/kvm ] && echo kvm || echo qemu)
 DEBOS_OPTS := --fakemachine-backend $(FAKEMACHINE_BACKEND) --memory 1GiB --scratchsize 6GiB
+DEBOS_ARGS ?=
 
 # Container support: auto-detect if debos is available, otherwise use container
 USE_CONTAINER ?= auto
@@ -50,13 +52,87 @@ export http_proxy
 all: disk-ufs.img disk-sdcard.img
 
 rootfs.tar: debos-recipes/qualcomm-linux-debian-rootfs.yaml
-	$(DEBOS_CMD) $<
+	$(DEBOS_CMD) $(DEBOS_ARGS) $<
 
 disk-ufs.img: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar
-	$(DEBOS_CMD) $<
+	$(DEBOS_CMD) $(DEBOS_ARGS) $<
 
 disk-sdcard.img: debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar
-	$(DEBOS_CMD) -t imagetype:sdcard $<
+	$(DEBOS_CMD) $(DEBOS_ARGS) -t imagetype:sdcard $<
+
+# Kernel build variables - override to build a specific kernel
+KERNEL_REPO ?= https://github.com/torvalds/linux
+KERNEL_REF ?= master
+KERNEL_DIR ?=
+# Set to 'yes' to use qcom-next defaults (auto-finds latest dated tag)
+USE_QCOM_NEXT ?= no
+# Set to 'yes' to use linux-next defaults (auto-finds latest dated tag)
+USE_LINUX_NEXT ?= no
+KERNEL_DEB_EXTRA_ARGS ?=
+
+# Local APT repo directory - mirrors what CI sets up via aptlocalrepo
+LOCAL_APT_REPO ?= local-apt-repo
+
+# KERNEL_PACKAGE: auto-detected from $(LOCAL_APT_REPO) after 'make kernel-deb'.
+# Override to select a specific package, or pass KERNEL_PACKAGE= to disable.
+KERNEL_PACKAGE ?= $(shell find $(LOCAL_APT_REPO) -type f -name 'linux-image-*' \
+    -not -name '*-dbg_*' 2>/dev/null | xargs -n1 basename 2>/dev/null | \
+    cut -f1 -d_ | sort | tail -1)
+ifneq ($(KERNEL_PACKAGE),)
+    override DEBOS_ARGS += -t aptlocalrepo:$(DEBOS_WORKDIR)/$(LOCAL_APT_REPO) \
+                           -t kernelpackage:$(KERNEL_PACKAGE)
+endif
+
+# Rebuild the APT repo index in $(LOCAL_APT_REPO).
+# Requires: apt-utils (apt-ftparchive)
+.PHONY: setup-apt-repo
+setup-apt-repo:
+	cd $(LOCAL_APT_REPO) && apt-ftparchive packages . > Packages && apt-ftparchive release . > Release
+	@echo ""
+	@echo "Local APT repo ready at: $(LOCAL_APT_REPO)/"
+	@echo ""
+	@echo "KERNEL_PACKAGE will be auto-detected; to build rootfs and images:"
+	@echo "  make rootfs.tar && make disk-ufs.img disk-sdcard.img"
+
+# Build a kernel deb package and add it to the local APT repo.
+# Examples:
+#   make kernel-deb USE_QCOM_NEXT=yes
+#   make kernel-deb KERNEL_REPO=https://github.com/qualcomm-linux/kernel KERNEL_REF=qcom-next
+#   make kernel-deb KERNEL_DIR=/path/to/linux   # use existing source
+.PHONY: kernel-deb
+kernel-deb:
+	@if [ "$(USE_QCOM_NEXT)" = "yes" ] && [ "$(USE_LINUX_NEXT)" = "yes" ]; then \
+	    echo "Error: Cannot use both USE_QCOM_NEXT=yes and USE_LINUX_NEXT=yes"; \
+	    exit 1; \
+	elif [ "$(USE_QCOM_NEXT)" = "yes" ]; then \
+	    scripts/build-linux-deb.py \
+	        --qcom-next \
+	        $(if $(KERNEL_DIR),--local-dir $(KERNEL_DIR)) \
+	        $(KERNEL_DEB_EXTRA_ARGS) \
+	        $(sort $(wildcard kernel-configs/*.config)); \
+	elif [ "$(USE_LINUX_NEXT)" = "yes" ]; then \
+	    scripts/build-linux-deb.py \
+	        --linux-next \
+	        $(if $(KERNEL_DIR),--local-dir $(KERNEL_DIR)) \
+	        $(KERNEL_DEB_EXTRA_ARGS) \
+	        $(sort $(wildcard kernel-configs/*.config)); \
+	else \
+	    scripts/build-linux-deb.py \
+	        $(if $(KERNEL_DIR),--local-dir $(KERNEL_DIR)) \
+	        --repo $(KERNEL_REPO) \
+	        --ref $(KERNEL_REF) \
+	        $(KERNEL_DEB_EXTRA_ARGS) \
+	        $(sort $(wildcard kernel-configs/*.config)); \
+	fi
+	mkdir -p $(LOCAL_APT_REPO)/kernel
+	@# Kernel debs are created in parent dir of kernel source
+	@if [ -n "$(KERNEL_DIR)" ]; then \
+	    mv -v $(dir $(abspath $(KERNEL_DIR)))*.deb $(LOCAL_APT_REPO)/kernel/ 2>/dev/null || \
+	    mv -v $(abspath $(KERNEL_DIR))/../*.deb $(LOCAL_APT_REPO)/kernel/; \
+	else \
+	    mv -v *.deb $(LOCAL_APT_REPO)/kernel/; \
+	fi
+	$(MAKE) setup-apt-repo
 
 .PHONY: test
 test: disk-ufs.img
@@ -65,7 +141,9 @@ test: disk-ufs.img
 
 .PHONY: clean
 clean:
-	rm -f disk-ufs.img1 disk-ufs.img2 disk-ufs.img
-	rm -f disk-sdcard.img1 disk-sdcard.img2 disk-sdcard.img
 	rm -f rootfs.tar
 	rm -f dtbs.tar.gz
+	rm -f disk-*.img disk-*.img.gz disk-*.img[0-9]
+	rm -rf rootfs/
+	rm -rf linux/
+	rm -rf $(LOCAL_APT_REPO)/

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -44,7 +44,7 @@ actions:
       cat >/etc/apt/sources.list.d/apt-local-repo.sources <<EOF
       Types: deb
       URIs: file:///media/apt-local-repo
-      Suites: /
+      Suites: ./
       Trusted: true
       EOF
 {{- end }}

--- a/scripts/build-linux-deb.py
+++ b/scripts/build-linux-deb.py
@@ -285,7 +285,7 @@ def main():
         subprocess.run(
             merge_command,
             check=True,
-            cwd="linux",
+            cwd=str(linux_dir),
             env={"ARCH": "arm64", **subprocess.os.environ}
         )
 
@@ -293,7 +293,7 @@ def main():
         subprocess.run(
             make_base_command + ["olddefconfig"],
             check=True,
-            cwd="linux"
+            cwd=str(linux_dir)
         )
 
     log_i("Building Linux deb")


### PR DESCRIPTION
Added makefile target "kernel-deb" for use of build-linux-deb script, linked to setup of the local apt repo for kernel installation.  Added DEBOS_ARGS as well. 

 This allows for a simple developer flow, like the following images I built for Glymur:

```
make kernel-deb USE_QCOM_NEXT=yes 
make rootfs.tar DEBOS_ARGS="-t gnomedesktop:true"
make disk-sdcard.img DEBOS_ARGS="-t dtb:qcom/glymur-crd.dtb"
```

The handling of the different cases for kernel branch building is a bit clunky, but I think may also help toward enabling makefile use also in CI with some tweaking. 