### PR TITLE
ci: re-enable monaco-evk/RB4 LAVA testing

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -41,4 +41,7 @@ jobs:
       suite: ${{ matrix.suite }}
       # qrb2210-rb1 can't boot forky pending a newer kernel; see #424
       # glymur-crd can't boot anything
-      boards_exclude: ${{ (matrix.suite == 'forky' && '["qrb2210-rb1", "glymur-crd"]') || '["glymur-crd"]' }}
+      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # kernels so far, not the distro kernel; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
+      boards_exclude: ${{ (matrix.suite == 'forky' && '["qrb2210-rb1", "glymur-crd", "monaco-evk"]') || '["glymur-crd", "monaco-evk"]' }}

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -28,4 +28,7 @@ jobs:
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
-      boards_exclude: '["glymur-crd"]'
+      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # kernels so far; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
+      boards_exclude: '["glymur-crd", "monaco-evk"]'

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -20,5 +20,8 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       kernel_name: mainline
-      lava_boards_exclude: '["glymur-crd"]'
+      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # kernels so far; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
+      lava_boards_exclude: '["glymur-crd", "monaco-evk"]'
     secrets: inherit

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -64,7 +64,10 @@ jobs:
     needs: retrieve-build-url
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}
-      boards_exclude: '["glymur-crd"]'
+      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # kernels so far; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
+      boards_exclude: '["glymur-crd", "monaco-evk"]'
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -1,0 +1,86 @@
+actions:
+- deploy:
+    images:
+      image:
+        headers:
+          Authorization: Q_S3_TOKEN
+        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
+    postprocess:
+      docker:
+        image: ghcr.io/foundriesio/lava-lmp-sign:main
+        steps:
+        - export IMAGE_PATH=$PWD
+        - cp overlay*.tar.gz overlay.tar.gz
+        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
+        - echo "DEVICE_TYPE=debian-monaco-evk_ufs" >> $IMAGE_PATH/flash.settings
+        - cat $IMAGE_PATH/flash.settings
+    timeout:
+      minutes: 200
+    to: downloads
+- deploy:
+    images:
+      image:
+        url: downloads://{{SUITE}}-flash-ufs.tar.gz
+      settings:
+        url: downloads://flash.settings
+      overlay:
+        url: downloads://overlay.tar.gz
+    timeout:
+      minutes: 20
+    to: flasher
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
+      - sudo su
+    method: minimal
+    prompts:
+    - root@debian
+    - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
+    timeout:
+      minutes: 3
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - from: git
+      name: "smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a"
+    - from: git
+      name: "wlan-smoke-test"
+      path: automated/linux/wlan-smoke/wlan-smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        WAIT_TIME: 60
+- command:
+    name: network_turn_on
+context:
+  lava_test_results_dir: /home/lava-%s
+  test_character_delay: 10
+device_type: monaco-evk
+job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+tags:
+- cambridge-lab
+timeouts:
+  job:
+    minutes: 210
+visibility: public


### PR DESCRIPTION
Restore the monaco-evk boot job reverted in #423 now that the
upstream kernel fixes have landed and the board boots again. This is
the same LAVA template as in
53ceca46f8513fd0af844b20366fa9160457c917 but with a trailing
whitespace removed.

Enable it only for the kernels confirmed working in #440
(linux-next, qcom-next, monza) — these workflows pick up the
template automatically via their exclude-only / explicit-include
board filters. Keep it excluded from the distro-kernel builds
(build-daily, build-on-push, test-on-pr) and the weekly mainline
build, which were not validated; notably forky still ships a 7.0
kernel lacking the monaco config fixes.

Fixes: #440
