### PR TITLE
qemu_test: raise default expect timeout

### DIFF
--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -52,6 +52,10 @@ def vm():
                 "-bios",
                 "/usr/share/AAVMF/AAVMF_CODE.fd",
             ],
+            # Emulated aarch64 (no KVM) on a loaded CI runner is slow, so give
+            # every expect() a generous default. The initial boot still
+            # overrides this with a longer per-call timeout below.
+            timeout=120,
         )
         child.logfile = sys.stdout.buffer
         yield child


### PR DESCRIPTION
test_password_reset_required timed out on emulated aarch64 (no KVM)
waiting for the login shell prompt after a successful password reset.
Only the first expect() set a timeout; the rest used pexpect's 30s
default, which is too tight for a loaded runner. Set a 120s default on
the spawn object so post-login steps have headroom.
