### PR TITLE
ci: Force wifi device for wifi smoke tests on qcs615-ride

### DIFF
--- a/ci/lava/qcs615-ride/boot.yaml
+++ b/ci/lava/qcs615-ride/boot.yaml
@@ -60,6 +60,7 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
+        DEVICE: wlp1s0
 context:
   test_character_delay: 10
 device_type: qcs615-ride


### PR DESCRIPTION
qcs615-ride wireless device is wlp1s0, so add the flag to the wlan-smoke-test lava test action.