### PR TITLE
ci: glymur: exclude glymur-crd.dtb hardcode

### DIFF
--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -21,7 +21,6 @@ jobs:
     with:
       kernel_name: glymur
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'
-      debos_extra_args: '-t dtb:qcom/glymur-crd.dtb'
       # we hardcode the DT, and that's not compatible with the QEMU machine model
       skip_qemu_tests: true
       skip_lava_tests: false

--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -21,7 +21,6 @@ jobs:
     with:
       kernel_name: glymur
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'
-      # we hardcode the DT, and that's not compatible with the QEMU machine model
       skip_qemu_tests: true
       skip_lava_tests: false
       lava_boards_include: '["glymur-crd"]'


### PR DESCRIPTION
Remove hardcoded glymur dtb passage to efi with below Boot bins PR bringing support of multi-dtb. 

Depends-on : https://github.com/qualcomm-linux/qcom-deb-images/pull/497