### PR TITLE
fix(get-rawprogram-filename): Return none when missing

### DIFF
--- a/scripts/get-rawprogram-filename.py
+++ b/scripts/get-rawprogram-filename.py
@@ -16,19 +16,17 @@ import defusedxml.ElementTree as ET
 
 if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} <label> <rawprogram0.xml>", file=sys.stderr)
-    sys.exit(1)
+    print("none")
+else:
+    label, xml_file = sys.argv[1], sys.argv[2]
 
-label, xml_file = sys.argv[1], sys.argv[2]
-
-root = ET.parse(xml_file).getroot()
-e = root.find(f".//program[@label='{label}']")
-if e is None:
-    print(f"error: no <program label='{label}'> found in {xml_file}",
-          file=sys.stderr)
-    sys.exit(1)
-
-filename = e.get("filename")
-# Strip any leading ../ path components
-while filename.startswith("../"):
-    filename = filename[3:]
-print(filename)
+    root = ET.parse(xml_file).getroot()
+    e = root.find(f".//program[@label='{label}']")
+    if e is None:
+        print("none")
+    else:
+        filename = e.get("filename")
+        # Strip any leading ../ path components
+        while filename.startswith("../"):
+            filename = filename[3:]
+        print(filename)


### PR DESCRIPTION
Return none when the input XML does not contain a rootfs entry or
when parsing fails, instead of erroring out. This allows callers to
distinguish between valid matches and missing data gracefully.