### PR TITLE
fix(ci): don't require monaco-evk to be in cam

### DIFF
--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -78,8 +78,6 @@ job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEM
 metadata:
   build-commit: '{{GITHUB_SHA}}'
 priority: 50
-tags:
-- cambridge-lab
 timeouts:
   job:
     minutes: 210


### PR DESCRIPTION
monaco-evk LAVA template searches for device with the cambrige-lab
tag, but all of them are actually in Hyderabad rather than
Cambridge. Drop the tag constraint and let LAVA select any device.
