### PR TITLE
Dynamic LAVA tests

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -28,4 +28,5 @@ jobs:
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
+      boards_json: ${{ needs.build-daily.outputs.boards_json }}
       suite: trixie

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -238,17 +238,22 @@ jobs:
       - name: "Print output"
         env:
           build_url: ${{ steps.upload_artifacts_s3.outputs.url }}
+          boards_json: ${{ steps.stage_artifacts.outputs.boards_json }}
         run: |
           echo "Downloads URL: ${build_url}"
           echo "url=\"${build_url}\"" >> $GITHUB_OUTPUT
-          echo "${build_url}" > build_url
           echo "## Download URL" >> $GITHUB_STEP_SUMMARY
           echo "[${build_url}](${build_url})" >> $GITHUB_STEP_SUMMARY
-      - name: Upload build URL
+          # bundle with boards.json so test-pr.yml can consume both together;
+          # boards_json is already compact (single line) from the step output
+          mkdir -v build-info-artifact
+          echo "${build_url}" > build-info-artifact/build-url.txt
+          printf '%s\n' "${boards_json}" > build-info-artifact/boards.json
+      - name: Upload build info
         uses: actions/upload-artifact@v7
         with:
-          name: build_url
-          path: build_url
+          name: ${{ inputs.suite }}-build-info
+          path: build-info-artifact/
       - name: Invoke test runner
         if: ${{ !inputs.skip_qemu_tests }}
         run: |

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -32,6 +32,9 @@ on:
       artifacts_url:
         description: "URL to retrieve build artifacts"
         value: ${{ jobs.build-debos.outputs.url }}
+      boards_json:
+        description: "JSON database of supported boards, with storage type and flash tarball"
+        value: ${{ jobs.build-debos.outputs.boards_json }}
 
 # implicitely set all other permissions to none
 permissions:
@@ -49,6 +52,7 @@ jobs:
     name: Build and upload debos recipes (${{ inputs.suite }})
     outputs:
       url: ${{ steps.upload_artifacts_s3.outputs.url }}
+      boards_json: ${{ steps.stage_artifacts.outputs.boards_json }}
     runs-on: [self-hosted, qcom-u2404, arm64]
     container:
       image: public.ecr.aws/debian/debian:trixie
@@ -144,6 +148,7 @@ jobs:
           make flash FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="-t u_boot_rb1:rb1-boot.img -t buildid:${BUILD_ID} --print-recipe ${DEBOS_EXTRA_ARGS}"
 
       - name: Stage debos artifacts for publishing
+        id: stage_artifacts
         run: |
           set -ux
           # create a directory for the current run
@@ -154,8 +159,16 @@ jobs:
           gzip -c disk-ufs.img >"${dir}/${PREFIX}-disk-ufs.img.gz"
           gzip -c disk-sdcard.img >"${dir}/${PREFIX}-disk-sdcard.img.gz"
           cp -av dtbs.tar.gz "${dir}/${PREFIX}-dtbs.tar.gz"
-          # create tarballs with support for all UFS and all eMMC boards
-          scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}"
+          # create tarballs with support for all UFS and all eMMC boards;
+          # also emit a boards database as JSON alongside the tarballs
+          scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}" "${dir}/${PREFIX}-boards.json"
+          # capture compact JSON for the step output before pretty-printing
+          boards_json=$(cat "${dir}/${PREFIX}-boards.json")
+          echo "boards_json=${boards_json}" >> "$GITHUB_OUTPUT"
+          # pretty-print with stdlib json.tool so humans can read the JSON
+          python3 -m json.tool "${dir}/${PREFIX}-boards.json" \
+              >"${dir}/${PREFIX}-boards.json.tmp"
+          mv "${dir}/${PREFIX}-boards.json.tmp" "${dir}/${PREFIX}-boards.json"
           # generate sha256sums for all artifacts
           (cd "${dir}" && sha256sum * | tee sha256sums.txt)
 

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -6,6 +6,11 @@ on:
       url:
         required: true
         type: string
+      boards_json:
+        description: "JSON database of supported boards; when set, only matching LAVA templates are submitted"
+        required: false
+        type: string
+        default: ''
       suite:
         description: Distribution suite (e.g. trixie, forky)
         type: string
@@ -40,22 +45,32 @@ jobs:
       - name: "List jobs"
         id: listjobs
         run: |
+          # when boards_json is provided, only submit jobs for boards that were built
+          BOARDS='${{ inputs.boards_json }}'
+          BOARDS="${BOARDS:-[]}"
           # json with display names and relative filenames to LAVA templates
           J=$(find "${LAVA_CI}" -name '*.yaml' -print0 |
-                  jq --compact-output --raw-input --slurp '
+                  jq --compact-output --raw-input --slurp --argjson built "$BOARDS" '
                       # split null-delimited list and remove last empty item
                       split("\u0000")[:-1]
                       # remove leading "ci/lava/"
                       | map(sub("^ci/lava/"; ""))
-                      # build include entries with target and pretty name
-                      | map({
-                          target: .,
-                          name: (
-                              .
-                              | sub("\\.yaml$"; "")
-                              | gsub("/"; " ")
-                          )
-                        })
+                      # filter to built boards and annotate with board metadata
+                      | map(
+                          . as $tpl
+                          | split("/")[0] as $board
+                          | ($built | map(select(.name == $board))) as $matches
+                          | if ($built | length) == 0 then
+                              { target: $tpl,
+                                name: ($tpl | sub("\\.yaml$"; "") | gsub("/"; " ")) }
+                            elif ($matches | length) > 0 then
+                              { target:        $tpl,
+                                name:          ($tpl | sub("\\.yaml$"; "") | gsub("/"; " ")),
+                                storage:       $matches[0].storage,
+                                flash_tarball: $matches[0].flash_tarball }
+                            else empty
+                            end
+                        )
                       # output as matrix.include list
                       | { include: . }
                       ')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -150,4 +150,5 @@ jobs:
     secrets: inherit
     with:
       url: ${{ needs.debos-linux-deb.outputs.artifacts_url }}
+      boards_json: ${{ needs.debos-linux-deb.outputs.boards_json }}
       suite: trixie

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,52 +18,79 @@ permissions:
   pull-requests: write
 
 jobs:
-  retrieve-build-url:
+  retrieve-build-info:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      url: ${{ steps.set-build-url.outputs.url }}
+      matrix: ${{ steps.collect.outputs.matrix }}
     steps:
-      - name: 'Download build URL'
+      - name: 'Download build-info artifacts'
         uses: actions/github-script@v9
         with:
           script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            const fs = require('fs');
+            const path = require('path');
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: context.payload.workflow_run.id,
             });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "build_url"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            const fs = require('fs');
-            const path = require('path');
+            const infoArtifacts = allArtifacts.data.artifacts.filter(
+              (a) => a.name.endsWith('-build-info')
+            );
             const temp = '${{ runner.temp }}/artifacts';
-            if (!fs.existsSync(temp)){
+            if (!fs.existsSync(temp)) {
               fs.mkdirSync(temp);
             }
-            fs.writeFileSync(path.join(temp, 'build_url.zip'), Buffer.from(download.data));
+            for (const a of infoArtifacts) {
+              const download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: a.id,
+                 archive_format: 'zip',
+              });
+              fs.writeFileSync(
+                path.join(temp, a.name + '.zip'),
+                Buffer.from(download.data)
+              );
+            }
 
-      - name: 'Setup build URL'
-        id: set-build-url
+      - name: 'Collect build-info into matrix'
+        id: collect
         run: |
-          unzip "${{ runner.temp }}/artifacts/build_url.zip"
-          BUILD_URL=$(cat build_url)
-          echo "Build URL: ${BUILD_URL}"
-          echo "url=${BUILD_URL}" >> $GITHUB_OUTPUT
+          set -eu -o pipefail
+          temp="${{ runner.temp }}/artifacts"
+          entries='[]'
+          for zip in "$temp"/*-build-info.zip; do
+            [ -f "$zip" ] || continue
+            name=$(basename "$zip" .zip)
+            suite=${name%-build-info}
+            mkdir -p "$temp/$suite"
+            unzip -o -d "$temp/$suite" "$zip"
+            url=$(cat "$temp/$suite/build-url.txt")
+            boards=$(cat "$temp/$suite/boards.json")
+            entries=$(jq -nc \
+                --argjson e "$entries" \
+                --arg s "$suite" \
+                --arg u "$url" \
+                --arg b "$boards" \
+                '$e + [{suite: $s, url: $u, boards_json: $b}]')
+          done
+          matrix=$(jq -nc --argjson i "$entries" '{include: $i}')
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   test:
+    needs: retrieve-build-info
+    if: ${{ needs.retrieve-build-info.outputs.matrix != '{"include":[]}' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.retrieve-build-info.outputs.matrix) }}
     uses: ./.github/workflows/lava-test.yml
     secrets: inherit
-    needs: retrieve-build-url
     with:
-      url: ${{ needs.retrieve-build-url.outputs.url }}
+      suite: ${{ matrix.suite }}
+      url: ${{ matrix.url }}
+      boards_json: ${{ matrix.boards_json }}
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/scripts/bundle-flash-dirs.sh
+++ b/scripts/bundle-flash-dirs.sh
@@ -6,11 +6,13 @@ set -eux
 
 output_dir=$1
 prefix=$2
+boards_json_file=${3:-}
 
 # use strings and word splitting as lists to construct output tarballs.
 # caveat is that flash_* directories cannot have spaces in them.
 emmc_dirs=""
 ufs_dirs=""
+boards_json_entries=""
 
 for d in flash_*
 do
@@ -32,6 +34,14 @@ do
 
     echo "choosen target $target for $d"
 
+    # extract board name and storage type from the flash dir name
+    # flash_${board_name}_${disk_type}: board names use hyphens only
+    dir_name="${d#flash_}"
+    disk_type="${dir_name##*_}"
+    board_name="${dir_name%_*}"
+    entry="{\"name\":\"${board_name}\",\"storage\":\"${disk_type}\",\"flash_tarball\":\"${prefix}-flash-${target}.tar.gz\"}"
+    boards_json_entries="${boards_json_entries:+${boards_json_entries},}${entry}"
+
     case "$target" in
         emmc)
             emmc_dirs="$emmc_dirs $d"
@@ -52,3 +62,7 @@ tar -cvzf "$output_dir/$prefix-flash-emmc.tar.gz" disk-sdcard.img1 disk-sdcard.i
 # word splitting is a feature in this case
 # shellcheck disable=SC2086
 tar -cvzf "$output_dir/$prefix-flash-ufs.tar.gz" disk-ufs.img1 disk-ufs.img2 $ufs_dirs
+
+if [ -n "$boards_json_file" ]; then
+    printf '[%s]\n' "$boards_json_entries" >"$boards_json_file"
+fi


### PR DESCRIPTION
Run LAVA on target boards and suites, as captured in build info:
- **scripts: bundle-flash-dirs: output boards.json**
- **ci: debos: generate and publish boards JSON**
- **ci: lava-test: filter matrix to supported boards**
- **ci: linux: pass boards_json to LAVA test job**
- **ci: build-daily: pass boards_json to LAVA test job**
- **ci: debos: add boards.json to per-suite build-info**
- **ci: test-pr: run LAVA tests per-suite**

Fixes: #387