### PR TITLE
fix(debos/flash): Revert to simpler cp calls

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -372,7 +372,7 @@ actions:
           rm -rf "${flash_dir}"
           mkdir -v "${flash_dir}"
           # copy platform partition files
-          cp --preserve=all --no-dereference -v \
+          cp --preserve=mode,timestamps -v \
               "build/ptool/${platform}"/* "${flash_dir}"
 
           # remove BLANK_GPT, WIPE_PARTITIONS and wipe_rawprogram files as
@@ -402,18 +402,18 @@ actions:
                   -or -name '*.fv' \
                   -or -name '*.mbn' \
               \) \
-              -exec cp --preserve=all --no-dereference -v '{}' "${flash_dir}" \;
+              -exec cp --preserve=mode,timestamps -v '{}' "${flash_dir}" \;
 
           if [ -n "${board_u_boot_file}" ]; then
               # copy U-Boot binary to boot.img; qcom-ptool partitions.conf
               # files use filename=boot.img for boot_a and boot_b partitions
-              cp --preserve=all --no-dereference -v \
+              cp --preserve=mode,timestamps -v \
                   "${ARTIFACTDIR}/${board_u_boot_file}" "${flash_dir}/boot.img"
           fi
 
           if [ -n "$board_cdt_filename" ]; then
               # copy just the CDT data; no partition or flashing files
-              cp --preserve=all --no-dereference -v \
+              cp --preserve=mode,timestamps -v \
                   "build/${board_name}_cdt/${board_cdt_filename}" \
                   "${flash_dir}"
           fi
@@ -452,7 +452,7 @@ actions:
                   [ "${storage}" = "spinor" ] && continue
                   target_dir="${ARTIFACTDIR}/flash_${board}_${storage}"
                   [ -d "${target_dir}" ] || continue
-                  cp --preserve=all --no-dereference -av "${spinor_dir}/." "${target_dir}/spinor/"
+                  cp --preserve=mode,timestamps -av "${spinor_dir}/." "${target_dir}/spinor/"
                   efi_img=$("${RECIPEDIR}/../scripts/get-rawprogram-filename.py" efi "${target_dir}/rawprogram0.xml")
                   rootfs_img=$("${RECIPEDIR}/../scripts/get-rawprogram-filename.py" rootfs "${target_dir}/rawprogram0.xml")
                   # fix file_path (../->../../) then rename efi.bin/rootfs.img


### PR DESCRIPTION
In 539f97b, compatibility symlinks were added for Axiom support,
requiring changes to "cp" calls to preserve these symlinks. The new
style of cp calls also try to preserve ownership of files, and that
fails under some debos fakemachine backends.

Revert to the older style of simpler "cp" calls which work across a
broader range of debos fakemachine backends.
