### PR TITLE
fix!(rootfs): use dracut for newer Debian suites

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -395,7 +395,11 @@ actions:
     recommends: true
     packages:
       - apparmor
+{{- if eq $suite "trixie" }}
       - initramfs-tools
+{{- else }}
+      - dracut
+{{- end }}
       - kmod
       - linux-base
 


### PR DESCRIPTION
Debian has migrated from initramfs-tools to dracut for forky. Update the kernel depedencies step to reflect this change as well.