### PR TITLE
qualcomm-linux-debian-flash: update boot to 00123

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -49,10 +49,10 @@ actions:
     "ptool_platforms" (list "qcs615-ride/ufs")
     "boot_binaries_download" (dict
         "description" "QCS615 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCS615.LE.1.0/common/build/common/bin/QCS615_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS615_bootbinaries.1.0/qcs615_bootbinaries.1.0-test-device-public/00123/QCS615_bootbinaries.zip"
         "name" "qcs615_boot-binaries"
         "filename" "qcs615_boot-binaries.zip"
-        "sha256sum" "6730c26235880f469075acb62115c9e1e566979d1bf12f4a4c4ecf590c1d357e"
+        "sha256sum" "9693a9d6ceeb8ecd47f6d8f7a4e28180602973d7d47da77673023a6fa7ad5789"
     )
     "cdt_download" (dict
         "description" "QCS615 Ride CDT"
@@ -72,10 +72,10 @@ actions:
     "ptool_platforms" (list "qcs6490-rb3gen2/ufs")
     "boot_binaries_download" (dict
         "description" "QCM6490 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCM6490.LE.1.0/common/build/ufs/bin/QCM6490_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCM6490_bootbinaries.1.0/qcm6490_bootbinaries.1.0-test-device-public/00123/QCM6490_bootbinaries.zip"
         "name" "qcm6490_boot-binaries"
         "filename" "qcm6490_boot-binaries.zip"
-        "sha256sum" "754598969a7ef6b2df448fb64d4d6b762415e8a8ea3c2a202c9a0e98a930f432"
+        "sha256sum" "df120b750128166c9f8f9ad28c7ecd30d3938c2750a250f2a12362757dc416b0"
     )
     "cdt_download" (dict
         "description" "RB3 Gen2 Vision Kit CDT"
@@ -95,10 +95,10 @@ actions:
     "ptool_platforms" (list "qcs8300-ride-sx/ufs")
     "boot_binaries_download" (dict
         "description" "QCS8300 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCS8300.LE.1.0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS8300_bootbinaries.1.0/qcs8300_bootbinaries.1.0-test-device-public/00123/QCS8300_bootbinaries.zip"
         "name" "qcs8300_boot-binaries"
         "filename" "qcs8300_boot-binaries.zip"
-        "sha256sum" "e07ed2b58c639373e22c289873f1059a4ba48cfe41bd9ae2f9651884177b60c9"
+        "sha256sum" "a0fca33863d5a665535717aa943d668d3ffa9e2970bbc10e7e5d04d9269a1b1f"
     )
     "cdt_download" (dict
         "description" "QCS8300 Ride SX EVK CDT"
@@ -116,10 +116,10 @@ actions:
     "ptool_platforms" (list "iq-8275-evk/emmc" "iq-8275-evk/ufs")
     "boot_binaries_download" (dict
         "description" "QCS8300 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCS8300.LE.1.0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS8300_bootbinaries.1.0/qcs8300_bootbinaries.1.0-test-device-public/00123/QCS8300_bootbinaries.zip"
         "name" "qcs8300_boot-binaries"
         "filename" "qcs8300_boot-binaries.zip"
-        "sha256sum" "e07ed2b58c639373e22c289873f1059a4ba48cfe41bd9ae2f9651884177b60c9"
+        "sha256sum" "a0fca33863d5a665535717aa943d668d3ffa9e2970bbc10e7e5d04d9269a1b1f"
     )
     "cdt_download" (dict
         "description" "IQ-8275 EVK CDT"
@@ -137,10 +137,10 @@ actions:
     "ptool_platforms" (list "qcs8275-monza/emmc")
     "boot_binaries_download" (dict
         "description" "QCS8300 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCS8300.LE.1.0/common/build/ufs/bin/QCS8300_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS8300_bootbinaries.1.0/qcs8300_bootbinaries.1.0-test-device-public/00123/QCS8300_bootbinaries.zip"
         "name" "qcs8300_boot-binaries"
         "filename" "qcs8300_boot-binaries.zip"
-        "sha256sum" "e07ed2b58c639373e22c289873f1059a4ba48cfe41bd9ae2f9651884177b60c9"
+        "sha256sum" "a0fca33863d5a665535717aa943d668d3ffa9e2970bbc10e7e5d04d9269a1b1f"
     )
     "cdt_download" (dict
         "description" "Monza CDT"
@@ -160,10 +160,10 @@ actions:
     "ptool_platforms" (list "qcs9100-ride-sx/ufs")
     "boot_binaries_download" (dict
         "description" "QCS9100 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCS9100.LE.1.0/common/build/ufs/bin/QCS9100_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS9100_bootbinaries.1.0/qcs9100_bootbinaries.1.0-test-device-public/00123/QCS9100_bootbinaries.zip"
         "name" "qcs9100_boot-binaries"
         "filename" "qcs9100_boot-binaries.zip"
-        "sha256sum" "df1b928a25f428f4c76a760be8a094104cec75cd5a6f758d9e3c62ad9be71c0c"
+        "sha256sum" "74bc46555034173a4d5282fe96b1e96e0874cfd7f874f4483d431eaa72300345"
     )
     "cdt_download" (dict
         "description" "QCS9100 Ride Rev3 EVK CDT"
@@ -181,10 +181,10 @@ actions:
     "ptool_platforms" (list "iq-9075-evk/ufs")
     "boot_binaries_download" (dict
         "description" "QCS9100 boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/software-product-family/Qualcomm_Linux.SPF.1.0/qualcomm_linux.spf.1.0-test-device-public/r1.0_00118.0/QCS9100.LE.1.0/common/build/ufs/bin/QCS9100_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QCS9100_bootbinaries.1.0/qcs9100_bootbinaries.1.0-test-device-public/00123/QCS9100_bootbinaries.zip"
         "name" "qcs9100_boot-binaries"
         "filename" "qcs9100_boot-binaries.zip"
-        "sha256sum" "df1b928a25f428f4c76a760be8a094104cec75cd5a6f758d9e3c62ad9be71c0c"
+        "sha256sum" "74bc46555034173a4d5282fe96b1e96e0874cfd7f874f4483d431eaa72300345"
     )
     "cdt_download" (dict
         "description" "QCS9100 RB8 Core Kit CDT"


### PR DESCRIPTION
Tech pack based release path and versioning is for SPF agnostic paths across QLI targets. This enabled SP level versioning of boot bins.

Known fixes:

QCS9100
fix(spi): improve AC policy logic and ensure operations stay within timing and access constraints to prevent faults
feat(can): add support for CAN channel 0
fix(sbl): prevent unauthorized privilege escalation during boot fix(tee): resolve random app crashes in concurrent secure sessions

QCS8300
fix(spi): improve AC policy logic and ensure operations stay within timing and access constraints to prevent faults feat(can): add support for CAN channel 0
feat(kvm): enable KVM PIL Auth & Reset
feat(dsp): enable DSP start and stop via remoteproc in Gunyah/KVM fix(sbl): prevent unauthorized privilege escalation during boot fix(tee): resolve random app crashes in concurrent secure sessions

QCS615
feat(kvm): enable KVM PIL Auth & Reset
feat(dsp): enable DSP start and stop via remoteproc in Gunyah/KVM fix(sbl): prevent unauthorized privilege escalation during boot fix(tee): resolve random app crashes in concurrent secure sessions fix(camera): resolve firmware download failure causing camera test failures

QCM6490
fix(sbl): prevent unauthorized privilege escalation during boot fix(tee): resolve random app crashes in concurrent secure sessions