### PR TITLE
fix: support "none" value for $overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. Defaults to `qsc-deb-releases` to add our overlay
   apt repository that contains some package delta that isn't fully upstreamed
-  and backported to trixie in Debian yet.
+  and backported to trixie in Debian yet. Can be set to "none" to not include
+  any overlay.
 - `kernelpackage`: name of the kernel package to install from apt; defaults to
   `Debian’s linux-image-arm64`. Can (and should) be set to `none` if you are
   providing local kernel package instead.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,7 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `xfcedesktop`: install an Xfce desktop environment; default: console only
   environment
 - `overlays`: a `,`-separated list of rootfs overlays to add from
-  `debos-recipes/overlays/`. Defaults to `qsc-deb-releases` to add our overlay
-  apt repository that contains some package delta that isn't fully upstreamed
-  and backported to trixie in Debian yet. Can be set to "none" to not include
-  any overlay.
+  `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackage`: name of the kernel package to install from apt; defaults to
   `Debian’s linux-image-arm64`. Can (and should) be set to `none` if you are
   providing local kernel package instead.
@@ -200,6 +197,31 @@ extra options to debos invocations, use `EXTRA_DEBOS_OPTS`, e.g.:
 ```
 make EXTRA_DEBOS_OPTS="-t xfcedesktop:true" disk-ufs.img
 ```
+
+#### Supported overlays
+
+Multiple overlays are available to include additional files not provided by
+Debian packages into the image’s root file system. They are located in
+`debos-recipes/overlays/`.
+
+By default, the *qsc-deb-releases* overlay is used if no overlays are specified
+using the `-t overlays:<value>` option. Multiple overlays can be specified,
+separated by a comma (`,`).
+
+Here is the list of supported overlays:
+
+<dl>
+    <dt>none</dt>
+    <dd>
+        Special value to disable all overlays.
+    </dd>
+    <dt>qsc-deb-releases</dt>
+    <dd>
+        Enable our overlay apt repository that contains some package delta that
+        isn't fully upstreamed and backported to trixie in Debian yet.
+        Including this overlay will also select the fastrpc-test package.
+    </dd>
+</dl>
 
 ### Flash the image
 

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -92,7 +92,13 @@ actions:
       # ext4 tools, notably e2fsck for the root filesystem
       - e2fsprogs
       # fastrpc support. fastrpc-tests pulls in the required stack
+{{- if ne $overlays "none" }}
+{{- range $overlay := split "," $overlays }}
+{{- if eq $overlay "qsc-deb-releases" }}
       - fastrpc-tests
+{{- end }}
+{{- end }}
+{{- end }}
       # fwupd tools, enable OTA EFI firmware capsule updates
       - fwupd
       # defaults to "systemd-sysv"; perhaps not needed

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -60,7 +60,7 @@ actions:
     description: Add Debian backports APT configuration
     source: overlays/backports
 
-{{- if $overlays }}
+{{- if ne $overlays "none" }}
 {{- range $overlay := split "," $overlays }}
   - action: overlay
     description: Apply overlay {{$overlay}}

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -145,8 +145,13 @@ actions:
       # some useful groups for desktop scenarios, but also to run payloads
       # from the serial console, over SSH, or in containers - where the desktop
       # session has not updated ACLs to the device nodes
+      groups="adm,audio,render,sudo,users,video"
+      # fastrpc group only exists when fastrpc-support is installed (Debian)
+      if getent group fastrpc >/dev/null 2>&1; then
+        groups="${groups},fastrpc"
+      fi
       useradd --create-home --shell /bin/bash --user-group \
-          --groups adm,audio,fastrpc,render,sudo,users,video debian
+          --groups "$groups" debian
       # set password to "debian"
       echo debian:debian | chpasswd
       # password must be changed on first login


### PR DESCRIPTION
The $overlays variable cannot easily be set to an empty string from the
command line or when calling the makefile. At least the following tries
do not work:

        make rootfs.tar EXTRA_DEBOS_OPTS="-t overlays:"
        make rootfs.tar EXTRA_DEBOS_OPTS="-t overlays:''"

Allow to set the overlays to "none" to be able to disable the otherwise
always enabled qsc-deb-releases overlay.