### PR TITLE
fix(debos/image): disable debos-grow-rootfs service after first successful run

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -146,6 +146,7 @@ actions:
       Type=oneshot
       ExecStartPre=-sh -c 'growpart /dev/\`lsblk -n -o pkname $ROOTFS_DEV\` 2'
       ExecStart=resize2fs $ROOTFS_DEV
+      ExecStartPost=/bin/systemctl disable debos-grow-rootfs.service
       [Install]
       WantedBy=default.target
       EOF


### PR DESCRIPTION
debos-grow-rootfs.service runs on every boot even after the partition
and filesystem were already grown. Add ExecStartPost to disable the 
service after a successful first run.