### PR TITLE
fix(debos/flash): copy over sail_nor when present

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -404,6 +404,14 @@ actions:
               \) \
               -exec cp --preserve=mode,timestamps -v '{}' "${flash_dir}" \;
 
+          # copy the sail_nor directory (standalone rawprogram/gpt/firehose/elf
+          # payloads) for SAIL domain flashing on SPI-NOR; only some silicon
+          # families ship it
+          sail_nor_dir="build/${board_name}_boot-binaries/sail_nor"
+          if [ -d "${sail_nor_dir}" ]; then
+              cp --preserve=mode,timestamps -rv "${sail_nor_dir}" "${flash_dir}/"
+          fi
+
           if [ -n "${board_u_boot_file}" ]; then
               # copy U-Boot binary to boot.img; qcom-ptool partitions.conf
               # files use filename=boot.img for boot_a and boot_b partitions


### PR DESCRIPTION
Flash dir assembly dropped the sail_nor payload directory from the
boot binaries, leaving out some SPI-NOR provisioning files for some
boards, notably monza.

The sail_nor directory holds standalone rawprogram/gpt/firehose/elf
files. Copy it into the per-board flash directory for any board
whose boot binaries ship it.

Of the public boot-binaries packages, only QCS8300 (Monaco) and
QCS9100 (LeMans) currently ship a sail_nor directory; Glymur,
QCM6490 and QCS615 ship none. The directory is always named exactly
"sail_nor" and sits at the top level of the unpacked boot binaries,
so a simple conditional copy works.

Fixes: #437
