### PR TITLE
Update unique job name for linux-daily-glymur.yml to invoke coral Workflow with unique checkrun completion

### DIFF
--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write # linux.yml
 
 jobs:
-  build:
+  build-glymur:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml


### PR DESCRIPTION
Coral workflow invoke based on checkrun passed from Github https://qswat.qualcomm.com/coral/qli-open-development/workflows/Debian_CRM_Nightly_Test_Hyd/edit/triggers

Since linux-daily-glymur.yml & linux-daily-monza.yml are having same check runs , which is effecting Glymur nightly coral workflow to be initiated even for monza nightly completion , 

To avoid conflict from other workflows, making glymur workflow checkrun name as build-glymur