### PR TITLE
ci: mainline: exclude glymur-crd from LAVA

### DIFF
--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -20,4 +20,5 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       kernel_name: mainline
+      lava_boards_exclude: '["glymur-crd"]'
     secrets: inherit


### PR DESCRIPTION
We currently don't flash boot firmware on glymur-crd, and the boot
firmware doesn't support DT FIT image anyway, so testing in LAVA is
not possible without forcing the DT or some stubble-like solution
which only the glymur daily build does. See #394.
