### PR TITLE
fix: dtb-multidtb.bin in spinor needs to be referenced 2 level above

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -509,6 +509,11 @@ actions:
                           -u "//download_file[file_name/text()='dtb-multidtb.bin']/file_path[text()='..']" -v "../../" \
                           "${copied_contents}"
                   fi
+                  # fix rawprogram*.xml in spinor dir: ../dtb-multidtb.bin -> ../../dtb-multidtb.bin
+                  find "${target_dir}/spinor" -name 'rawprogram*.xml' \
+                      -exec xmlstarlet ed -L \
+                          -u "//program[@filename='../dtb-multidtb.bin']/@filename" -v "../../dtb-multidtb.bin" \
+                      '{}' \;
               done
       done
 


### PR DESCRIPTION
When dtb-multidtb is referenced from rawprograms in SPINOR, it needs to point two levels above. This is required to keep dtb-multidtb common across boards and to satisfy the SPINOR structure.

this fix is needed only for multidtb spinor directory structure, hence it is done post xml generation