### PR TITLE
fix: use /usr/bin instead of /bin for Debian

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -106,7 +106,7 @@ actions:
       set -eux
       # Fixes error when running outside qemu
       dpkg-divert --local --rename --add /etc/kernel/postinst.d/u-boot-efi-dtb
-      ln -s /bin/true /etc/kernel/postinst.d/u-boot-efi-dtb
+      ln -s /usr/bin/true /etc/kernel/postinst.d/u-boot-efi-dtb
       # u-boot-efi-dtb installs a kernel hook that will trigger on kernel
       # installation/upgrade, but also calls it explicitely in its postinst in
       # case it was installed after the kernel; it requires an ESP partition to
@@ -146,7 +146,7 @@ actions:
       Type=oneshot
       ExecStartPre=-sh -c 'growpart /dev/\`lsblk -n -o pkname $ROOTFS_DEV\` 2'
       ExecStart=resize2fs $ROOTFS_DEV
-      ExecStartPost=/bin/systemctl disable debos-grow-rootfs.service
+      ExecStartPost=/usr/bin/systemctl disable debos-grow-rootfs.service
       [Install]
       WantedBy=default.target
       EOF

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -347,7 +347,7 @@ actions:
       if getent group fastrpc >/dev/null 2>&1; then
         groups="${groups},fastrpc"
       fi
-      useradd --create-home --shell /bin/bash --user-group \
+      useradd --create-home --shell /usr/bin/bash --user-group \
           --groups "$groups" debian
       # set password to "debian"
       echo debian:debian | chpasswd


### PR DESCRIPTION
Now that usrmerge is done in Debian, we know that /bin is a symlink to /usr/bin. Directly use /usr/bin where it makes sense to avoid an extra symlink dereference.

Note that this is not done for the scripts/ directory because we cannot assume that the user of these scripts is running an usrmerged system. Same for the recipe scripts not run in the Debian chroot. We only do this for everything that we are sure is running on a Debian target.