### PR TITLE
feat!(image): use UKI instead of kernel+initramfs

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -77,11 +77,21 @@ actions:
     setup-fstab: true
     append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30
 
+  - action: run
+    description: Create /etc/kernel/install.conf file
+    chroot: true
+    command: |
+      set -eux
+      tee /etc/kernel/install.conf <<EOF
+      layout=uki
+      EOF
+
   - action: apt
     description: Make system bootable with systemd-boot
     recommends: true
     packages:
       - systemd-boot
+      - systemd-ukify
       # TODO investigate why systemd-boot Recommends: shim-signed which
       # Depends on grub packages
       - shim-signed-

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -88,11 +88,21 @@ actions:
       apt-get update
 {{- end }}
 
+  - action: run
+    description: Ask for UKI via /etc/kernel/install.conf
+    chroot: true
+    command: |
+      set -eux
+      tee /etc/kernel/install.conf <<EOF
+      layout=uki
+      EOF
+
   - action: apt
     description: Make system bootable with systemd-boot
     recommends: true
     packages:
       - systemd-boot
+      - systemd-ukify
       # TODO investigate why systemd-boot Recommends: shim-signed which
       # Depends on grub packages
       - shim-signed-


### PR DESCRIPTION
Use systemd-ukify to create an UKI .efi file instead of the classic "bls" approach, which splits kernel and initramfs into separate files.

It can be discovered and booted by systemd-boot directly without the need for any entry. However this means than editing the command line and/or device-tree takes more step as one as to regenerate the UKI after changing /etc/kernel/commandline and/or /etc/kernel/devicetree resp. and dpkg-reconfigure the kernel to call the ukify install hooks.

This change is needed as a first step for using stubble to have .dtbauto sections and ultimately be able to autoselect a devicetree for supported platforms.

cherry-picked and reworked from #362