### PR TITLE
feat(kernel-configs): enable ov5647 (RPiv1 camera)

### DIFF
--- a/kernel-configs/arduino-accessories.config
+++ b/kernel-configs/arduino-accessories.config
@@ -1,0 +1,6 @@
+# these configs enable drivers for accessories used with Arduino boards, such
+# as camera sensors, displays, or expansion boards
+
+# OmniVision OV5647 sensor support; used in Raspberry Pi v1 camera
+# https://github.com/qualcomm-linux/qcom-deb-images/issues/449
+CONFIG_VIDEO_OV5647=m


### PR DESCRIPTION
As we want to enable testing with some reference Arduino
accessories, add a config file list useful drivers such  as camera
sensors, displays, or expansions boards

Fixes: #449
