### PR TITLE
chore(lava/rb3gen2): use new device_type

### DIFF
--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -73,7 +73,7 @@ actions:
 context:
   lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
-device_type: qcs6490
+device_type: qcs6490-rb3gen2-vision-kit
 job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}
 metadata:
   build-commit: '{{GITHUB_SHA}}'


### PR DESCRIPTION
Device Types were renamed after a LAVA upgrade; use the new
qcs6490-rb3gen2-vision-kit device_type name, matching the CI
template filename and the upstream kernel DTB name.
