### PR TITLE
install kernel headers

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -107,9 +107,17 @@ jobs:
           kernel_packages="$KERNEL_PACKAGES"
           suite="$SUITE"
           case "$kernel_packages" in
-            # if kernel package is from EFS, determine actual package name(s)
+            # NB: this is slightly weak as we collapse
+            # kernelpackages which is potentially a list and only
+            # look at the special value efs/* instead of splitting
+            #
+            # if kernel package is from EFS, determine actual package name(s);
+            # install the generated linux-headers-* packages alongside the
+            # linux-image-* ones since these are ephemeral and not published in
+            # an APT repo (unlike official Debian kernels, installed from APT)
+            # 
             efs/*)
-              kernel_packages="$(find local-apt-repo/kernel -type f -name 'linux-image-*' -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_|paste -sd,)"
+              kernel_packages="$(find local-apt-repo/kernel -type f \( -name 'linux-image-*' -o -name 'linux-headers-*' \) -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_|sort|paste -sd,)"
               ;;
             default-ci)
               case "$suite" in

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -11,11 +11,11 @@ on:
         description: List of overlays to use
         type: string
         default: qsc-deb-releases
-      kernelpackage:
+      kernelpackages:
         description: >
-          Kernel package to install from APT repositories (e.g.
-          linux-image-arm64) or name of a EFS kernel package directory
-          (e.g. efs/mainline)
+          Comma-separated list of kernel packages to install from APT
+          repositories (e.g. linux-image-arm64) or name of a EFS kernel
+          package directory (e.g. efs/mainline)
         type: string
         default: default-ci
       debos_extra_args:
@@ -40,7 +40,7 @@ permissions:
 env:
   # image build id; used for SBOM generation
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-  KERNEL_PACKAGE: ${{ inputs.kernelpackage }}
+  KERNEL_PACKAGES: ${{ inputs.kernelpackages }}
   SUITE: ${{ inputs.suite }}
   DEBOS_EXTRA_ARGS: -t suite:${{ inputs.suite }} ${{ inputs.debos_extra_args }}
   PREFIX: ${{ inputs.suite }}
@@ -87,11 +87,11 @@ jobs:
           mkdir -v local-apt-repo
 
           # optionally, copy kernel debs from EFS
-          case "$KERNEL_PACKAGE" in
+          case "$KERNEL_PACKAGES" in
             efs/*)
               mkdir -v local-apt-repo/kernel
               # get kernel from EFS
-              cp -av "/efs/${KERNEL_PACKAGE#efs/}/"*.deb local-apt-repo/kernel
+              cp -av "/efs/${KERNEL_PACKAGES#efs/}/"*.deb local-apt-repo/kernel
             ;;
           esac
 
@@ -104,12 +104,12 @@ jobs:
       - name: Build rootfs with debos
         run: |
           set -ux
-          kernel_package="$KERNEL_PACKAGE"
+          kernel_packages="$KERNEL_PACKAGES"
           suite="$SUITE"
-          case "$kernel_package" in
-            # if kernel package is from EFS, determine actual package name
+          case "$kernel_packages" in
+            # if kernel package is from EFS, determine actual package name(s)
             efs/*)
-              kernel_package="$(find local-apt-repo/kernel -type f -name 'linux-image-*' -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_)"
+              kernel_packages="$(find local-apt-repo/kernel -type f -name 'linux-image-*' -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_|paste -sd,)"
               ;;
             default-ci)
               case "$suite" in
@@ -117,10 +117,10 @@ jobs:
                   # the package name will be passed to APT which interprets the trailing
                   # plus sign in the package name as a request to install the package, so
                   # use two plus signs
-                  kernel_package="linux-image-6.16.7-qcom1++"
+                  kernel_packages="linux-image-6.16.7-qcom1++"
                   ;;
                 *)
-                  kernel_package="linux-image-arm64"
+                  kernel_packages="linux-image-arm64"
                   ;;
               esac
               ;;
@@ -130,7 +130,7 @@ jobs:
               -t overlays:'${{ inputs.overlays }}' \
               -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
-              -t kernelpackage:"$kernel_package" \
+              -t kernelpackages:"$kernel_packages" \
               -t "buildid:${BUILD_ID}" \
               ${DEBOS_EXTRA_ARGS} \
               --print-recipe \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -149,7 +149,7 @@ jobs:
     needs: build-linux-deb
     uses: ./.github/workflows/debos.yml
     with:
-      kernelpackage: efs/${{ inputs.kernel_name || 'mainline' }}
+      kernelpackages: efs/${{ inputs.kernel_name || 'mainline' }}
       debos_extra_args: ${{ inputs.debos_extra_args }}
       skip_qemu_tests: ${{ inputs.skip_qemu_tests || false }}
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To build flashable assets for all supported boards, follow these steps:
 
     # (optional) if you've built a local kernel, copy it to `debos-recipes/local-debs/`
     # and run this instead:
-    #EXTRA_DEBOS_OPTS="-t localdebs:local-debs/ -t kernelpackage:none" make rootfs.tar
+    #EXTRA_DEBOS_OPTS="-t localdebs:local-debs/ -t kernelpackages:none" make rootfs.tar
     ```
 
 1. build disk and filesystem images from the root filesystem tarball
@@ -148,9 +148,11 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `gnomedesktop`: install a GNOME desktop environment; default: console only environment
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
-- `kernelpackage`: name of the kernel package to install from apt; defaults to
-  `Debian’s linux-image-arm64`. Can (and should) be set to `none` if you are
-  providing local kernel package instead.
+- `kernelpackages`: a `,`-separated list of kernel packages to install from
+  apt; defaults to `Debian’s linux-image-arm64`. Can (and should) be set to
+  `none` if you are providing local kernel package instead.
+- `kernelpackage`: **deprecated**, superseded by `kernelpackages`; still
+  accepted as a single package name for backwards compatibility.
 - `suite`: Debian suite to use, defaults to `trixie`.
 - `snapshot`: use a Debian snapshot archive for a reproducible build (`YYYYMMDD`
   or `YYYYMMDDTHHMMSSZ`); logged to `/etc/buildinfo` as `SNAPSHOT=<date>`.

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -2,7 +2,8 @@
 {{- $gnomedesktop := or .gnomedesktop "false" }}
 {{- $localdebs := or .localdebs "none" }}
 {{- $aptlocalrepo := or .aptlocalrepo "none" }}
-{{- $kernelpackage := or .kernelpackage "linux-image-arm64" }}
+# $kernelpackage (singular) is deprecated, superseded by $kernelpackages
+{{- $kernelpackages := or .kernelpackages .kernelpackage "linux-image-arm64" }}
 {{- $overlays := or .overlays "qsc-deb-releases" }}
 {{- $buildid := or .buildid "" }}
 {{- $snapshot := or .snapshot "" }}
@@ -617,8 +618,10 @@ actions:
     packages:
       - firmware-atheros
       - firmware-qcom-soc
-{{- if ne $kernelpackage "none" }}
+{{- if ne $kernelpackages "none" }}
+{{- range $kernelpackage := split "," $kernelpackages }}
       - {{$kernelpackage}}
+{{- end }}
 {{- end }}
 
   # this is currently needed on boards such as RB1 which are using Android

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -24,6 +24,17 @@
 architecture: arm64
 
 actions:
+{{- if .kernelpackage }}
+  - action: run
+    description: Warn that the kernelpackage variable is deprecated
+    chroot: false
+    command: |
+      echo "WARNING: the 'kernelpackage' debos variable is deprecated and superseded by 'kernelpackages' (a comma-separated list); please migrate as 'kernelpackage' will be removed in a future release" >&2
+      # give the operator a chance to notice the warning before the build scrolls past
+      echo "(sleeping 10s to get some attention and leave some time to read this)" >&2
+      sleep 10
+{{- end }}
+
   - action: mmdebstrap
     description: Bootstrap initial filesystem
     suite: {{ $suite }}


### PR DESCRIPTION
Refactor `kernel_package` / `kernelpackage` semantics to take a list of
packages, and use this to install headers:
- **refactor(kernel)!: accept a list of kernel packages**
- **feat(kernel)!: install linux-headers along -image**

Headers are not installed when using standard Debian kernels, as
they can be installed from APT.

Fixes: #467 