### PR TITLE
feat!(rootfs): do not use a default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,8 @@ NB: It's also possible to run qdl from the host while the board is not connected
 
 #### Login
 
-Once the image has booted, you can log in as the `debian` user, with the
-default `debian` password. The image should then ask you to change this default
-password to a safe one.
+Once the image has booted, you can log in as the `debian` user. The image
+should then ask you to define a password for this user.
 
 ## Development
 

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -35,10 +35,7 @@ actions:
     auto_login:
       login_prompt: 'login:'
       username: debian
-      password_prompt: 'Password'
-      password: debian
       login_commands:
-      - "debian"
       - "new password"
       - "new password"
       - sudo su

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -72,11 +72,7 @@ def test_password_reset_required(vm):
     vm.expect_exact("debian login:", timeout=240)
 
     vm.send("debian\r\n")
-    vm.expect_exact("Password:")
-    vm.send("debian\r\n")
     vm.expect_exact("You are required to change your password immediately")
-    vm.expect_exact("Current password:")
-    vm.send("debian\r\n")
     vm.expect_exact("New password:")
     vm.send("new password\r\n")
     vm.expect_exact("Retype new password:")

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -323,10 +323,12 @@ actions:
       fi
       useradd --create-home --shell /bin/bash --user-group \
           --groups "$groups" debian
-      # set password to "debian"
+
+      # do not use any password and force password change on first login
       echo debian:debian | chpasswd
-      # password must be changed on first login
+      passwd -d debian
       chage --lastday 0 debian
+
       # add to sudoers
       mkdir -v --mode 755 --parents /etc/sudoers.d
       # subshell to override umask


### PR DESCRIPTION
Default passwords are a bit of a hassle to remember between "debian", "qcom" or anything else. Remove the default password altogether and continue to enforce a password on first login.

This reduces user friction when using the image on the first time while keeping the security in check by asking for a new password on first login.

This change is inspired by what is done in arduino-deb-images and aims to reduce this delta:
https://github.com/arduino/arduino-deb-images/blob/arduino/debos-recipes/qualcomm-linux-debian-rootfs-arduino-extra.yaml#L50