### PR TITLE
rootfs: snapshot based enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
   `Debian’s linux-image-arm64`. Can (and should) be set to `none` if you are
   providing local kernel package instead.
 - `suite`: Debian suite to use, defaults to `trixie`.
+- `snapshot`: use a Debian snapshot archive for a reproducible build (`YYYYMMDD`
+  or `YYYYMMDDTHHMMSSZ`); logged to `/etc/buildinfo` as `SNAPSHOT=<date>`.
+  Live mirrors are restored in the final image to allow upgrades.
 
 For the image recipe:
 

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -2,6 +2,7 @@
 {{- $imagesize := or .imagesize "6GiB" }}
 {{- $imagetype := or .imagetype "ufs" }}
 {{- $image := printf "disk-%s.img" $imagetype }}
+{{- $snapshot := or .snapshot "" }}
 
 architecture: arm64
 sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
@@ -77,6 +78,16 @@ actions:
     setup-fstab: true
     append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30
 
+{{- if $snapshot }}
+  - action: run
+    description: Enable snapshot sources for image build
+    chroot: true
+    command: |
+      set -eux
+      apt-snapshot-toggle enable
+      apt-get update
+{{- end }}
+
   - action: apt
     description: Make system bootable with systemd-boot
     recommends: true
@@ -140,6 +151,17 @@ actions:
       EOF
       # enable unit
       systemctl enable debos-grow-rootfs
+
+{{- if $snapshot }}
+  - action: run
+    description: Restore APT sources to live mirrors and clean up snapshot helpers
+    chroot: true
+    command: |
+      set -eux
+      apt-snapshot-toggle disable
+      rm -f /etc/apt/sources.list.d/snapshot_*.sources
+      rm -f /usr/local/bin/apt-snapshot-toggle
+{{- end }}
 
   - action: run
     description: Extract partition images

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -5,6 +5,7 @@
 {{- $kernelpackage := or .kernelpackage "linux-image-arm64" }}
 {{- $overlays := or .overlays "qsc-deb-releases" }}
 {{- $buildid := or .buildid "" }}
+{{- $snapshot := or .snapshot "" }}
 {{- $suite := or .suite "trixie" }}
 
 {{- $variantid := "console" }}
@@ -57,6 +58,30 @@ actions:
       EOF
 {{- end }}
 
+{{- if $snapshot }}
+  - action: run
+    description: Install apt-snapshot-toggle into rootfs
+    chroot: false
+    command: |
+      set -eux
+      cat > "${ROOTDIR}/usr/local/bin/apt-snapshot-toggle" <<'TOGGLE'
+      #!/bin/sh
+      mode="$1"
+      for f in /etc/apt/sources.list.d/*.sources; do
+          case "$f" in
+            */snapshot_*) want=$([ "$mode" = "enable" ] && echo yes || echo no) ;;
+            *)             want=$([ "$mode" = "enable" ] && echo no  || echo yes) ;;
+          esac
+          if ! grep -q "^Enabled:" "$f"; then
+              echo "Warning: no Enabled: field in ${f}" >&2
+          else
+              sed -i "s/^Enabled:.*/Enabled: ${want}/" "$f"
+          fi
+      done
+      TOGGLE
+      chmod +x "${ROOTDIR}/usr/local/bin/apt-snapshot-toggle"
+{{- end }}
+
   # after debootstrap, only a basic etc/apt/sources.list is created; add more
   # modern etc/apt/sources.list.d/*.sources; sources.list is removed after
   # applying all overlays, and followed by an APT update and full-upgrade
@@ -65,6 +90,16 @@ actions:
     chroot: true
     command: |
       set -eux
+{{- if $snapshot }}
+      if echo "{{ $snapshot }}" | grep -qE '^([0-9]{8}|[0-9]{8}T[0-9]{6}Z)$'; then
+        SNAPSHOT="{{ $snapshot }}"
+      else
+        echo "ERROR: invalid snapshot '{{ $snapshot }}'. Use: YYYYMMDD | YYYYMMDDTHHMMSSZ" >&2
+        exit 1
+      fi
+      touch /etc/buildinfo && chmod 644 /etc/buildinfo
+      echo "SNAPSHOT=${SNAPSHOT}" >> /etc/buildinfo
+{{- end }}
       tee /etc/apt/sources.list.d/debian.sources <<EOF
       # Debian archive
       Types: deb
@@ -72,6 +107,7 @@ actions:
       Suites: {{ $suite }}
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
 
 {{- if ne $suite "unstable" }}
 
@@ -81,6 +117,7 @@ actions:
       Suites: {{ $suite }}-updates
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
 
       # Debian security updates
       Types: deb
@@ -88,8 +125,21 @@ actions:
       Suites: {{ $suite }}-security
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
 {{- end }}
       EOF
+
+{{- if $snapshot }}
+      # Derive snapshot_debian.sources from debian.sources by rewriting mirror URLs
+      sed \
+        -e "s#http://deb\.debian\.org/debian/#https://snapshot.debian.org/archive/debian/${SNAPSHOT}/#g" \
+        -e "s#http://deb\.debian\.org/debian-security/#https://snapshot.debian.org/archive/debian-security/${SNAPSHOT}/#g" \
+        -e "/^Enabled:/a\\# TODO: remove Check-Valid-Until once Debusine-based snapshots are available" \
+        -e "/^Enabled:/a\\Check-Valid-Until: no" \
+        /etc/apt/sources.list.d/debian.sources \
+        > /etc/apt/sources.list.d/snapshot_debian.sources
+      apt-snapshot-toggle enable
+{{- end }}
 
 {{- if and (ne $suite "unstable") (ne $suite "testing") }}
   - action: run
@@ -97,6 +147,9 @@ actions:
     chroot: true
     command: |
       set -eux
+{{- if $snapshot }}
+      SNAPSHOT=$(grep '^SNAPSHOT=' /etc/buildinfo | cut -d= -f2)
+{{- end }}
       tee /etc/apt/sources.list.d/debian-backports.sources <<EOF
       # Debian backports
       Types: deb
@@ -106,6 +159,18 @@ actions:
       Enabled: yes
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
       EOF
+
+{{- if $snapshot }}
+      # Derive snapshot_debian-backports.sources from debian-backports.sources by rewriting mirror URLs
+      sed \
+        -e "s#http://deb\.debian\.org/debian/#https://snapshot.debian.org/archive/debian/${SNAPSHOT}/#g" \
+        -e "s#http://deb\.debian\.org/debian\$#https://snapshot.debian.org/archive/debian/${SNAPSHOT}/#" \
+        -e "/^Enabled:/a\\# TODO: remove Check-Valid-Until once Debusine-based snapshots are available" \
+        -e "/^Enabled:/a\\Check-Valid-Until: no" \
+        /etc/apt/sources.list.d/debian-backports.sources \
+        > /etc/apt/sources.list.d/snapshot_debian-backports.sources
+      apt-snapshot-toggle enable
+{{- end }}
       tee /etc/apt/preferences.d/debian-backports.pref <<EOF
       # for binary packages built from these source packages, score the version from
       # Debian backports higher as to get hardware enabled or better hardware support
@@ -164,6 +229,15 @@ actions:
       set -eux
       # remove old style, incomplete sources, superseded in apt-sources overlay
       rm -vf /etc/apt/sources.list
+{{- if $snapshot }}
+      SNAPSHOT=$(grep '^SNAPSHOT=' /etc/buildinfo | cut -d= -f2)
+      for f in /etc/apt/sources.list.d/*.sources; do
+          case "$f" in */snapshot_*) continue ;; esac
+          if grep -q "^Enabled: yes" "$f"; then
+              echo "Warning: $(basename "$f" .sources) has no snapshot support; packages from this source will be the latest available" >&2
+          fi
+      done
+{{- end }}
       # APT update and upgrade to pickup changes from overlays
       apt-get -y update
       apt-get -y full-upgrade
@@ -562,6 +636,15 @@ actions:
       set -eux
       rm -v /etc/apt/sources.list.d/apt-local-repo.sources
       apt-get update
+{{- end }}
+
+{{- if $snapshot }}
+  - action: run
+    description: Restore APT sources to live mirrors
+    chroot: true
+    command: |
+      set -eux
+      apt-snapshot-toggle disable
 {{- end }}
 
   - action: run


### PR DESCRIPTION
enable snapshot based build
build with -t snapshot can take true/date/snapshot-id