### PR TITLE
feat(kernel-configs): add qcom-laptops config

### DIFF
--- a/kernel-configs/qcom-laptops.config
+++ b/kernel-configs/qcom-laptops.config
@@ -1,0 +1,3 @@
+# needed for M.2 pwrseq driver
+# https://lore.kernel.org/linux-pci/20260501164440.11788-1-manivannan.sadhasivam@oss.qualcomm.com/
+CONFIG_POWER_SEQUENCING_PCIE_M2=m


### PR DESCRIPTION
Fix T14s Gen6 not booting with upcoming M.2 changes which require a
new config not yet in defconfig.
