### PR TITLE
feat(ci): generate sha256sums.txt file

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -148,6 +148,8 @@ jobs:
           cp -av dtbs.tar.gz "${dir}"
           # create tarballs with support for all UFS and all eMMC boards
           scripts/bundle-flash-dirs.sh "${dir}"
+          # generate sha256sums for all artifacts
+          (cd "${dir}" && sha256sum * | tee sha256sums.txt)
 
       # upload to a cloud storage space accessible by Axiom
       - name: Upload private artifacts (S3)


### PR DESCRIPTION
This allows to verify the correctness of the image files that can be quite big and bitrot over bad connections.

Closes: #320