### PR TITLE
ci: add rb4/monaco/iq-8275-evk job template

### DIFF
--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -78,8 +78,6 @@ job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEM
 metadata:
   build-commit: '{{GITHUB_SHA}}'
 priority: 50
-tags:
-- cambridge-lab
 timeouts:
   job:
     minutes: 210

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -1,0 +1,86 @@
+actions:
+- deploy:
+    images:
+      image:
+        headers:
+          Authorization: Q_S3_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
+    postprocess:
+      docker:
+        image: ghcr.io/foundriesio/lava-lmp-sign:main
+        steps:
+        - export IMAGE_PATH=$PWD
+        - cp overlay*.tar.gz overlay.tar.gz
+        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-monaco-evk" >> $IMAGE_PATH/flash.settings
+        - cat $IMAGE_PATH/flash.settings
+    timeout:
+      minutes: 200
+    to: downloads
+- deploy:
+    images:
+      image:
+        url: downloads://{{SUITE}}-flash-ufs.tar.gz
+      settings:
+        url: downloads://flash.settings
+      overlay:
+        url: downloads://overlay.tar.gz
+    timeout:
+      minutes: 20
+    to: flasher
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
+      - sudo su
+    method: minimal
+    prompts:
+    - root@debian
+    - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
+    timeout:
+      minutes: 3
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - from: git
+      name: "smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a"
+    - from: git
+      name: "wlan-smoke-test"
+      path: automated/linux/wlan-smoke/wlan-smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        WAIT_TIME: 60
+- command:
+    name: network_turn_on
+context:
+  lava_test_results_dir: /home/lava-%s
+  test_character_delay: 10
+device_type: monaco-evk 
+job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+tags:
+- cambridge-lab
+timeouts:
+  job:
+    minutes: 210
+visibility: public


### PR DESCRIPTION
Add LAVA test job for 'monaco'. The job only does minimal flashing and boot test.