### PR TITLE
fix(debos/rootfs): fix locale-gen invocation

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -370,7 +370,7 @@ actions:
       set -eux
       if which locale-gen >/dev/null 2>&1; then
           echo en_US.UTF-8 UTF-8 >>/etc/locale.gen
-          locale-gen en_US.UTF-8 UTF-8
+          locale-gen
           update-locale LANG=en_US.UTF-8
       fi
 


### PR DESCRIPTION
Call locale-gen without arguments so it reads /etc/locale.gen. This
improves compatibility of the recipes with Ubuntu, even if Ubuntu is
unsupported right now.

Previously the extra "UTF-8" argument was interpreted by Ubuntu's
locale-gen as a second (invalid) locale name:
    Error: 'UTF-8' is not a supported language or locale
