### PR TITLE
fix(debos.yml): prefix sha256sums.txt files

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -157,7 +157,7 @@ jobs:
           # create tarballs with support for all UFS and all eMMC boards
           scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}"
           # generate sha256sums for all artifacts
-          (cd "${dir}" && sha256sum * | tee sha256sums.txt)
+          (cd "${dir}" && sha256sum * | tee "${PREFIX}-sha256sums.txt")
 
       # upload to a cloud storage space accessible by Axiom
       - name: Upload private artifacts (S3)


### PR DESCRIPTION
Now that the debos.yml workflow is called multiple times to test both Debian trixie and forky, concatenate the generated sha256sums.txt files instead of erasing them so all files are listed instead of the ones from the last running workflow.

Closes: #388

Created as a draft to verify the CI results.