### PR TITLE
ci: update wifi device name on some boards to wlp1s0

### DIFF
--- a/ci/lava/lemans-evk/boot.yaml
+++ b/ci/lava/lemans-evk/boot.yaml
@@ -60,6 +60,7 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
+        DEVICE: wlp1s0
 context:
   test_character_delay: 10
 device_type: lemans-evk

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -71,6 +71,7 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
+        DEVICE: wlp1s0
 context:
   test_character_delay: 10
 device_type: monaco-evk

--- a/ci/lava/qcs8300-ride/boot.yaml
+++ b/ci/lava/qcs8300-ride/boot.yaml
@@ -60,6 +60,7 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
+        DEVICE: wlp1s0
 context:
   test_character_delay: 10
 # our board name "qcs8300-ride" is not a LAVA alias; the matching LAVA


### PR DESCRIPTION
The devices lemans-evk, monaco-evk and qcs8300-ride enumerate their wifi device as wlp1s0, so we need to set the LAVA test action to use this instead of default wlan0. Same change as for qcs615-ride.