### PR TITLE
fix(ci/glymur-crd): add more generous pattern

### DIFF
--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -44,6 +44,14 @@ actions:
       - "new password"
       - sudo su
     method: minimal
+    parameters:
+      # glymur-crd's serial console drops bytes during the fast boot output
+      # burst, so the single-line default kernel-start-message
+      # ('Linux version [0-9]') is frequently mangled and never matched,
+      # stalling auto-login until timeout. Match the kernel timestamp prefix
+      # instead: it recurs on every dmesg line, so no single dropped line can
+      # defeat it, and it arms the login logic as early as possible.
+      kernel-start-message: '\[ *[0-9]+\.[0-9]+\]'
     prompts:
     - root@debian
     - debian@debian


### PR DESCRIPTION
Serial console seems to lose some characters on glymur-crd, even
during boot ROM. Workaround the lack of detection for the early boot
for now.
