### PR TITLE
debos: install and enable openssh-server for SSH access

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Once the image has booted, you can log in as the `debian` user, with the
 default `debian` password. The image should then ask you to change this default
 password to a safe one.
 
+Note: "openssh server is installed but disabled by default; enable with "systemctl enable --now ssh" as root user".
+
 ## Development
 
 Want to join in the development? Changes welcome! See [CONTRIBUTING.md file](CONTRIBUTING.md) for step by step instructions.

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -302,13 +302,25 @@ actions:
       - wget
 
   - action: run
-    description: Add default user to docker group
+    description: Install openssh-server without generating host keys and report any existing keys
     chroot: true
     command: |
       set -eux
-      usermod -a -G docker debian
+      export DEBIAN_FRONTEND=noninteractive
+      install -d -m 700 /etc/ssh
+      touch /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_rsa_key.pub /etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_ecdsa_key.pub /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key.pub
+      chmod 600 /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_ed25519_key
+      dpkg-divert --add --rename /usr/bin/ssh-keygen
+      ln -s /bin/true /usr/bin/ssh-keygen
+      apt-get -y install openssh-server
+      rm /usr/bin/ssh-keygen
+      dpkg-divert --remove /usr/bin/ssh-keygen
+      systemctl mask ssh.service 2>/dev/null || true
+      systemctl disable ssh.service 2>/dev/null || true
+      find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*_key' -size +0 | grep -q . && { echo "SSH host key files found"; exit 1; } || echo "No SSH host key files present"
 
 {{- if eq $xfcedesktop "true" }}
+
   # this should ideally be task-xfce-desktop, but this pulls too many apps;
   # instead, curate from the Depends and Recommends of task-xfce-desktop and
   # task-desktop recursively; also, disable Recommends


### PR DESCRIPTION
Install openssh-server and enable the ssh service during image build so SSH access is available immediately after first boot.