### PR TITLE
Ci/qdl lava templates

### DIFF
--- a/.github/workflows/lava-schema-check.yml
+++ b/.github/workflows/lava-schema-check.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   schema-check:
     runs-on: ubuntu-latest
-    container: lavasoftware/lava-server:2025.04
+    container: ghcr.io/linux-validation/lava/lava-server-amd64:2026.05-qualcomm-2026.05-22-d5988428c
     steps:
       - name: Clone repository
         uses: actions/checkout@v6

--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -1,37 +1,35 @@
 actions:
 - deploy:
-    images:
-      image:
-        headers:
-          Authorization: Q_S3_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
-    postprocess:
-      docker:
-        image: ghcr.io/foundriesio/lava-lmp-sign:main
-        steps:
-        - export IMAGE_PATH=$PWD
-        - cp overlay*.tar.gz overlay.tar.gz
-        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
-        - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-glymur-crd_nvme" >> $IMAGE_PATH/flash.settings
-        - echo "STORAGE=nvme" >> $IMAGE_PATH/flash.settings
-        - echo "FIREHOSE_PROGRAM=xbl_s_devprg_ns.melf" >> $IMAGE_PATH/flash.settings
-        - cat $IMAGE_PATH/flash.settings
-    timeout:
-      minutes: 200
-    to: downloads
-- deploy:
-    images:
-      image:
-        url: downloads://{{SUITE}}-flash-emmc.tar.gz
-      settings:
-        url: downloads://flash.settings
-      overlay:
-        url: downloads://overlay.tar.gz
+    rootfs_image: disk-sdcard.img2
+    overlay_path: /
+    qcomflash:
+      headers:
+        Authorization: Q_S3_TOKEN
+      url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
+      apply-overlay: true
     timeout:
       minutes: 20
-    to: flasher
+    to: qdl
+- boot:
+    firehose_program: xbl_s_devprg_ns.melf
+    rawprogram: rawprogram0.xml
+    patch: patch0.xml
+    path: flash_glymur-crd_nvme/spinor
+    storage: spinor
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
+- boot:
+    firehose_program: xbl_s_devprg_ns.melf
+    rawprogram: rawprogram0.xml
+    patch: patch0.xml
+    path: flash_glymur-crd_nvme
+    storage: nvme
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
 - boot:
     auto_login:
       login_prompt: 'login:'

--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -30,6 +30,8 @@ actions:
     timeout:
       minutes: 15
     method: qdl
+- command:
+    name: network_turn_on
 - boot:
     auto_login:
       login_prompt: 'login:'
@@ -68,8 +70,6 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
-- command:
-    name: network_turn_on
 context:
   test_character_delay: 10
 device_type: glymur-crd

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -31,6 +31,8 @@ actions:
     timeout:
       minutes: 15
     method: qdl
+- command:
+    name: network_turn_on
 - boot:
     auto_login:
       login_prompt: 'login:'
@@ -69,8 +71,6 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
-- command:
-    name: network_turn_on
 context:
   test_character_delay: 10
 device_type: monaco-evk

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -1,35 +1,36 @@
 actions:
 - deploy:
-    images:
-      image:
-        headers:
-          Authorization: Q_S3_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
-    postprocess:
-      docker:
-        image: ghcr.io/foundriesio/lava-lmp-sign:main
-        steps:
-        - export IMAGE_PATH=$PWD
-        - cp overlay*.tar.gz overlay.tar.gz
-        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
-        - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-monaco-evk_ufs" >> $IMAGE_PATH/flash.settings
-        - cat $IMAGE_PATH/flash.settings
-    timeout:
-      minutes: 200
-    to: downloads
-- deploy:
-    images:
-      image:
-        url: downloads://{{SUITE}}-flash-ufs.tar.gz
-      settings:
-        url: downloads://flash.settings
-      overlay:
-        url: downloads://overlay.tar.gz
+    rootfs_image: disk-ufs.img2
+    overlay_path: /
+    qcomflash:
+      headers:
+        Authorization: Q_S3_TOKEN
+      url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
+      apply-overlay: true
     timeout:
       minutes: 20
-    to: flasher
+    to: qdl
+- boot:
+    firehose_program: prog_firehose_ddr.elf
+    rawprogram: rawprogram0.xml
+    patch: patch0.xml
+    path: flash_monaco-evk_ufs/sail_nor
+    storage: spinor
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
+- boot:
+    firehose_program: prog_firehose_ddr.elf
+    rawprogram: rawprogram0.xml rawprogram1.xml rawprogram2.xml rawprogram3.xml
+      rawprogram4.xml rawprogram5.xml
+    patch: patch0.xml patch1.xml patch2.xml patch3.xml patch4.xml patch5.xml
+    path: flash_monaco-evk_ufs
+    storage: ufs
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
 - boot:
     auto_login:
       login_prompt: 'login:'

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -20,6 +20,8 @@ actions:
     timeout:
       minutes: 15
     method: qdl
+- command:
+    name: network_turn_on
 - boot:
     auto_login:
       login_prompt: 'login:'
@@ -58,8 +60,6 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
-- command:
-    name: network_turn_on
 context:
   test_character_delay: 10
 device_type: qcs6490-rb3gen2-vision-kit

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -1,35 +1,25 @@
 actions:
 - deploy:
-    images:
-      image:
-        headers:
-          Authorization: Q_S3_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
-    postprocess:
-      docker:
-        image: ghcr.io/foundriesio/lava-lmp-sign:main
-        steps:
-        - export IMAGE_PATH=$PWD
-        - cp overlay*.tar.gz overlay.tar.gz
-        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
-        - echo "ROOTFS_IMAGE=disk-ufs.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-qcs6490-rb3gen2-vision-kit_ufs" >> $IMAGE_PATH/flash.settings
-        - cat $IMAGE_PATH/flash.settings
-    timeout:
-      minutes: 200
-    to: downloads
-- deploy:
-    images:
-      image:
-        url: downloads://{{SUITE}}-flash-ufs.tar.gz
-      settings:
-        url: downloads://flash.settings
-      overlay:
-        url: downloads://overlay.tar.gz
+    rootfs_image: disk-ufs.img2
+    overlay_path: /
+    qcomflash:
+      headers:
+        Authorization: Q_S3_TOKEN
+      url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
+      apply-overlay: true
     timeout:
       minutes: 20
-    to: flasher
+    to: qdl
+- boot:
+    firehose_program: prog_firehose_ddr.elf
+    rawprogram: rawprogram0.xml rawprogram1.xml rawprogram2.xml rawprogram3.xml rawprogram4.xml rawprogram5.xml
+    patch: patch0.xml patch1.xml patch2.xml patch3.xml patch4.xml patch5.xml
+    path: flash_qcs6490-rb3gen2-vision-kit_ufs
+    storage: ufs
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
 - boot:
     auto_login:
       login_prompt: 'login:'

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -20,6 +20,8 @@ actions:
     timeout:
       minutes: 15
     method: qdl
+- command:
+    name: network_turn_on
 - boot:
     auto_login:
       login_prompt: 'login:'
@@ -58,8 +60,6 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
-- command:
-    name: network_turn_on
 context:
   test_character_delay: 10
 device_type: qrb2210-rb1

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -1,36 +1,25 @@
 actions:
 - deploy:
-    images:
-      image:
-        headers:
-          Authorization: Q_S3_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
-    postprocess:
-      docker:
-        image: ghcr.io/foundriesio/lava-lmp-sign:main
-        steps:
-        - export IMAGE_PATH=$PWD
-        - cp overlay*.tar.gz overlay.tar.gz
-        - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
-        - echo "STORAGE=emmc" >> $IMAGE_PATH/flash.settings
-        - echo "ROOTFS_IMAGE=disk-sdcard.img2" >> $IMAGE_PATH/flash.settings
-        - echo "DEVICE_TYPE=debian-qrb2210-rb1_emmc" >> $IMAGE_PATH/flash.settings
-        - cat $IMAGE_PATH/flash.settings
-    timeout:
-      minutes: 200
-    to: downloads
-- deploy:
-    images:
-      image:
-        url: downloads://{{SUITE}}-flash-emmc.tar.gz
-      settings:
-        url: downloads://flash.settings
-      overlay:
-        url: downloads://overlay.tar.gz
+    rootfs_image: disk-sdcard.img2
+    overlay_path: /
+    qcomflash:
+      headers:
+        Authorization: Q_S3_TOKEN
+      url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
+      apply-overlay: true
     timeout:
       minutes: 20
-    to: flasher
+    to: qdl
+- boot:
+    firehose_program: prog_firehose_ddr.elf
+    rawprogram: rawprogram0.xml
+    patch: patch0.xml
+    path: flash_qrb2210-rb1_emmc
+    storage: emmc
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
 - boot:
     auto_login:
       login_prompt: 'login:'


### PR DESCRIPTION
ci: move LAVA templates to native qdl deployment

Use deploy/boot to qdl from LAVA actions. Support for QDL is available since 2026.05-qualcomm and 2026.06 (upstream).