### PR TITLE
fix(rootfs): rename sid to unstable

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -11,6 +11,11 @@
 {{- $variantid = "xfce" }}
 {{- end }}
 
+# Rename sid to unstable to reduce if/else complexity
+{{- if eq $suite "sid" }}
+{{- $suite = "unstable" }}
+{{- end }}
+
 architecture: arm64
 
 actions:
@@ -65,7 +70,7 @@ actions:
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
-{{- if and (ne $suite "unstable") (ne $suite "sid") }}
+{{- if ne $suite "unstable" }}
 
       # Debian stable updates
       Types: deb
@@ -83,7 +88,7 @@ actions:
 {{- end }}
       EOF
 
-{{- if and (ne $suite "unstable") (ne $suite "sid") (ne $suite "testing") }}
+{{- if and (ne $suite "unstable") (ne $suite "testing") }}
   - action: run
     description: Add Debian {{ $suite }}-backports APT configuration
     chroot: true
@@ -117,7 +122,7 @@ actions:
 {{- end }}
 
 # QArtifactory is missing a Release file for some suites.
-{{- if and (ne $suite "sid") (ne $suite "testing") (ne $suite "forky") }}
+{{- if and (ne $suite "testing") (ne $suite "forky") }}
   # The qsc-deb-releases overlay only ships the keyring (.asc); generate the
   # .sources and .pref files dynamically to use the correct $suite-overlay
   - action: run


### PR DESCRIPTION
This allows to reduce the if/else complexity and potential for error if one checks only for one or the other but not both.

This change also allows to drop the QArtifactory overlay handling that did have support for "unstable" but not for "sid", which could lead to unexpected results.