### PR TITLE
ci: fix LAVA templates to match 2026.05-qualcomm release

### DIFF
--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -12,7 +12,7 @@ actions:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
         - echo "DEVICE_TYPE=debian-glymur-crd_nvme" >> $IMAGE_PATH/flash.settings
         - echo "STORAGE=nvme" >> $IMAGE_PATH/flash.settings
@@ -73,7 +73,6 @@ actions:
 - command:
     name: network_turn_on
 context:
-  lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
 device_type: glymur-crd
 job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -12,7 +12,7 @@ actions:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
         - echo "DEVICE_TYPE=debian-monaco-evk_ufs" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
@@ -71,7 +71,6 @@ actions:
 - command:
     name: network_turn_on
 context:
-  lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
 device_type: monaco-evk
 job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -12,7 +12,7 @@ actions:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
         - echo "DEVICE_TYPE=debian-qcs6490-rb3gen2-vision-kit_ufs" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
@@ -71,7 +71,6 @@ actions:
 - command:
     name: network_turn_on
 context:
-  lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
 device_type: qcs6490-rb3gen2-vision-kit
 job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -12,7 +12,7 @@ actions:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "STORAGE=emmc" >> $IMAGE_PATH/flash.settings
         - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
         - echo "DEVICE_TYPE=debian-qrb2210-rb1_emmc" >> $IMAGE_PATH/flash.settings
@@ -72,7 +72,6 @@ actions:
 - command:
     name: network_turn_on
 context:
-  lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
 device_type: qrb2210-rb1
 job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}


### PR DESCRIPTION
The CompressOverlay fix causes the overlay to always be packaged from "/". Prior to this release the top directory in the overlay tarball was named "lava-XXX" where XXX is the job ID. LAVA stripped the rest of the path during compression. This means that the jobs had to uncompress the tarball to a proper location if lava_test_results_dir variable was used. After the fix tarball can be decompressed at "/" and overlay will be placed in the right directory.