### PR TITLE
feat(rootfs): install efivar package

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -292,6 +292,8 @@ actions:
       - dosfstools
       # ext4 tools, notably e2fsck for the root filesystem
       - e2fsprogs
+      # tools to read/write EFI variables
+      - efivar
       # fwupd tools, enable OTA EFI firmware capsule updates
       - fwupd
       # defaults to "systemd-sysv"; perhaps not needed


### PR DESCRIPTION
Adds **'efivar'** by default to the rootfs.
**'efivar'** provides the CLI tools to read/write UEFI variables from userspace.