### PR TITLE
fix(debos/rootfs): disable sudo hostname resolution

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -389,6 +389,8 @@ actions:
         umask 226
         echo "debian ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-debos
       )
+      # avoid unnecessary sudo hostname lookups
+      echo "Defaults !fqdn" >/etc/sudoers.d/disable-fqdn
 
   # NB: Recommends pull in way too many packages, and we don't need to follow
   # Recommends reaching outside of this Priority level


### PR DESCRIPTION
Configure sudo to not resolve the local hostname to a fully qualified domain name. This avoids delays or failures when DNS isn't yet resolved or `/etc/hosts` is not yet configured.

Closes: #193
Supersedes: #199 