### PR TITLE
ci: skip RB1 boot tests on forky

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -39,4 +39,5 @@ jobs:
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
-      boards_exclude: '["glymur-crd"]'
+      # qrb2210-rb1 can't boot forky pending a newer kernel; see #424
+      boards_exclude: ${{ (matrix.suite == 'forky' && '["qrb2210-rb1"]') || '["glymur-crd"]' }}


### PR DESCRIPTION
forky's kernel doesn't yet have the configs needed for RB1 to boot.
Make boards_exclude in build-daily.yml's test matrix conditional on
the suite so qrb2210-rb1 is skipped only on forky; trixie testing is
unaffected.

Refs: #424
