### PR TITLE
support to reproduce the build

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -154,6 +154,8 @@ jobs:
           gzip -c disk-ufs.img >"${dir}/${PREFIX}-disk-ufs.img.gz"
           gzip -c disk-sdcard.img >"${dir}/${PREFIX}-disk-sdcard.img.gz"
           cp -av dtbs.tar.gz "${dir}/${PREFIX}-dtbs.tar.gz"
+          # copy installed packages list
+          cp -av installed-packages.txt "${dir}/${PREFIX}-installed-packages.txt"
           # create tarballs with support for all UFS and all eMMC boards
           scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}"
           # generate sha256sums for all artifacts

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,34 @@ test: disk-ufs.img
 	# rootfs/ is a build artifact, so should not be scanned for tests
 	py.test-3 --ignore=rootfs
 
+# Reproduce an exact build from a previously captured installed-packages.txt.
+# APT packages are installed at their exact recorded versions; local/unknown
+# packages (e.g. a locally-built kernel) are installed from LOCALDEBS dir.
+#
+# Usage:
+#   make reproduce
+#   make reproduce PACKAGES_FILE=trixie-installed-packages.txt
+#   make reproduce PACKAGES_FILE=... SUITE=forky
+#   make reproduce LOCALDEBS=local-debs   # supply locally-built .deb files
+PACKAGES_FILE ?= installed-packages.txt
+SUITE         ?= trixie
+LOCALDEBS     ?= none
+
+# packagesfile is passed as a path relative to ARTIFACTDIR (the repo root).
+# localdebs overlay source is relative to the recipe dir (debos-recipes/), so
+# strip the leading debos-recipes/ prefix if the user supplies a repo-root path.
+# e.g. LOCALDEBS=debos-recipes/local-debs/ → overlay source: local-debs/
+_LOCALDEBS_REL := $(patsubst debos-recipes/%,%,$(LOCALDEBS))
+_LOCALDEBS_OPT := $(if $(filter-out none,$(LOCALDEBS)),-t localdebs:$(_LOCALDEBS_REL))
+
+.PHONY: reproduce
+reproduce: debos-recipes/qualcomm-linux-debian-reproduce.yaml $(PACKAGES_FILE)
+	$(DEBOS_CMD) \
+		-t packagesfile:$(PACKAGES_FILE) \
+		-t suite:$(SUITE) \
+		$(_LOCALDEBS_OPT) \
+		$<
+
 .PHONY: clean
 clean:
 	rm -f $(DISK_UFS_IMAGES)

--- a/debos-recipes/qualcomm-linux-debian-reproduce.yaml
+++ b/debos-recipes/qualcomm-linux-debian-reproduce.yaml
@@ -1,0 +1,126 @@
+{{- $packagesfile := or .packagesfile "installed-packages.txt" }}
+{{- $suite := or .suite "trixie" }}
+{{- $localdebs := or .localdebs "none" }}
+
+architecture: arm64
+
+actions:
+  - action: mmdebstrap
+    description: Bootstrap minimal base filesystem
+    suite: {{ $suite }}
+    components:
+      - main
+      - contrib
+      - non-free
+      - non-free-firmware
+    mirrors: ['http://deb.debian.org/debian']
+    variant: minbase
+    # ca-certificates needed for https APT sources; python3 needed for the
+    # pinned-install step below
+    include: [ca-certificates, python3]
+
+  - action: overlay
+    description: Install QSC APT keyring (needed for qsc-deb-releases repo)
+    source: overlays/qsc-deb-releases
+
+  - action: run
+    description: Parse packages list – write APT sources and install script into rootfs
+    chroot: false
+    command: |
+      set -eux
+      python3 -c "
+      import os
+      rootdir     = os.environ['ROOTDIR']
+      artifactdir = os.environ['ARTIFACTDIR']
+      pkgsfile    = os.path.join(artifactdir, '{{$packagesfile}}')
+      lines = [l.strip() for l in open(pkgsfile) if l.strip() and not l.startswith('#')]
+      pkgs, srcs, local_pkgs = {}, {}, []
+      for l in lines:
+          p = l.split('\t')
+          if len(p) < 3: continue
+          pkg, ver, src = p[0], p[1], p[2]
+          if src == 'local/unknown':
+              local_pkgs.append((pkg, ver)); continue
+          pkgs[pkg] = ver
+          parts = src.split()
+          if len(parts) >= 2:
+              url, f2 = parts[0], parts[1]
+              f3 = parts[2] if len(parts) > 2 else ''
+              suite, comp = f2.split('/', 1) if '/' in f2 else (f2, f3)
+              srcs[(url, suite, comp)] = True
+      import glob
+      srcdir = os.path.join(rootdir, 'etc/apt/sources.list.d')
+      os.makedirs(srcdir, exist_ok=True)
+      # Remove sources created by mmdebstrap to avoid Trusted: conflicts
+      for f in glob.glob(os.path.join(srcdir, '*.sources')) + \
+               glob.glob(os.path.join(srcdir, '*.list')) + \
+               [os.path.join(rootdir, 'etc/apt/sources.list')]:
+          if os.path.exists(f): os.remove(f)
+      def signed_by(url):
+          if 'deb.debian.org' in url:
+              return '/usr/share/keyrings/debian-archive-keyring.gpg'
+          if 'qartifactory' in url:
+              return '/etc/apt/keyrings/qsc-deb-releases.asc'
+          return ''
+      with open(os.path.join(srcdir, 'reproduced-build.sources'), 'w') as f:
+          for url, suite, comp in sorted(srcs):
+              sb = signed_by(url)
+              entry = 'Types: deb\nURIs: {}\nSuites: {}\nComponents: {}\n'.format(url, suite, comp)
+              if sb: entry += 'Signed-By: {}\n'.format(sb)
+              f.write(entry + '\n')
+      os.makedirs(os.path.join(rootdir, 'root'), exist_ok=True)
+      with open(os.path.join(rootdir, 'root/install-packages.sh'), 'w') as f:
+          f.write('#!/bin/sh\nset -eux\nexport DEBIAN_FRONTEND=noninteractive\napt-get -y update\n')
+          f.write('apt-get install -y --allow-downgrades --no-install-recommends')
+          for p, v in sorted(pkgs.items()):
+              f.write(' ' + p + '=' + v)
+          f.write('\n')
+      print('Wrote APT sources ({} repos) and install script ({} packages)'.format(len(srcs), len(pkgs)))
+      if local_pkgs:
+          print('NOTE: {} local/unknown package(s) skipped (supply via localdebs):'.format(len(local_pkgs)))
+          for p, v in local_pkgs: print('  {} {}'.format(p, v))
+      "
+
+  - action: run
+    description: Install exact pinned packages from APT sources
+    chroot: true
+    command: |
+      set -eux
+      bash /root/install-packages.sh
+      rm -f /root/install-packages.sh
+
+{{- if ne $localdebs "none" }}
+  - action: overlay
+    description: Overlay local debs directory {{ $localdebs }} to /root/
+    source: {{ $localdebs }}
+    destination: /root/
+
+  - action: run
+    description: Install local debs from /root/ (e.g. locally-built kernel)
+    chroot: true
+    command: |
+      set -eux
+      apt-get -y install /root/*.deb
+      rm -vf /root/*.deb
+{{- end }}
+
+  - action: run
+    description: Create DTBs tarball
+    chroot: false
+    command: |
+      set -eux
+      kernel_dirs=$(ls -d "$ROOTDIR"/usr/lib/linux-image-*)
+      latest_kernel=$(echo "$kernel_dirs" | sort -V | tail -1)
+      tar \
+          -C "${latest_kernel}" \
+          --transform='s|^\./||' \
+          -cvzf "$ARTIFACTDIR/dtbs.tar.gz" \
+          .
+
+  - action: pack
+    description: Create reproduced root filesystem tarball
+    file: rootfs.tar
+    compression: none
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -473,6 +473,36 @@ actions:
           -cvzf "$ARTIFACTDIR/dtbs.tar.gz" \
           .
 
+  - action: run
+    description: Generate installed packages list with versions and APT sources
+    chroot: true
+    command: |
+      set -eux
+      dpkg-query -W --showformat='${Package}\t${Version}\n' | sort > /tmp/pkgs.txt
+      python3 -c "
+      import re, subprocess
+      pkgs = dict(l.split('\t',1) for l in open('/tmp/pkgs.txt').read().splitlines() if '\t' in l)
+      pol = subprocess.run(['apt-cache','policy']+sorted(pkgs), capture_output=True, text=True).stdout
+      src, cur, star = {}, None, False
+      for l in pol.splitlines():
+          m = re.match(r'^(\S+):$', l)
+          if m: cur, star = m.group(1), False
+          elif re.match(r'^\s+[*]{3}', l): star = True
+          elif star:
+              m = re.match(r'^\s+\d+\s+(https?://\S+|file:\S+)\s+(\S+)\s+(\S+)', l)
+              if m: src[cur] = '{} {} {}'.format(*m.groups())
+              star = False
+      open('/installed-packages.txt','w').write(
+          '# Package\tVersion\tAPT Source\n' +
+          ''.join('{}\t{}\t{}\n'.format(p, pkgs[p], src.get(p,'local/unknown')) for p in sorted(pkgs)))
+      print('Total packages:', len(pkgs))
+      "
+
+  - action: run
+    description: Copy installed packages list to artifact directory
+    chroot: false
+    command: cp -v "${ROOTDIR}/installed-packages.txt" "${ARTIFACTDIR}/installed-packages.txt"
+
   - action: pack
     description: Create root filesystem tarball
     file: rootfs.tar


### PR DESCRIPTION

Record every installed package, its version, and APT source repo in
installed-packages.txt at the end of each debos rootfs build.  The
file is copied to ARTIFACTDIR and staged alongside other artifacts
in the GitHub Actions workflow.

ex: installed-packages.txt
openssl-provider-legacy 3.5.5-1~deb13u2 http://deb.debian.org/debian-security trixie-security/main arm64
pinentry-curses 1.3.1-2 http://deb.debian.org/debian trixie/main arm64
pipewire        1.4.2-1~qcom1   https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases trixie-overlay/main arm64

Add debos-recipes/qualcomm-linux-debian-reproduce.yaml and a
Makefile `reproduce` target that consume installed-packages.txt to
rebuild an identical rootfs:

- Parse the file outside the chroot (chroot: false) to reconstruct
  the exact APT sources and generate /root/install-packages.sh with
  every package pinned to its recorded version.
- Run the install script inside the chroot (chroot: true) with
  DEBIAN_FRONTEND=noninteractive to avoid interactive prompts.
- Accept locally-built .deb files (e.g. a custom kernel) via the
  LOCALDEBS variable, mirroring the rootfs recipe's localdebs path.


Usage:
  make rootfs   // would create installed-packages.txt and when run in ci it will also be uploaded

// to reproduce one can use qualcomm-linux-debian-reproduce.yaml , it recreates same outputs as qualcomm-linux-debian-rootfs.yaml (except installed-packages.txt since its reproduce)

  make reproduce
  make reproduce PACKAGES_FILE=installed-packages.txt
  make reproduce LOCALDEBS=debos-recipes/local-debs/

