### PR TITLE
alsa-lib and efivar backports

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -187,7 +187,7 @@ actions:
       # for binary packages built from these source packages, score the version from
       # Debian backports higher as to get hardware enabled or better hardware support
 
-      Package: src:alsa-ucm-conf:any src:fastrpc src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
+      Package: src:alsa-lib:any src:alsa-ucm-conf:any src:fastrpc src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
       Pin: release n={{ $suite }}-backports
       Pin-Priority: 900
       EOF

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -187,7 +187,7 @@ actions:
       # for binary packages built from these source packages, score the version from
       # Debian backports higher as to get hardware enabled or better hardware support
 
-      Package: src:alsa-lib:any src:alsa-ucm-conf:any src:fastrpc src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
+      Package: src:alsa-lib:any src:alsa-ucm-conf:any src:efivar src:fastrpc src:firmware-free:any src:firmware-nonfree:any src:hexagon-dsp-binaries src:linux:any src:linux-signed-arm64:any src:mesa:any src:u-boot-efi-dtb
       Pin: release n={{ $suite }}-backports
       Pin-Priority: 900
       EOF


### PR DESCRIPTION
Add a couple of backports to our list:
- **fix(debos): also pin alsa-lib from backports**
- **feat(debos/rootfs): allow efivar from backports**
