### PR TITLE
workflows: enable LAVA testing on Glymur

### DIFF
--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -24,5 +24,5 @@ jobs:
       debos_extra_args: '-t dtb:qcom/glymur-crd.dtb'
       # we hardcode the DT, and that's not compatible with the QEMU machine model
       skip_qemu_tests: true
-      skip_lava_tests: true
+      skip_lava_tests: false
     secrets: inherit

--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -1,0 +1,85 @@
+actions:
+- deploy:
+    images:
+      image:
+        headers:
+          Authorization: Q_S3_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
+    postprocess:
+      docker:
+        image: ghcr.io/foundriesio/lava-lmp-sign:main
+        steps:
+        - export IMAGE_PATH=$PWD
+        - cp overlay*.tar.gz overlay.tar.gz
+        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "STORAGE=emmc" >> $IMAGE_PATH/flash.settings
+        - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-glymur-crd_nvme" >> $IMAGE_PATH/flash.settings
+        - cat $IMAGE_PATH/flash.settings
+    timeout:
+      minutes: 200
+    to: downloads
+- deploy:
+    images:
+      image:
+        url: downloads://{{SUITE}}-flash-emmc.tar.gz
+      settings:
+        url: downloads://flash.settings
+      overlay:
+        url: downloads://overlay.tar.gz
+    timeout:
+      minutes: 20
+    to: flasher
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
+      - sudo su
+    method: minimal
+    prompts:
+    - root@debian
+    - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
+    timeout:
+      minutes: 3
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - from: git
+      name: "smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a"
+    - from: git
+      name: "wlan-smoke-test"
+      path: automated/linux/wlan-smoke/wlan-smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        WAIT_TIME: 60
+- command:
+    name: network_turn_on
+context:
+  lava_test_results_dir: /home/lava-%s
+  test_character_delay: 10
+device_type: glymur-crd
+job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+timeouts:
+  job:
+    minutes: 210
+visibility: public


### PR DESCRIPTION
Add boot/smoke test template for Glymur and enable LAVA testing in daily Glymur build.