### PR TITLE
ci: fix rb1 and rb3gen2 bad images

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -22,7 +22,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://flash-ufs.tar.gz
+        url: downloads://{{SUITE}}-flash-ufs.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -23,7 +23,7 @@ actions:
 - deploy:
     images:
       image:
-        url: downloads://flash-emmc.tar.gz
+        url: downloads://{{SUITE}}-flash-emmc.tar.gz
       settings:
         url: downloads://flash.settings
       overlay:


### PR DESCRIPTION
After adding a prefix to the images, the first occurrence of the image name in these boot.yaml files was updated, but not the second occurrence where the image is also referred to.