### PR TITLE
rootfs: add snapshot build support via Debian snapshot APT

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
   `Debian’s linux-image-arm64`. Can (and should) be set to `none` if you are
   providing local kernel package instead.
 - `suite`: Debian suite to use, defaults to `trixie`.
+- `snapshot`: pin all apt sources to a Debian snapshot for a reproducible
+  build. Accepts `true` (today's date), `YYYYMMDD`, or `YYYYMMDDTHHMMSSz`.
+  Sources are restored to live mirrors after the build; the date is logged to
+  `/etc/buildinfo`.
 
 For the image recipe:
 

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -2,6 +2,7 @@
 {{- $imagesize := or .imagesize "6GiB" }}
 {{- $imagetype := or .imagetype "ufs" }}
 {{- $image := printf "disk-%s.img" $imagetype }}
+{{- $snapshot := or .snapshot "" }}
 
 architecture: arm64
 sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
@@ -77,6 +78,22 @@ actions:
     setup-fstab: true
     append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30
 
+{{- if $snapshot }}
+  - action: run
+    description: Enable snapshot sources for image build
+    chroot: true
+    command: |
+      set -eux
+      # snapshot-debian.sources already has Enabled: no — flip to yes
+      sed -i 's/Enabled: no/Enabled: yes/' /etc/apt/sources.list.d/snapshot-debian.sources
+      sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/debian.sources
+      [ -f /etc/apt/sources.list.d/snapshot-debian-backports.sources ] && \
+          sed -i 's/Enabled: no/Enabled: yes/' /etc/apt/sources.list.d/snapshot-debian-backports.sources || true
+      [ -f /etc/apt/sources.list.d/debian-backports.sources ] && \
+          sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/debian-backports.sources || true
+      apt-get update
+{{- end }}
+
   - action: apt
     description: Make system bootable with systemd-boot
     recommends: true
@@ -140,6 +157,20 @@ actions:
       EOF
       # enable unit
       systemctl enable debos-grow-rootfs
+
+{{- if $snapshot }}
+  - action: run
+    description: Restore APT sources to live mirrors
+    chroot: true
+    command: |
+      set -eux
+      sed -i 's/Enabled: no/Enabled: yes/' /etc/apt/sources.list.d/debian.sources
+      sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/snapshot-debian.sources
+      [ -f /etc/apt/sources.list.d/debian-backports.sources ] && \
+          sed -i 's/Enabled: no/Enabled: yes/' /etc/apt/sources.list.d/debian-backports.sources || true
+      [ -f /etc/apt/sources.list.d/snapshot-debian-backports.sources ] && \
+          sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/snapshot-debian-backports.sources || true
+{{- end }}
 
   - action: run
     description: Extract partition images

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -5,6 +5,7 @@
 {{- $kernelpackage := or .kernelpackage "linux-image-arm64" }}
 {{- $overlays := or .overlays "qsc-deb-releases" }}
 {{- $buildid := or .buildid "" }}
+{{- $snapshot := or .snapshot "" }}
 {{- $suite := or .suite "trixie" }}
 
 {{- $variantid := "console" }}
@@ -65,6 +66,17 @@ actions:
     chroot: true
     command: |
       set -eux
+{{- if $snapshot }}
+      if [ "{{ $snapshot }}" = "today" ]; then
+        SNAPSHOT_DATE=$(date -u +%Y%m%dT%H%M%SZ)
+      elif echo "{{ $snapshot }}" | grep -qE '^([0-9]{8}|[0-9]{8}T[0-9]{6}Z)$'; then
+        SNAPSHOT_DATE="{{ $snapshot }}"
+      else
+        echo "ERROR: invalid snapshot '{{ $snapshot }}'. Use: today | YYYYMMDD | YYYYMMDDTHHMMSSz"; exit 1
+      fi
+      touch /etc/buildinfo && chmod 644 /etc/buildinfo
+      echo "SNAPSHOT=${SNAPSHOT_DATE}" >> /etc/buildinfo
+{{- end }}
       tee /etc/apt/sources.list.d/debian.sources <<EOF
       # Debian archive
       Types: deb
@@ -72,6 +84,7 @@ actions:
       Suites: {{ $suite }}
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
 
 {{- if ne $suite "unstable" }}
 
@@ -81,6 +94,7 @@ actions:
       Suites: {{ $suite }}-updates
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
 
       # Debian security updates
       Types: deb
@@ -88,8 +102,43 @@ actions:
       Suites: {{ $suite }}-security
       Components: main contrib non-free non-free-firmware
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
 {{- end }}
       EOF
+
+{{- if $snapshot }}
+      # Disable regular sources so snapshot sources take over
+      sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/debian.sources
+      # Snapshot sources — Enabled: yes; Check-Valid-Until scoped to this file
+      tee /etc/apt/sources.list.d/snapshot-debian.sources <<EOF
+      Types: deb
+      URIs: http://snapshot.debian.org/archive/debian/${SNAPSHOT_DATE}/
+      Suites: {{ $suite }}
+      Components: main contrib non-free non-free-firmware
+      Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
+      Check-Valid-Until: no
+
+{{- if ne $suite "unstable" }}
+
+      Types: deb
+      URIs: http://snapshot.debian.org/archive/debian/${SNAPSHOT_DATE}/
+      Suites: {{ $suite }}-updates
+      Components: main contrib non-free non-free-firmware
+      Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
+      Check-Valid-Until: no
+
+      Types: deb
+      URIs: http://snapshot.debian.org/archive/debian-security/${SNAPSHOT_DATE}/
+      Suites: {{ $suite }}-security
+      Components: main contrib non-free non-free-firmware
+      Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      Enabled: yes
+      Check-Valid-Until: no
+{{- end }}
+      EOF
+{{- end }}
 
 {{- if and (ne $suite "unstable") (ne $suite "testing") }}
   - action: run
@@ -97,6 +146,9 @@ actions:
     chroot: true
     command: |
       set -eux
+{{- if $snapshot }}
+      SNAPSHOT_DATE=$(grep '^SNAPSHOT=' /etc/buildinfo | cut -d= -f2)
+{{- end }}
       tee /etc/apt/sources.list.d/debian-backports.sources <<EOF
       # Debian backports
       Types: deb
@@ -106,6 +158,21 @@ actions:
       Enabled: yes
       Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
       EOF
+
+{{- if $snapshot }}
+      # Disable regular backports so snapshot backports take over
+      sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/debian-backports.sources
+      # Snapshot backports — Enabled: yes; Check-Valid-Until scoped to this file
+      tee /etc/apt/sources.list.d/snapshot-debian-backports.sources <<EOF
+      Types: deb
+      URIs: http://snapshot.debian.org/archive/debian/${SNAPSHOT_DATE}/
+      Suites: {{ $suite }}-backports
+      Components: main contrib non-free non-free-firmware
+      Enabled: yes
+      Check-Valid-Until: no
+      Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+      EOF
+{{- end }}
       tee /etc/apt/preferences.d/debian-backports.pref <<EOF
       # for binary packages built from these source packages, score the version from
       # Debian backports higher as to get hardware enabled or better hardware support
@@ -562,6 +629,22 @@ actions:
       set -eux
       rm -v /etc/apt/sources.list.d/apt-local-repo.sources
       apt-get update
+{{- end }}
+
+{{- if $snapshot }}
+  - action: run
+    description: Restore APT sources to live mirrors
+    chroot: true
+    command: |
+      set -eux
+      # Re-enable regular sources, disable snapshot sources via Enabled: toggle
+      sed -i 's/Enabled: no/Enabled: yes/' /etc/apt/sources.list.d/debian.sources
+      [ -f /etc/apt/sources.list.d/debian-backports.sources ] && \
+          sed -i 's/Enabled: no/Enabled: yes/' /etc/apt/sources.list.d/debian-backports.sources || true
+      [ -f /etc/apt/sources.list.d/snapshot-debian.sources ] && \
+          sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/snapshot-debian.sources || true
+      [ -f /etc/apt/sources.list.d/snapshot-debian-backports.sources ] && \
+          sed -i 's/Enabled: yes/Enabled: no/' /etc/apt/sources.list.d/snapshot-debian-backports.sources || true
 {{- end }}
 
   - action: run


### PR DESCRIPTION
Add support for snapshot-based rootfs builds via -t selector.

Introduce snapshot_*.sources alongside regular APT sources and toggle "Enabled:" to switch between live and snapshot repositories during build.

usage: -t snapshot:today | YYYYMMDD | snapshot-id