### PR TITLE
feat!: Rename monza daily build to arduino

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -41,7 +41,7 @@ jobs:
       suite: ${{ matrix.suite }}
       # qrb2210-rb1 can't boot forky pending a newer kernel; see #424
       # glymur-crd can't boot anything
-      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # monaco-evk only validated against the linux-next/qcom-next/arduino
       # kernels so far, not the distro kernel; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
       boards_exclude: ${{ (matrix.suite == 'forky' && '["qrb2210-rb1", "glymur-crd", "monaco-evk"]') || '["glymur-crd", "monaco-evk"]' }}

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
-      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # monaco-evk only validated against the linux-next/qcom-next/arduino
       # kernels so far; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
       boards_exclude: '["glymur-crd", "monaco-evk"]'

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -1,4 +1,4 @@
-name: Daily monza linux build
+name: Daily arduino linux build
 
 on:
   # run daily at 6:30am
@@ -19,8 +19,8 @@ jobs:
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
     with:
-      kernel_name: monza
-      build_linux_deb_extra_args: '--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/monza'
+      kernel_name: arduino
+      build_linux_deb_extra_args: '--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/arduino'
       # workaround-hexagon-dsp-binaries-monza can be dropped once an
       # updated hexagon-dsp-binaries with Monza support is integrated; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/298 and

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       kernel_name: mainline
-      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # monaco-evk only validated against the linux-next/qcom-next/arduino
       # kernels so far; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
       lava_boards_exclude: '["glymur-crd", "monaco-evk"]'

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -64,7 +64,7 @@ jobs:
     needs: retrieve-build-url
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}
-      # monaco-evk only validated against the linux-next/qcom-next/monza
+      # monaco-evk only validated against the linux-next/qcom-next/arduino
       # kernels so far; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
       boards_exclude: '["glymur-crd", "monaco-evk"]'


### PR DESCRIPTION
Focus for monza work is moving to a new early/hwe/arduino kernel
branch with support for both UNO Q and VENTUNO Q. Update to the new
branch name and adjust workflow names to match.
