### PR TITLE
ci: add '_ufs' suffix to monaco-evk DEVICE_TYPE

### DIFF
--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -14,7 +14,7 @@ actions:
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
         - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-monaco-evk" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-monaco-evk_ufs" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
       minutes: 200


### PR DESCRIPTION
This should fix `/usr/local/bin/flash-universal.sh: line 228: cd: flash_monaco-evk: No such file or directory` errors.