### PR TITLE
fix(scripts/gen-ptool): Drop Axiom compat symlinks

### DIFF
--- a/scripts/gen-ptool.sh
+++ b/scripts/gen-ptool.sh
@@ -24,12 +24,12 @@ PARTITIONS_CONF="${QCOM_PTOOL}/platforms/${PLATFORM}/partitions.conf"
 
 case "$DISK_TYPE" in
   emmc|nvme)
-    esp="disk-sdcard.img1"
-    rootfs="disk-sdcard.img2"
+    esp="../disk-sdcard.img1"
+    rootfs="../disk-sdcard.img2"
     ;;
   ufs)
-    esp="disk-ufs.img1"
-    rootfs="disk-ufs.img2"
+    esp="../disk-ufs.img1"
+    rootfs="../disk-ufs.img2"
     ;;
   spinor)
     # spinor carries firmware only; no OS efi/rootfs partitions
@@ -57,14 +57,6 @@ partition_map="${partition_map},dtb_a=dtb.bin"
 partition_map="${partition_map},dtb_b=dtb.bin"
 partition_map="${partition_map},efi=${esp}"
 partition_map="${partition_map},rootfs=${rootfs}"
-
-# create symlinks from flat image to actual file
-if [ -n "$esp" ]; then
-    ln -s "../${esp}" "$esp"
-fi
-if [ -n "$rootfs" ]; then
-    ln -s "../${rootfs}" "$rootfs"
-fi
 
 # generate ptool-partitions.xml from partitions.conf
 "${QCOM_PTOOL}/gen_partition.py" -i "${PARTITIONS_CONF}" \


### PR DESCRIPTION
Windows requires non-default permissions to unpack symlinks, so this is
not a mechanism we can scale. Instead, Axiom will be fixed to follow
relative pathnames in *.xml files.
