### PR TITLE
AGENTS.md and initial skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in **qcom-deb-images** — the repo that
+builds Debian/Ubuntu images and flashable assets for Qualcomm Linux boards.
+
+This file complements, and does not replace, [CONTRIBUTING.md](CONTRIBUTING.md)
+and [README.md](README.md). It is organised by activity: read the section that
+matches what you are about to do.
+
+## Orienting yourself
+
+- [debos](https://github.com/go-debos/debos) recipes under `debos-recipes/`
+  build a Debian rootfs (`…-image.yaml`) and per-board flashable assets
+  (`…-flash.yaml`).
+- Board-specific logic lives almost entirely in
+  `debos-recipes/qualcomm-linux-debian-flash.yaml`; helper shell lives under
+  `scripts/`.
+- CI lives under `ci/` (LAVA boot configs) and `.github/workflows/`.
+
+## Working with debos recipes
+
+- The `…-flash.yaml` recipe mixes three languages: YAML (debos actions), Go
+  [`text/template`](https://pkg.go.dev/text/template) (the `{{- … }}` blocks
+  that build the board list and expand per-board actions), and POSIX shell (the
+  bodies of `action: run`). When editing, keep each construct in its own layer —
+  template-expand values into shell variables at the top of a `run` body, then
+  keep the rest of the body in plain shell, as the existing actions do.
+- External inputs (boot binaries, CDT archives, and the `qcom-ptool` /
+  `qcom-dtb-metadata` tarballs) are pinned by URL **and** `sha256sum`, and
+  verified at build time with `sha256sum --strict -c -`. Treat a URL and its
+  checksum as a unit: never change one without regenerating the other from the
+  actual bytes you downloaded.
+- Tools fetched as source (`qcom-ptool`, `qcom-dtb-metadata`) are pinned to
+  exact commits in the recipe. Changing a pin can change behaviour or data
+  formats the recipe depends on — review what moved between the old and new
+  commit before bumping.
+- Prefer making the recipe data-driven over special-casing: most boards are just
+  another entry in the board list. Reach for new template/shell logic only when
+  a board needs handling the existing fields cannot express.
+
+## Writing commit messages
+
+- Follow the existing history's [Conventional Commits](https://www.conventionalcommits.org/)
+  style: `feat(debos/flash): …`, `fix(debos/flash): …`, and `!` for breaking
+  changes (`refactor(debos/flash)!: …`). Scope the subject to the area touched.
+- Keep each change focused; split independent changes into separate commits.
+- **AI attribution.** When an agent helped produce a change, add an
+  `Assisted-by:` trailer per [CONTRIBUTING.md](CONTRIBUTING.md), one line per
+  tool, in the format `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL…]`.
+- **DCO.** Only a human may add `Signed-off-by:` to certify the
+  [DCO](https://developercertificate.org/). Never add it on their behalf.
+
+## Using project skills
+
+Task-specific playbooks live under `skills/` in the portable `SKILL.md` format
+(a `name` + `description` frontmatter and Markdown instructions), modeled on the
+[qcom-linux-skills](https://github.com/qualcomm-linux/qcom-linux-skills) catalog
+so any agent that understands `SKILL.md` (Claude Code, Codex, Cursor, …) can use
+them. Each skill's `description` carries the phrases that should trigger it —
+invoke a skill by name, or just describe the task.

--- a/skills/qcom-deb-add-board/SKILL.md
+++ b/skills/qcom-deb-add-board/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: qcom-deb-add-board
+description: >-
+  Add support for a new Qualcomm board to the debos flash recipe
+  (debos-recipes/qualcomm-linux-debian-flash.yaml) by appending a board entry
+  to the templated board list: pick the DTB name (from the board's kernel repo,
+  defaulting to the mainline Linux kernel), the soc_id (matching
+  qcom-dtb-metadata's /soc node), the qcom-ptool platform(s), and the
+  checksum-verified boot-binaries and CDT downloads. Use when asked to "add a
+  board", "add support for <board>", "enable <board> in the flash recipe", or
+  "add <board> to qcom-deb-images". Covers bumping the pinned qcom-ptool /
+  qcom-dtb-metadata when a board needs it, and cross-referencing meta-qcom for a
+  board already enabled there. NOT for updating an existing board's binaries
+  (use qcom-deb-update-boot-binaries) or bumping deps for their own sake (use
+  qcom-deb-update-deps).
+---
+
+# Add a board to the debos flash recipe
+
+## What this does
+
+Every flashable board in this repo is one entry in the Go-`text/template` board
+list at the top of `debos-recipes/qualcomm-linux-debian-flash.yaml`. Adding a
+board means appending a correct, checksum-verified entry to that list — no new
+recipe logic in the common case. This skill is the checklist for gathering the
+five facts a board entry needs and validating them before you write it.
+
+For general conventions (recipe structure, checksum discipline, commit style)
+see `AGENTS.md`; this skill covers only what is board-specific.
+
+## The board entry, field by field
+
+A board is a `dict` appended to `$boards`. Copy the closest existing entry as a
+template and change these fields:
+
+- **`name`** — the board's short name, used for the flash-dir and artifact
+  names. Match the board's conventional name (usually its DTB stem, e.g.
+  `qcs6490-rb3gen2`).
+- **`soc_id`** — the SoC identifier. **Must** equal a `/soc` node name in the
+  pinned `qcom-dtb-metadata`'s `qcom-metadata.dts`; this is what
+  `build-dtb-image.sh --soc` uses to select FIT configs. If the SoC has no
+  `/soc` node, the board cannot build a FIT (see qcm2290, excluded for exactly
+  this reason) — bumping `qcom-dtb-metadata` may be needed (see below).
+- **`ptool_platforms`** — a list of `<platform>/<storage>` strings. Each
+  `<platform>` must be a directory under the pinned `qcom-ptool`'s
+  `platforms/<platform>/` containing a `partitions.conf`; `<storage>` is the
+  disk type (`emmc`, `nvme`, `ufs`, `spinor`). **ptool platform names follow
+  marketing/board names, not SoC names** — they can differ substantially from
+  `name` (e.g. IQ-X7181/IQ-X5121 EVKs both map to ptool platform
+  `iq-x7181-evk`). Never assume `platform == name`; look it up.
+- **`boot_binaries_download`** — a `dict` with `description`, `url`, `name`,
+  `filename`, `sha256sum`. The archive is a `.zip` unpacked with `unzip`.
+- **`cdt_download`** (optional) + **`cdt_filename`** — the CDT archive and the
+  path to the `.bin` **inside** it. Existing CDTs are `.zip` (unpacked with
+  `unzip`); if the only published CDT is a `.tar.gz`, the recipe's CDT-unpack
+  step needs a small change to handle it — call that out rather than renaming
+  the URL.
+- **`dtb`** — `qcom/<stem>.dtb`, the DTB filename as built by the kernel.
+- **`dtb_bin_type`** (optional) — `combineddtb` (default) or `multidtb`.
+
+## Procedure
+
+### 1. Find the DTB name
+
+The DTB is what the board's **kernel** builds, so the kernel repo is the source
+of truth. Default to the mainline Linux kernel unless the board ships from a
+different tree.
+
+- Look under `arch/arm64/boot/dts/qcom/` for the board's `.dts`; the `dtb` field
+  is `qcom/<that-stem>.dtb`.
+- If the board is downstream-only, use the kernel repo it actually ships from
+  and note that in the commit message.
+
+### 2. Shortcut — is the board already enabled in meta-qcom?
+
+If the board already has a machine in
+[meta-qcom](https://github.com/qualcomm-linux/meta-qcom), it has already been
+mapped to concrete boot binaries, CDT, and partition layout — read them off
+instead of hunting. For a machine `conf/machine/<board>.conf`:
+
+- `KERNEL_DEVICETREE` → the `.dtb` (and thus `dtb`, `name` stem).
+- `QCOM_PARTITION_FILES_SUBDIR*` → `partitions/<platform>/<storage>`, i.e. the
+  ptool `<platform>` and which storages exist.
+- `QCOM_BOOT_FIRMWARE` / `QCOM_CDT_FIRMWARE` → the boot/CDT recipes under
+  `recipes-bsp/firmware-boot/`. Their `.bb`/`.inc` carry the exact `SRC_URI`
+  (URL) and `SRC_URI[...sha256sum]` you need for `boot_binaries_download` /
+  `cdt_download`, plus the in-archive `.bin` path for `cdt_filename`.
+- Two boards can share all of these (e.g. IQ-X5121 reuses IQ-X7181's partitions,
+  boot firmware and CDT) — such boards differ only in `name`, `soc_id`, `dtb`.
+
+Cross-check meta-qcom's values against the actual downloaded bytes anyway
+(step 4); meta-qcom may pin a different build-id than you want.
+
+### 3. Confirm ptool has the platform (bump the pin if needed)
+
+The pinned `qcom-ptool` must have `platforms/<platform>/partitions.conf` for
+each `<platform>` in `ptool_platforms`. Check the recipe's pinned commit:
+
+```bash
+grep -n 'qcom-ptool/archive' debos-recipes/qualcomm-linux-debian-flash.yaml
+# then, at that commit <sha>:
+gh api "repos/qualcomm-linux/qcom-ptool/contents/platforms?ref=<sha>" --jq '.[].name'
+gh api "repos/qualcomm-linux/qcom-ptool/contents/platforms/<platform>?ref=<sha>" \
+    --jq '.[].name'   # expect partitions.conf and per-storage dirs
+```
+
+If the platform is missing at the pin but exists upstream, it is **acceptable to
+bump the `qcom-ptool` pin** to pick it up — but do it via `qcom-deb-update-deps`
+so the backwards-incompatibility review happens. Likewise, if `soc_id` has no
+`/soc` node at the pinned `qcom-dtb-metadata`, bumping that pin may add it; again
+route through `qcom-deb-update-deps`.
+
+### 4. Verify every download
+
+For the boot-binaries archive and (if present) the CDT archive, download the
+exact URL and compute its checksum yourself — this is the value that goes in the
+entry and that the recipe enforces:
+
+```bash
+curl -fSL -o /tmp/boot.zip "<boot_binaries url>"
+sha256sum /tmp/boot.zip
+unzip -l /tmp/boot.zip | head        # sanity: expected top-level dir layout
+curl -fSL -o /tmp/cdt.zip "<cdt url>"
+sha256sum /tmp/cdt.zip
+unzip -l /tmp/cdt.zip                 # find the .bin -> cdt_filename (in-archive path)
+```
+
+Put the computed sums into `sha256sum`. If a value came from meta-qcom, confirm
+it matches what you downloaded.
+
+### 5. Write the entry and validate
+
+- Append the `dict` in the same style as the neighbouring entries (respect any
+  `{{- if eq $build_<soc> "true" }}` guards the surrounding boards use).
+- Re-read the whole `{{- $boards = append … }}` block for template balance
+  (`{{- if }}`/`{{- end }}`).
+- Do a lint pass on the shell/YAML you touched. A full `debos` build is the real
+  test; if you can't run it, say so and list what a maintainer should build to
+  confirm.
+
+### 6. Stage and report
+
+Stage the recipe change. Report: the board's five facts, the checksums you
+computed (and whether they matched meta-qcom), whether any pin bump was needed,
+and any recipe-logic change required (e.g. `.tar.gz` CDT). Propose a
+`feat(debos/flash): add <board>` commit message.
+
+## Notes
+
+- One board per commit keeps review easy; if several boards share binaries, they
+  can still be separate entries in one focused commit.
+- If a board needs a field the entry schema doesn't have, prefer extending the
+  schema minimally and defaulting it (as `dtb_bin_type` defaults to
+  `combineddtb`) over special-casing that board in shell.

--- a/skills/qcom-deb-update-boot-binaries/SKILL.md
+++ b/skills/qcom-deb-update-boot-binaries/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: qcom-deb-update-boot-binaries
+description: >-
+  Bump an existing board's boot binaries in the debos flash recipe
+  (debos-recipes/qualcomm-linux-debian-flash.yaml) to a newer release: change
+  the build-id in the boot_binaries_download URL, recompute and update the
+  sha256sum from the actual downloaded archive, and summarise what changed in
+  the new release. Use when asked to "update boot binaries", "bump <board> boot
+  binaries", "update <SoC> bootbinaries to the latest build", or "move <board>
+  to build-id NNNNN". NOT for adding a brand-new board to the recipe, nor for
+  bumping the pinned qcom-ptool / qcom-dtb-metadata commits — those are separate
+  activities.
+---
+
+# Update a board's boot binaries
+
+## What this does
+
+Boot-binary archives are versioned by a build-id embedded in the download URL
+(e.g. `…/QCS615_bootbinaries.1.0-test-device-public/00123/…`). Updating a board
+to a newer release means changing that build-id, re-verifying the archive's
+`sha256sum`, and recording what moved. The `sha256sum` is enforced at build time
+(`sha256sum --strict -c -`), so it must come from the actual new bytes.
+
+For checksum discipline and commit style see `AGENTS.md`; this skill covers the
+boot-binary-specific steps.
+
+## Procedure
+
+### 1. Locate the entry and the current build-id
+
+Find the board's `boot_binaries_download` in the recipe and note the current
+build-id segment in the `url` and the current `sha256sum`. Confirm the same
+boot-binaries archive isn't shared by other board entries — if it is, they all
+move together (update every entry that references it).
+
+### 2. Find the target build-id
+
+Determine the newer build-id (from the request, or by listing the release
+directory). If a board is also tracked in
+[meta-qcom](https://github.com/qualcomm-linux/meta-qcom), its
+`recipes-bsp/firmware-boot/firmware-qcom-boot-<board>_<buildid>.bb` records the
+build-id and `SRC_URI[bootbinaries.sha256sum]` meta-qcom uses — a useful
+cross-check, but not a substitute for downloading and hashing yourself.
+
+### 3. Download and verify
+
+```bash
+url="…/<NEW_BUILDID>/<Archive>.zip"
+curl -fSL -o /tmp/boot.zip "$url"
+sha256sum /tmp/boot.zip
+# sanity-check the archive still has the expected top-level layout:
+unzip -l /tmp/boot.zip | head
+```
+
+The printed sum is the new `sha256sum`. If meta-qcom recorded a sum for the same
+build-id, confirm it matches.
+
+### 4. Edit the entry
+
+Change **both** the build-id in `url` and the `sha256sum` to the new values.
+Leave `name` / `filename` / the in-archive layout alone unless the archive
+structure actually changed (the `unzip -l` sanity check tells you). Update every
+entry sharing this archive.
+
+### 5. Summarise what changed ("Known fixes")
+
+Record, per SoC/board, what the new release brings — a short changelog aids
+review and future bisection. Sources, in order of preference:
+
+- release notes accompanying the build,
+- the diff in meta-qcom's `firmware-qcom-boot-*` recipe/`.inc` between the old
+  and new build-id, if the board is tracked there,
+- otherwise state plainly that no changelog was available.
+
+Keep it to the user-visible effect ("fixes USB enumeration on cold boot"), not a
+file-list dump.
+
+### 6. Stage and report
+
+Stage the recipe change. Report: board(s) updated, old→new build-id, old→new
+`sha256sum` (and whether it matched meta-qcom), and the per-SoC "Known fixes"
+summary. Propose a `fix(debos/flash): update <board> boot binaries to
+<buildid>` (or `feat(...)` if the bump adds capability) commit message with the
+"Known fixes" notes in the body.

--- a/skills/qcom-deb-update-deps/SKILL.md
+++ b/skills/qcom-deb-update-deps/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: qcom-deb-update-deps
+description: >-
+  Bump the pinned qcom-ptool and/or qcom-dtb-metadata commit(s) in the debos
+  flash recipe (debos-recipes/qualcomm-linux-debian-flash.yaml) to a newer or
+  target commit, recompute the archive sha256sum, and review the diff and log
+  from the current sha to the target sha for backwards-incompatible changes that
+  would require updating qcom-deb-images logic or data. Use when asked to
+  "update qcom-ptool", "bump qcom-dtb-metadata", "update the flash recipe
+  dependencies", "move ptool/metadata to <sha>", or when another skill
+  determines a board needs a newer ptool platform or SoC /soc node. NOT for
+  adding a board to the recipe, nor for updating an existing board's boot
+  binaries — those are separate activities.
+---
+
+# Update flash-recipe dependencies (qcom-ptool / qcom-dtb-metadata)
+
+## What this does
+
+The flash recipe downloads `qcom-ptool` and `qcom-dtb-metadata` as GitHub
+archive tarballs pinned to exact commits, verified by `sha256sum`. This skill
+bumps a pin and — crucially — checks the range from the current commit to the
+target for changes that would break the recipe, since these tools supply the
+partition layouts (`qcom-ptool`) and FIT `/soc` metadata + build scripts
+(`qcom-dtb-metadata`) the recipe depends on.
+
+The pin bump itself is mechanical; the review is the point.
+
+## Procedure
+
+### 1. Identify current pin and target
+
+```bash
+grep -nE 'qcom-ptool/archive|qcom-dtb-metadata/archive' \
+    debos-recipes/qualcomm-linux-debian-flash.yaml
+```
+
+The `<sha>` is in the archive URL (`…/archive/<sha>.tar.gz`). The target is
+either given, or the latest on the tool's default branch:
+
+```bash
+gh api repos/qualcomm-linux/<tool>/commits/<branch> --jq '.sha'
+```
+
+### 2. Review the range for backwards-incompatible changes
+
+This is the mandatory step. Read both the log and the diff between current and
+target, looking for anything the recipe relies on:
+
+```bash
+gh api "repos/qualcomm-linux/<tool>/compare/<cur_sha>...<target_sha>" \
+    --jq '.commits[] | "\(.sha[0:12]) \(.commit.message | split("\n")[0])"'
+gh api "repos/qualcomm-linux/<tool>/compare/<cur_sha>...<target_sha>" \
+    --jq '.files[] | "\(.status)\t\(.filename)"'
+```
+
+Flag as potentially breaking:
+
+- **qcom-ptool:** renamed/removed `platforms/<platform>/` dirs or
+  `partitions.conf`; changes to `gen-ptool.sh`'s CLI/args (the recipe calls
+  `scripts/gen-ptool.sh` which shells into ptool); changed disk-type or output
+  file naming; changed `partitions.conf` schema.
+- **qcom-dtb-metadata:** renamed/removed `/soc` node names in
+  `qcom-metadata.dts` (the recipe's `soc_id` values must still resolve); changes
+  to `build-dtb-image.sh`'s flags (`--soc`, `--prune`, `--multidtb`/combined
+  handling) or its output filenames.
+- Anything in a `BREAKING CHANGE:`/`!`-marked commit, or renamed top-level files
+  the recipe references by path.
+
+For each concern, check whether the recipe or a board entry needs a
+corresponding update, and either make that update in the same change or record
+it as required follow-up. Cross-check every board's `soc_id` and
+`ptool_platforms` still resolve at the target commit.
+
+### 3. Recompute the archive checksum
+
+The pin is verified by `sha256sum`, so the sum must match the target archive's
+bytes:
+
+```bash
+url="https://github.com/qualcomm-linux/<tool>/archive/<target_sha>.tar.gz"
+curl -fSL -o /tmp/dep.tar.gz "$url"
+sha256sum /tmp/dep.tar.gz
+```
+
+Note: GitHub archive tarballs are generally byte-stable per commit, but always
+use the sum you actually computed.
+
+### 4. Edit the pin
+
+Update the archive `url` (the `<sha>` segment) **and** the matching `sha256sum`
+in the download action. Apply any recipe/board-data updates the review found.
+
+### 5. Stage and report
+
+Stage the changes. Report: tool, old→new sha, commit count in range, the
+backwards-incompatibility review outcome (explicitly "none found" or the list of
+concerns and how each was handled), new `sha256sum`, and any board entries
+touched. Propose a commit message — `chore(debos/flash): bump <tool> to
+<short-sha>` for a clean bump, or `feat`/`fix`/`refactor(debos/flash)!:` if the
+bump required recipe or data changes (mark `!` if those are breaking).
+
+## Notes
+
+- If the bump exists solely to support a new board, do the review here first,
+  then complete the board entry as part of that work.
+- Prefer a standalone dep-bump commit separate from the board/feature that
+  motivated it, so the review and the pin change are easy to audit.


### PR DESCRIPTION
Introduce guidance for AI agents with AGENTS.md and some initial skills for recurring development tasks.
- **docs: add AGENTS.md and portable skills catalog**
- **docs(skills): add qcom-deb-update-boot-binaries skill**
- **docs(skills): add qcom-deb-update-deps skill**
- **docs(skills): add qcom-deb-add-board skill**
