### PR TITLE
chore(ci): exclude monaco-evk from various wfs

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -39,4 +39,4 @@ jobs:
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
-      boards_exclude: '["glymur-crd"]'
+      boards_exclude: '["glymur-crd", "monaco-evk"]'

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -28,4 +28,4 @@ jobs:
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
-      boards_exclude: '["glymur-crd"]'
+      boards_exclude: '["glymur-crd", "monaco-evk"]'

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -21,5 +21,5 @@ jobs:
     with:
       kernel_name: linux-next
       build_linux_deb_extra_args: '--linux-next'
-      lava_boards_exclude: '["glymur-crd"]'
+      lava_boards_exclude: '["glymur-crd", "monaco-evk"]'
     secrets: inherit

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -21,5 +21,5 @@ jobs:
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next prune.config qcom.config'
-      lava_boards_exclude: '["glymur-crd"]'
+      lava_boards_exclude: '["glymur-crd", "monaco-evk"]'
     secrets: inherit

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -20,5 +20,5 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       kernel_name: mainline
-      lava_boards_exclude: '["glymur-crd"]'
+      lava_boards_exclude: '["glymur-crd", "monaco-evk"]'
     secrets: inherit

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -64,7 +64,7 @@ jobs:
     needs: retrieve-build-url
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}
-      boards_exclude: '["glymur-crd"]'
+      boards_exclude: '["glymur-crd", "monaco-evk"]'
 
   publish-test-results:
     name: "Publish Tests Results"


### PR DESCRIPTION
monaco-evk / RB4 currently fails to boot with a number of kernels,
preventing proper test reporting for other reference platforms.
Disable LAVA testing of this board for most workflows except the
daily monza build which also targets Monaco.
