### PR TITLE
feat(qcom-next): update to tag qcom-next-7.1-20260708

### DIFF
--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       kernel_name: glymur
-      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.1-20260628 prune.config qcom.config'
+      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.1-20260708 prune.config qcom.config'
       debos_extra_args: '-t dtb:qcom/glymur-crd.dtb'
       # we hardcode the DT, and that's not compatible with the QEMU machine model
       skip_qemu_tests: true

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -20,6 +20,6 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       kernel_name: qcom-next
-      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.1-20260628 prune.config qcom.config'
+      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.1-20260708 prune.config qcom.config'
       lava_boards_exclude: '["glymur-crd"]'
     secrets: inherit


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.1-20260708, which corresponds to kernel version qcom-next-7.1-20260708.