### PR TITLE
Fixes for LAVA boards per workflow

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -35,3 +35,4 @@ jobs:
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
+      boards_exclude: '["glymur-crd"]'

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
+      has_jobs: ${{ steps.listjobs.outputs.has_jobs }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v6
@@ -83,10 +84,12 @@ jobs:
                       | { include: . }
                       ')
           echo "jobmatrix=$J" >> $GITHUB_OUTPUT
+          echo "has_jobs=$(echo "$J" | jq '.include | length > 0')" >> $GITHUB_OUTPUT
           echo "Preparing testjob files"
 
   submit-job:
     needs: prepare-job-list
+    if: needs.prepare-job-list.outputs.has_jobs == 'true'
     runs-on: ubuntu-latest
     name: Submit ${{ matrix.name }}
     strategy:

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -21,4 +21,5 @@ jobs:
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next prune.config qcom.config'
+      lava_boards_exclude: '["glymur-crd"]'
     secrets: inherit


### PR DESCRIPTION
A few fixes as a followup to #390:
- **ci: lava: skip matrix when no boards match filters**
- **ci: build-on-push: exclude glymur-crd from LAVA**
- **ci: qcom-next: exclude glymur-crd from LAVA**