### PR TITLE
feat(ci): verify Syft installer signature before running

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -75,8 +75,10 @@ jobs:
 
       # mtools is needed for the flash recipe
       # file, device-tree-compiler and u-boot-tools are needed by qcom-dtb-metadata
+      # gettext-base is needed by cosign-installer, which uses envsubst internally
+      # curl is needed by cosign-installer and the Syft install script
       - name: Install debos and dependencies of the recipes and local tests
-        run: apt -y install debian-archive-keyring debos file make mmdebstrap mtools python3-pexpect python3-pytest qemu-efi-aarch64 qemu-system-arm xmlstarlet python3-defusedxml device-tree-compiler u-boot-tools
+        run: apt -y install curl debian-archive-keyring debos file gettext-base make mmdebstrap mtools python3-pexpect python3-pytest qemu-efi-aarch64 qemu-system-arm xmlstarlet python3-defusedxml device-tree-compiler u-boot-tools
 
       - name: Setup local APT repo
         run: |
@@ -190,13 +192,16 @@ jobs:
       - name: Unpack rootfs to generate SBOM
         run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar
 
+      - name: Install cosign
+        # Required so the syft installer can verify the release signature (-v).
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       # Syft is not packaged in Debian; it's available as a binary tarball or
       # as container image from upstream; it's available on arm64 and x86
       - name: Install Syft
         run: |
           set -ux
-          apt -y install curl
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -v
 
       - name: Generate SBOMs with Syft
         run: |


### PR DESCRIPTION
Make sure we verify the Syft install script using cosign before installation [1].

[1] https://oss.anchore.com/docs/installation/syft/