### PR TITLE
ci(linux): publish unstripped vmlinux as artifact

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -124,6 +124,13 @@ jobs:
           # stage artifacts in a directory
           mkdir -v artifacts
           cp -av `dcmd *.changes` artifacts
+          # also publish the unstripped vmlinux to help debug crashes: it
+          # carries the kernel symbol table so oops/panic backtraces can be
+          # symbolize. This matches the vmlinux artifact meta-qcom's Yocto CI
+          # publishes and is required by teams analyzing kernel crashes.
+          if [ -f linux/vmlinux ]; then
+            cp -av linux/vmlinux artifacts/
+          fi
 
       - name: Upload results to EFS
         run: |


### PR DESCRIPTION
The kernel deb build only publishes the .deb packages, whose
linux-image ships a stripped Image. That leaves no way to get good
oops/panic backtraces from kernel crashes.

make bindeb-pkg leaves an unstripped linux/vmlinux in the source tree,
carrying the kernel symbol table.  Copy it into the artifacts
directory so it flows to both the EFS and S3 uploads, giving
crash-debugging parity with the vmlinux artifact meta-qcom's Yocto
CI publishes.
