### PR TITLE
Use backports of AI enablement packages

### DIFF
--- a/debos-recipes/overlays/backports/etc/apt/preferences.d/debian-backports.pref
+++ b/debos-recipes/overlays/backports/etc/apt/preferences.d/debian-backports.pref
@@ -1,6 +1,6 @@
 # for binary packages built from these source packages, score the version from
 # Debian backports higher as to get hardware enabled or better hardware support
 
-Package: src:alsa-ucm-conf:any src:firmware-free:any src:firmware-nonfree:any src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
+Package: src:alsa-ucm-conf:any src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
 Pin: release n=trixie-backports
 Pin-Priority: 900

--- a/debos-recipes/overlays/backports/etc/apt/preferences.d/debian-backports.pref
+++ b/debos-recipes/overlays/backports/etc/apt/preferences.d/debian-backports.pref
@@ -1,6 +1,6 @@
 # for binary packages built from these source packages, score the version from
 # Debian backports higher as to get hardware enabled or better hardware support
 
-Package: src:alsa-ucm-conf:any src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
+Package: src:alsa-ucm-conf:any src:fastrpc src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
 Pin: release n=trixie-backports
 Pin-Priority: 900


### PR DESCRIPTION
Prefer backports of AI enablement packages if available:
- **feat(debos): hexagon-dsp-binaries from backports**
- **feat(debos): fastrpc from backports**
