### PR TITLE
workflows: upgrade lava-action to v11

### DIFF
--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Submit ${{ matrix.target }}
         timeout-minutes: 240
-        uses: foundriesio/lava-action@v10
+        uses: foundriesio/lava-action@v11
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'


### PR DESCRIPTION
lava-action@v11 moves to node24 in place of deprecated node20. This will remove the warning when workflow is executed.