### PR TITLE
feat(debos/flash)!: update Glymur boot binaries to 00079

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -41,10 +41,10 @@ actions:
     "ptool_platforms" (list "glymur-crd/nvme" "glymur-crd/spinor")
     "boot_binaries_download" (dict
         "description" "Glymur boot binaries"
-        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Glymur_bootbinaries.1.0/glymur_bootbinaries.1.0-test-device-public/00073/Glymur_bootbinaries.zip"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Glymur_bootbinaries.1.0/glymur_bootbinaries.1.0-test-device-public/00079/Glymur_bootbinaries.zip"
         "name" "glymur_boot-binaries"
         "filename" "glymur_boot-binaries.zip"
-        "sha256sum" "ab9e2349c18ac761522c31822a6874818ac027f9560e36cb83c48103ff96a2c4"
+        "sha256sum" "b8063fd1dff26bdc289d96ceb21edb6fcc0dbd604277a948df43699299b32649"
     )
     "cdt_download" (dict
         "description" "Glymur CRD CDT"


### PR DESCRIPTION
Known fixes:

EFI Variables Changes & Multi-DTB Support

Extended EFI variable handling to support runtime read/write operations aligned with UEFI BDS boot flow.

AOSS Sleep Issue Fixes

Addressed AOSS (Always-On SubSystem) sleep entry/exit failures that were preventing the platform from achieving deep low-power states on Glymur LNX.

FastRPC Related Fix

Resolved a FastRPC communication failure that was causing intermittent DSP session establishment errors.