### PR TITLE
feature(Makefile): install missing dependencies in debos container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ DEBOS_OPTS := $(FAKEMACHINE_OPTS) --memory 1GiB --scratchsize 6GiB $(EXTRA_DEBOS
 # Container support: auto-detect if debos is available, otherwise use container
 USE_CONTAINER ?= auto
 CONTAINER_IMAGE ?= ghcr.io/go-debos/debos:latest
-
 ifeq ($(USE_CONTAINER),auto)
 	ifdef GITHUB_ACTIONS
 		# Disable container in GitHub Actions
@@ -37,7 +36,7 @@ ifeq ($(USE_CONTAINER),yes)
 		--mount "type=bind,source=$(CURDIR),destination=$(DEBOS_WORKDIR)" \
 		--security-opt label=disable \
 		$(CONTAINER_IMAGE) \
-		$(DEBOS_OPTS)
+		$(DEBOS_OPTS) -t auto_install_deps:true
 else
 	# Working directory for native debos
 	DEBOS_WORKDIR := $(CURDIR)

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -9,10 +9,18 @@
 {{- $buildid := or .buildid "" }}
 
 {{- $target_boards := or .target_boards "all" }}
-
+{{- $auto_install_deps := or .auto_install_deps "false" }}
 architecture: arm64
 
 actions:
+  - action: run
+    description: Check host build dependencies
+    chroot: false
+    command: |
+      "${RECIPEDIR}/../scripts/check-deps.sh" \
+          {{if eq $auto_install_deps "true"}}--install{{end}} \
+          dosfstools mtools python3-defusedxml unzip xmlstarlet
+
   - action: download
     description: Download qcom-ptool
     url: https://github.com/qualcomm-linux/qcom-ptool/archive/6b5135fe5bf4166b1212fd0f04610e59d4b68478.tar.gz

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -9,10 +9,18 @@
 {{- if eq $xfcedesktop "true" }}
 {{- $variantid = "xfce" }}
 {{- end }}
-
+{{- $auto_install_deps := or .auto_install_deps "false" }}
 architecture: arm64
 
 actions:
+  - action: run
+    description: Check host build dependencies
+    chroot: false
+    command: |
+      "${RECIPEDIR}/../scripts/check-deps.sh" \
+          {{if eq $auto_install_deps "true"}}--install{{end}} \
+          debian-archive-keyring mmdebstrap
+
   - action: mmdebstrap
     description: Bootstrap initial filesystem
     # NB: not currently configurable

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Check whether a list of packages is installed; optionally install missing ones.
+# Usage: check-deps.sh [--install] pkg1 pkg2 ...
+
+set -eu
+
+
+setup_apt() {
+    [ -d /etc/apt/apt.conf.d ] && [ -f /var/lib/dpkg/status ] && return 0
+    echo "check-deps: bootstrapping apt (trixie)..."
+    mkdir -p /etc/apt/apt.conf.d \
+                  /etc/apt/sources.list.d \
+                  /etc/apt/preferences.d \
+                  /etc/apt/trusted.gpg.d \
+                  /var/lib/dpkg/info \
+                  /var/lib/dpkg/updates \
+                  /var/lib/dpkg/alternatives \
+                  /var/cache/apt/archives/partial \
+                  /var/log/apt
+    touch /var/lib/dpkg/status /var/lib/dpkg/available
+
+    opt=""
+    for f in /usr/share/keyrings/debian-archive-keyring.gpg \
+             /usr/share/keyrings/debian-archive-removed-keys.gpg; do
+        [ -f "$f" ] && cp "$f" /etc/apt/trusted.gpg.d/ || opt="[trusted=yes] "
+    done
+
+    echo "deb ${opt}http://deb.debian.org/debian trixie main contrib non-free non-free-firmware" |
+        tee /etc/apt/sources.list >/dev/null
+    apt-get update -y
+}
+
+install=false
+if [ "$1" = "--install" ]; then
+    install=true
+    shift
+fi
+
+missing=""
+for pkg in "$@"; do
+    dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+done
+
+[ -z "$missing" ] && exit 0
+
+
+if [ "$install" = true ]; then
+    setup_apt
+    apt-get install -y --no-install-recommends $missing
+else
+    echo "E: Missing host packages:$missing" >&2
+    echo "E: Install them manually, or set -t auto_install_deps:true to install automatically" >&2
+    exit 0
+fi


### PR DESCRIPTION
While running `make flash` on ARM machines, the base image `ghcr.io/go-debos/debos:latest` is missing required tools such as`mtools`, causing failures (e.g. `mcopy` not found).

Problem:
Developers using `CONTAINER_IMAGE ?= ghcr.io/go-debos/debos:latest` encounter errors because required dependencies are not present inside the container.

Solution:
Introduce `check_install_dependency.sh`, which:
- checks for missing dependencies
- generates `Dockerfile.auto-deps` on top of the base debos image
- installs only missing packages
- builds and returns a new container image when required

The script is invoked from the Makefile to automatically select the correct container image.

Usage:
  chmod +x check_install_dependency.sh