### PR TITLE
return to combined dtbs

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -50,6 +50,7 @@ actions:
     )
     "cdt_filename" "CRD/cdt_glymur_crd_0.1.0.bin"
     "dtb" "qcom/glymur-crd.dtb"
+    "dtb_bin_type" "multidtb"
 )}}
 {{- if eq $build_qcs615 "true" }}
 {{- $boards = append $boards (dict
@@ -72,7 +73,6 @@ actions:
     )
     "cdt_filename" "cdt_adp_air_sa6155p.bin"
     "dtb" "qcom/qcs615-ride.dtb"
-    "dtb_bin_type" "combineddtb"
 )}}
 {{- end }}
 {{- if eq $build_qcm6490 "true" }}
@@ -96,7 +96,6 @@ actions:
     )
     "cdt_filename" "cdt_vision_kit.bin"
     "dtb" "qcom/qcs6490-rb3gen2.dtb"
-    "dtb_bin_type" "combineddtb"
 )}}
 {{- end }}
 {{- if eq $build_qcs8300 "true" }}
@@ -120,7 +119,6 @@ actions:
     )
     "cdt_filename" "cdt_ride_sx.bin"
     "dtb" "qcom/qcs8300-ride.dtb"
-    "dtb_bin_type" "combineddtb"
 )}}
 {{- $boards = append $boards (dict
     "name" "monaco-evk"
@@ -186,7 +184,6 @@ actions:
     )
     "cdt_filename" "cdt_ride_sx.bin"
     "dtb" "qcom/qcs9100-ride-r3.dtb"
-    "dtb_bin_type" "combineddtb"
 )}}
 {{- $boards = append $boards (dict
     "name" "lemans-evk"
@@ -224,7 +221,6 @@ actions:
     )
     "u_boot_file" .u_boot_rb1
     "dtb" "qcom/qrb2210-rb1.dtb"
-    "dtb_bin_type" "combineddtb"
 )}}
 {{- end }}
 {{- $boards = append $boards (dict
@@ -239,7 +235,6 @@ actions:
         "sha256sum" "c606e95d0107f8c58d0dd9494e00624d1db7c4361cca20513bc78ef02ca28dd1"
     )
     "dtb" "qcom/qrb2210-arduino-imola.dtb"
-    "dtb_bin_type" "combineddtb"
 )}}
 
 {{- range $board := $boards }}
@@ -333,8 +328,8 @@ actions:
       # in shell syntax
       board_name="{{$board.name}}"
       board_dtb="{{$board.dtb}}"
-      # default dtb_bin_type is multidtb
-      board_dtb_bin_type="{{or $board.dtb_bin_type "multidtb"}}"
+      # default dtb_bin_type is combineddtb
+      board_dtb_bin_type="{{or $board.dtb_bin_type "combineddtb"}}"
       echo "Board ${board_name}: dtb_bin_type=${board_dtb_bin_type}"
       boot_binaries_filename="{{$board.boot_binaries_download.filename}}"
       board_cdt_download_filename=""
@@ -459,17 +454,17 @@ actions:
           fi
 
           if [ "${board_dtb_bin_type}" = "combineddtb" ]; then
-              # generate a dtb-combineddtb.bin" FAT partition with just a single dtb for the
-              # current board; long-term this should really be a set of dtbs and
-              # overlays as to share dtb.bin across boards
+              # generate a dtb-combineddtb.bin" FAT partition with just a
+              # single dtb for the current board; long-term this should really
+              # be a set of dtbs and overlays as to share dtb.bin across boards
               dtb_bin="${flash_dir}/dtb-combineddtb.bin"
               rm -f "${dtb_bin}"
-              # dtb-combineddtb.bin is only used in UFS based boards at the moment
-              # and UFS uses a 4k sector size, so pass -S 4096 in
+              # dtb-combineddtb.bin is only used in UFS based boards at the
+              # moment and UFS uses a 4k sector size, so pass -S 4096 in
               # qcom-ptool/platforms/*/partitions.conf, dtb_a and _b partitions
               # are provisioned with 64MiB; create a 4MiB FAT that will
-              # comfortably fit in these and hold the target device tree, which is
-              # 4096 KiB sized blocks for mkfs.vfat's last argument
+              # comfortably fit in these and hold the target device tree, which
+              # is 4096 KiB sized blocks for mkfs.vfat's last argument
               mkfs.vfat -S 4096 -C "${dtb_bin}" 4096
               # extract board device tree from the root filesystem provided
               # tarball


### PR DESCRIPTION
Return to combined DTBs to fix regressions due to introduction of FIT images.
- **fix(flash)!: combineddtb for monaco and lemans**
- **feat(flash)!: default dtb_bin_type to combineddtb**
- **chore(debos): Drop combineddtb from board entries**

Fixes: #444