### PR TITLE
fix(ci): trigger daily builds 2 hours earlier, 6:30 in the morning

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -1,9 +1,9 @@
 name: Daily Build
 
 on:
-  # run daily at 8:30am
+  # run daily at 6:30am
   schedule:
-    - cron: '30 8 * * *'
+    - cron: '30 6 * * *'
   # allow manual runs
   workflow_dispatch:
 


### PR DESCRIPTION
For my personal timezone, Europe/Amsterdam, the daily build triggers after my workday has started, it would be nice to have it finished before starting.