### PR TITLE
Update Stale PR Workflow: Auto-close after 30+5 days

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-            days-before-close: -1
+            days-before-close: 5
+            days-before-issue-close: -1
             days-before-issue-stale: 30
             days-before-pr-stale: 30
             stale-pr-message: "This PR is stale. Add a nice message, can mention maintainers or maintainer team to draw attention"


### PR DESCRIPTION
Update Stale PR Workflow: Auto-close after 30+5 days Updates the Stale GitHub Actions workflow to mark PRs as stale after 30 days of inactivity and automatically close them after an additional 5 days. This aligns with PdM's request to ensure stale PRs that may no longer be needed are closed, making it easier to track progress and milestones