### PR TITLE
rootfs: Remove adbd package

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -164,8 +164,6 @@ actions:
     description: Install foundational packages
     recommends: true
     packages:
-      # Android Debug Bridge (daemon)
-      - adbd
       # bluetooth
       - bluez
       # vfat tools, notably fsck.fat for the ESP


### PR DESCRIPTION
For qcom debian distributed targets, SSH is only recommended to use for testing and also For Glymur compute, ADB is not PORed. 

removing adbd package from rootfs , as it is leading to axiom usb device identifier failures.