### PR TITLE
fix(ci): build-on-pr: drop lava-tests.yml perms

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -5,10 +5,7 @@ on:
 
 # implicitely set all other permissions to none
 permissions:
-  checks: write # lava-test.yml
-  contents: read # debos.yml lava-schema-check.yml lava-test.yml
-  packages: read # lava-test.yml
-  pull-requests: write # lava-test.yml
+  contents: read # debos.yml lava-schema-check.yml
 
 jobs:
   event-file:


### PR DESCRIPTION
Other build-* workflows include lava-test.yml, but not build-on-pr.
Drop corresponding permissions.
