### PR TITLE
ci: fix zizmor & semgrep findings across the GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # This points to .github/workflows
     schedule:
       interval: "daily"
+    # wait a week before proposing a new release, so a compromised or simply
+    # broken action version has time to be yanked before we adopt it
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -7,12 +7,8 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-# implicitely set all other permissions to none
-permissions:
-  checks: write # lava-test.yml
-  contents: read # debos.yml lava-test.yml
-  packages: read # lava-test.yml
-  pull-requests: write # lava-test.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build-daily:
@@ -23,6 +19,8 @@ jobs:
       matrix:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
+    permissions:
+      contents: read # debos.yml
     with:
       suite: ${{ matrix.suite }}
 
@@ -35,6 +33,11 @@ jobs:
         suite: [trixie, forky]
     uses: ./.github/workflows/lava-test.yml
     needs: build-daily
+    permissions:
+      checks: write # lava-test.yml
+      contents: read # lava-test.yml
+      packages: read # lava-test.yml
+      pull-requests: write # lava-test.yml
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -38,7 +38,8 @@ jobs:
       contents: read # lava-test.yml
       packages: read # lava-test.yml
       pull-requests: write # lava-test.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -3,14 +3,15 @@ name: Build on PR
 on:
   pull_request:
 
-# implicitely set all other permissions to none
-permissions:
-  contents: read # debos.yml lava-schema-check.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   event-file:
     name: "Upload event file"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/upload-artifact
     steps:
     - name: Upload
       uses: actions/upload-artifact@v7
@@ -24,7 +25,11 @@ jobs:
       matrix:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
+    permissions:
+      contents: read # debos.yml
     with:
       suite: ${{ matrix.suite }}
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
+    permissions:
+      contents: read # lava-schema-check.yml

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read # actions/upload-artifact
     steps:
     - name: Upload
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Event File
         path: ${{ github.event_path }}

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -4,12 +4,8 @@ on:
   push:
     branches: [main]
 
-# implicitely set all other permissions to none
-permissions:
-  checks: write # lava-test.yml
-  contents: read # debos.yml lava-schema-check.yml lava-test.yml
-  packages: read # lava-test.yml
-  pull-requests: write # lava-test.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build-daily:
@@ -18,13 +14,22 @@ jobs:
       matrix:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
+    permissions:
+      contents: read # debos.yml
     with:
       suite: ${{ matrix.suite }}
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
+    permissions:
+      contents: read # lava-schema-check.yml
   test:
     uses: ./.github/workflows/lava-test.yml
     needs: [build-daily, schema-check]
+    permissions:
+      checks: write # lava-test.yml
+      contents: read # lava-test.yml
+      packages: read # lava-test.yml
+      pull-requests: write # lava-test.yml
     secrets: inherit
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -30,7 +30,8 @@ jobs:
       contents: read # lava-test.yml
       packages: read # lava-test.yml
       pull-requests: write # lava-test.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       # monaco-evk only validated against the linux-next/qcom-next/arduino

--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install sbuild and dependencies
         run: |

--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -8,8 +8,13 @@ on:
         required: true
         type: string
 
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read # actions/checkout
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -33,7 +33,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt -y full-upgrade
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -99,7 +99,7 @@ jobs:
               --config "$CONFIG" --output-dir upload
 
       - name: Upload as private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         with:
           path: upload
           # these should be the defaults; or ought to reuse BUILD_ID

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -41,6 +41,7 @@ env:
   # image build id; used for SBOM generation
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
   KERNEL_PACKAGES: ${{ inputs.kernelpackages }}
+  OVERLAYS: ${{ inputs.overlays }}
   SUITE: ${{ inputs.suite }}
   DEBOS_EXTRA_ARGS: -t suite:${{ inputs.suite }} ${{ inputs.debos_extra_args }}
   PREFIX: ${{ inputs.suite }}
@@ -138,7 +139,7 @@ jobs:
           esac
 
           debos \
-              -t overlays:'${{ inputs.overlays }}' \
+              -t "overlays:$OVERLAYS" \
               -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
               -t kernelpackages:"$kernel_packages" \

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Copy U-Boot for RB1 from EFS
         run: cp -av "/efs/u-boot-rb1-latest/rb1-boot.img" .

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -70,7 +70,7 @@ jobs:
           apt -y upgrade
           apt -y full-upgrade
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -186,7 +186,7 @@ jobs:
 
       # upload to a cloud storage space accessible by Axiom
       - name: Upload private artifacts (S3)
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         id: upload_artifacts_s3
         with:
           path: debos-artifacts
@@ -242,7 +242,7 @@ jobs:
           done
 
       - name: Upload SBOMs as private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         id: upload_sbom_artifacts
         with:
           path: sboms
@@ -260,7 +260,7 @@ jobs:
           echo "## Download URL" >> $GITHUB_STEP_SUMMARY
           echo "[${build_url}](${build_url})" >> $GITHUB_STEP_SUMMARY
       - name: Upload build URL
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build_url
           path: build_url

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -33,9 +33,10 @@ on:
         description: "URL to retrieve build artifacts"
         value: ${{ jobs.build-debos.outputs.url }}
 
-# implicitely set all other permissions to none
-permissions:
-  contents: read # actions/checkout
+# grant nothing by default; every job below declares the scopes it needs. these
+# are also capped by the calling job's permissions: block, so callers have to
+# grant at least as much.
+permissions: {}
 
 env:
   # image build id; used for SBOM generation
@@ -49,6 +50,8 @@ env:
 jobs:
   build-debos:
     name: Build and upload debos recipes (${{ inputs.suite }})
+    permissions:
+      contents: read # actions/checkout
     outputs:
       url: ${{ steps.upload_artifacts_s3.outputs.url }}
     runs-on: [self-hosted, qcom-u2404, arm64]

--- a/.github/workflows/efs-maintenance.yml
+++ b/.github/workflows/efs-maintenance.yml
@@ -46,9 +46,8 @@ on:
         type: string
         default: '30'
 
-# implicitely set all other permissions to none
-permissions:
-  contents: read
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 env:
   EFS_NEW_PATH: /efs/qli/qcom-deb-images
@@ -58,6 +57,8 @@ env:
 jobs:
   efs-maintenance:
     name: EFS maintenance
+    # only prunes files under /efs, never touches the repository
+    permissions: {}
     # don't run from forks of the main repository
     if: github.repository == 'qualcomm-linux/qcom-deb-images'
     runs-on: [self-hosted, qcom-u2404, amd64]

--- a/.github/workflows/efs-maintenance.yml
+++ b/.github/workflows/efs-maintenance.yml
@@ -53,6 +53,7 @@ permissions:
 env:
   EFS_NEW_PATH: /efs/qli/qcom-deb-images
   EFS_OLD_PATH: /efs/qli/metaqcom/gh-runners/quic-yocto/downloads/qcom-deb-images
+  MAX_AGE_DAYS: ${{ inputs.max_age_days }}
 
 jobs:
   efs-maintenance:
@@ -77,7 +78,7 @@ jobs:
         if: ${{ inputs.age_cleanup || github.event_name == 'schedule' }}
         run: |
           set -ux
-          max_age_days="${{ inputs.max_age_days }}"
+          max_age_days="$MAX_AGE_DAYS"
 
           if [ ! -d "${EFS_NEW_PATH}" ]; then
             echo "New EFS directory ${EFS_NEW_PATH} does not exist, skipping"

--- a/.github/workflows/lava-schema-check.yml
+++ b/.github/workflows/lava-schema-check.yml
@@ -3,13 +3,16 @@ name: Check LAVA templates
 on:
   workflow_call:
 
-# implicitely set all other permissions to none
-permissions:
-  contents: read # actions/checkout
+# grant nothing by default; every job below declares the scopes it needs. these
+# are also capped by the calling job's permissions: block, so callers have to
+# grant at least as much.
+permissions: {}
 
 jobs:
   schema-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
     container: ghcr.io/linux-validation/lava/lava-server-amd64:2026.05-qualcomm-2026.05-22-d5988428c
     steps:
       - name: Clone repository

--- a/.github/workflows/lava-schema-check.yml
+++ b/.github/workflows/lava-schema-check.yml
@@ -16,7 +16,7 @@ jobs:
     container: ghcr.io/linux-validation/lava/lava-server-amd64:2026.05-qualcomm-2026.05-22-d5988428c
     steps:
       - name: Clone repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/lava-schema-check.yml
+++ b/.github/workflows/lava-schema-check.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Schema check
         run: |
           DEVICE_TYPE="my-device"

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -110,9 +110,10 @@ jobs:
           persist-credentials: false
 
       - name: Update test definition ${{ matrix.target }}
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           # e.g. qrb2210-rb1/boot.yaml
-          TARGET="${{ matrix.target }}"
           TEMPLATE="${LAVA_CI}${TARGET}"
           # left-side – e.g. qrb2210-rb1
           DEVICE_TYPE="${TARGET%/*}"

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -19,12 +19,10 @@ on:
         type: string
         default: ''
 
-# implicitely set all other permissions to none
-permissions:
-  checks: write # EnricoMi/publish-unit-test-result-action
-  contents: read # actions/checkout
-  packages: read # actions/download-artifact
-  pull-requests: write # EnricoMi/publish-unit-test-result-action
+# grant nothing by default; every job below declares the scopes it needs. these
+# are also capped by the calling job's permissions: block, so callers have to
+# grant at least as much.
+permissions: {}
 
 env:
   BUILD_URL: ${{ inputs.url }}
@@ -36,6 +34,8 @@ env:
 jobs:
   prepare-job-list:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
     outputs:
       jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
       has_jobs: ${{ steps.listjobs.outputs.has_jobs }}
@@ -98,6 +98,8 @@ jobs:
     needs: prepare-job-list
     if: needs.prepare-job-list.outputs.has_jobs == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
     name: Submit ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -154,6 +156,11 @@ jobs:
     name: Publish Tests Results
     needs: submit-job
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # EnricoMi/publish-unit-test-result-action
+      contents: read # EnricoMi/publish-unit-test-result-action
+      packages: read # actions/download-artifact
+      pull-requests: write # EnricoMi/publish-unit-test-result-action
 
     steps:
       # Artifacts live at the run level and persist across re-run attempts, so

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Print trigger
         run: |
           echo "Triggered by ${{ github.event_name }}"
@@ -106,6 +107,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Update test definition ${{ matrix.target }}
         run: |

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -47,7 +47,7 @@ jobs:
       has_jobs: ${{ steps.listjobs.outputs.has_jobs }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -112,7 +112,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-job-list.outputs.jobmatrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -141,7 +141,7 @@ jobs:
 
       - name: Submit ${{ matrix.target }}
         timeout-minutes: 240
-        uses: foundriesio/lava-action@v13
+        uses: foundriesio/lava-action@3d40f621e0cd5acec50f557783b755f278ca892d # v13
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'
@@ -174,12 +174,12 @@ jobs:
       # download-artifact tries to fetch stale artifacts from superseded
       # attempts (and the other suite) and 404s on the orphaned ones.
       - name: Download test results (this debian suite; latest per board)
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: test-results-${{ inputs.suite }}-*
       - name: Download job details (this debian suite, this run attempt)
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: ${{ inputs.suite }}-${{ github.run_attempt }}-test-job-*
@@ -190,7 +190,7 @@ jobs:
           ls -R $GITHUB_WORKSPACE
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           files: "${{ github.workspace }}/artifacts/**/*.xml"
 

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -18,6 +18,12 @@ on:
         description: JSON array of board names to exclude (empty = none excluded)
         type: string
         default: ''
+    # this is the only workflow that consumes a secret; like permissions:, it
+    # has to be named again by every caller down the chain
+    secrets:
+      LAVATOKEN:
+        description: API token used to submit jobs to LAVA
+        required: true
 
 # grant nothing by default; every job below declares the scopes it needs. these
 # are also capped by the calling job's permissions: block, so callers have to

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -7,17 +7,19 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-permissions:
-  checks: write # linux.yml
-  contents: read # linux.yml
-  packages: read # linux.yml
-  pull-requests: write # linux.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
+    permissions:
+      checks: write # linux.yml
+      contents: read # linux.yml
+      packages: read # linux.yml
+      pull-requests: write # linux.yml
     with:
       kernel_name: arduino
       build_linux_deb_extra_args: '--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/arduino'

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -31,4 +31,5 @@ jobs:
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/258
       debos_extra_args: '-t overlays:qsc-deb-releases,workaround-hexagon-dsp-binaries-monza,workaround-initramfs-firmware-monaco'
       lava_boards_include: '["monaco-arduino-monza", "monaco-evk"]'
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -7,17 +7,19 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-permissions:
-  checks: write # linux.yml
-  contents: read # linux.yml
-  packages: read # linux.yml
-  pull-requests: write # linux.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
+    permissions:
+      checks: write # linux.yml
+      contents: read # linux.yml
+      packages: read # linux.yml
+      pull-requests: write # linux.yml
     with:
       kernel_name: glymur
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'

--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -28,4 +28,5 @@ jobs:
       skip_qemu_tests: true
       skip_lava_tests: false
       lava_boards_include: '["glymur-crd"]'
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -7,17 +7,19 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-permissions:
-  checks: write # linux.yml
-  contents: read # linux.yml
-  packages: read # linux.yml
-  pull-requests: write # linux.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
+    permissions:
+      checks: write # linux.yml
+      contents: read # linux.yml
+      packages: read # linux.yml
+      pull-requests: write # linux.yml
     with:
       kernel_name: linux-next
       build_linux_deb_extra_args: '--linux-next'

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -24,4 +24,5 @@ jobs:
       kernel_name: linux-next
       build_linux_deb_extra_args: '--linux-next'
       lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -7,17 +7,19 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-permissions:
-  checks: write # linux.yml
-  contents: read # linux.yml
-  packages: read # linux.yml
-  pull-requests: write # linux.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
+    permissions:
+      checks: write # linux.yml
+      contents: read # linux.yml
+      packages: read # linux.yml
+      pull-requests: write # linux.yml
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -24,4 +24,5 @@ jobs:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'
       lava_boards_exclude: '["glymur-crd"]'
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -7,17 +7,19 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-permissions:
-  checks: write # linux.yml
-  contents: read # linux.yml
-  packages: read # linux.yml
-  pull-requests: write # linux.yml
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   build:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
+    permissions:
+      checks: write # linux.yml
+      contents: read # linux.yml
+      packages: read # linux.yml
+      pull-requests: write # linux.yml
     with:
       kernel_name: mainline
       # monaco-evk only validated against the linux-next/qcom-next/arduino

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -26,4 +26,5 @@ jobs:
       # kernels so far; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
       lava_boards_exclude: '["glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,12 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      LAVATOKEN:
+        description: API token used to submit jobs to LAVA
+        # only forwarded to lava-test.yml; callers passing skip_lava_tests
+        # never reach that job, so this stays optional
+        required: false
   # allow manual runs
   workflow_dispatch:
     inputs:
@@ -172,7 +178,8 @@ jobs:
       contents: read # lava-test.yml
       packages: read # lava-test.yml
       pull-requests: write # lava-test.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
     with:
       url: ${{ needs.debos-linux-deb.outputs.artifacts_url }}
       suite: trixie

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,12 +54,10 @@ on:
         required: false
         type: string
 
-# implicitely set all other permissions to none
-permissions:
-  checks: write # lava-test.yml
-  contents: read # actions/checkout debos.yml lava-test.yml
-  packages: read # lava-test.yml
-  pull-requests: write # lava-test.yml
+# grant nothing by default; every job below declares the scopes it needs. these
+# are also capped by the calling job's permissions: block, so callers have to
+# grant at least as much.
+permissions: {}
 
 env:
   # github runs are only unique per repository and may also be re-run; create a
@@ -79,6 +77,8 @@ jobs:
   build-linux-deb:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read # actions/checkout
     # for cross-builds
     runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both
@@ -156,6 +156,8 @@ jobs:
   debos-linux-deb:
     needs: build-linux-deb
     uses: ./.github/workflows/debos.yml
+    permissions:
+      contents: read # debos.yml
     with:
       kernelpackages: efs/${{ inputs.kernel_name || 'mainline' }}
       debos_extra_args: ${{ inputs.debos_extra_args }}
@@ -165,6 +167,11 @@ jobs:
     if: ${{ !inputs.skip_lava_tests }}
     uses: ./.github/workflows/lava-test.yml
     needs: debos-linux-deb
+    permissions:
+      checks: write # lava-test.yml
+      contents: read # lava-test.yml
+      packages: read # lava-test.yml
+      pull-requests: write # lava-test.yml
     secrets: inherit
     with:
       url: ${{ needs.debos-linux-deb.outputs.artifacts_url }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,7 +94,7 @@ jobs:
       volumes:
         - /efs/qli/qcom-deb-images:/efs
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -151,7 +151,7 @@ jobs:
           sync
 
       - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         id: upload_artifacts
         with:
           path: artifacts

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,6 +91,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # make sure we have latest packages first, to get latest fixes, to avoid
       # an automated update while we're building, and to prevent version skews

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -6,13 +6,15 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
- contents: read
- security-events: write
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 jobs:
   preflight:
     name: Run QC Preflight Checks
+    permissions:
+      contents: read # reusable-qcom-preflight-checks-orchestrator.yml
+      security-events: write # reusable-qcom-preflight-checks-orchestrator.yml
     uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
     with:
       enable-semgrep-scan: true

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read # reusable-qcom-preflight-checks-orchestrator.yml
       security-events: write # reusable-qcom-preflight-checks-orchestrator.yml
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@15377d14305caeaeacbda9b24f93f57258e55b37 # v2.0.8
     with:
       enable-semgrep-scan: true
       enable-dependency-review: true

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
             days-before-close: -1
             days-before-issue-stale: 30

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -3,8 +3,14 @@ on:
     schedule:
       - cron: '30 1 * * *'
 
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
+
 jobs:
   stale:
+    permissions:
+      issues: write # actions/stale
+      pull-requests: write # actions/stale
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -8,9 +8,8 @@ on:
   push:
     branches: [main]
 
-# implicitely set all other permissions to none
-permissions:
-  contents: read # actions/checkout
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 # cancel in progress builds for this workflow triggered by the same ref
 concurrency:
@@ -21,6 +20,8 @@ jobs:
   flake8:
     name: Install and run Flake8 on Python scripts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
     steps:
       - name: Install flake8
         run: sudo apt update && sudo apt -y install file flake8
@@ -38,6 +39,8 @@ jobs:
   pylint:
     name: Install and run Pylint on Python scripts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
     steps:
       - name: Install Pylint and dependencies
         run: sudo apt update && sudo apt -y install file pylint python3-voluptuous python3-defusedxml
@@ -55,6 +58,8 @@ jobs:
   shellcheck:
     name: Install and run ShellCheck on shell scripts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
     steps:
       - name: Install ShellCheck
         run: sudo apt update && sudo apt -y install shellcheck file

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Flake8 and dependencies
         run: |
@@ -44,6 +45,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Pylint (error mode)
         run: |
@@ -60,6 +62,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run ShellCheck
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install flake8
         run: sudo apt update && sudo apt -y install file flake8
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -45,7 +45,7 @@ jobs:
       - name: Install Pylint and dependencies
         run: sudo apt update && sudo apt -y install file pylint python3-voluptuous python3-defusedxml
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -64,7 +64,7 @@ jobs:
       - name: Install ShellCheck
         run: sudo apt update && sudo apt -y install shellcheck file
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -2,7 +2,12 @@ name: Test PR build
 
 run-name: "Tests triggered by PR: ${{ github.event.workflow_run.display_title }}"
 
-on:
+# workflow_run is required to comment on PRs from forks: pull_request runs
+# from a fork get a read-only token and cannot post a comment. This workflow
+# never checks out or executes PR-controlled code, it only reads artifacts and
+# the event payload, so the usual workflow_run privilege-escalation route does
+# not apply.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["Build on PR"]
     types:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -27,7 +27,7 @@ jobs:
       url: ${{ steps.set-build-url.outputs.url }}
     steps:
       - name: 'Download build URL'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -97,19 +97,19 @@ jobs:
       # artifacts from superseded attempts and 404 on the orphaned ones. These
       # patterns must match the names set in lava-test.yml (suite: trixie above).
       - name: Download test results (latest per board)
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: test-results-trixie-*
 
       - name: Download job details (this run attempt)
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: trixie-${{ github.run_attempt }}-test-job-*
 
       - name: Download event file
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             run-id: ${{ github.event.workflow_run.id }}
             path: artifacts
@@ -121,7 +121,7 @@ jobs:
           ls -R $GITHUB_WORKSPACE
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
@@ -146,7 +146,7 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           file-path: pr-comment.txt
           pr-number: ${{ steps.pr_comment_prep.outputs.pr_number }}

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -67,7 +67,8 @@ jobs:
       contents: read # lava-test.yml
       packages: read # lava-test.yml
       pull-requests: write # lava-test.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
     needs: retrieve-build-url
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -120,8 +120,10 @@ jobs:
 
       - name: Prepare PR comment
         id: pr_comment_prep
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          echo "## Test jobs for commit ${{ github.event.workflow_run.head_sha }}" > pr-comment.txt
+          echo "## Test jobs for commit ${HEAD_SHA}" > pr-comment.txt
           for json_file in $(find ${{ github.workspace }} -name "*test-job-*.json")
           do
               DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -13,18 +13,15 @@ on: # zizmor: ignore[dangerous-triggers]
     types:
       - completed
 
-# implicitely set all other permissions to none
-permissions:
-  checks: write # lava-test.yml EnricoMi/publish-unit-test-result-action
-  contents: read # lava-test.yml actions/checkout
-  packages: read # lava-test.yml actions/download-artifact
-  # lava-test.yml EnricoMi/publish-unit-test-result-action
-  # thollander/actions-comment-pull-request
-  pull-requests: write
+# grant nothing by default; every job below declares the scopes it needs, so
+# retrieve-build-url stays read-only
+permissions: {}
 
 jobs:
   retrieve-build-url:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/github-script
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       url: ${{ steps.set-build-url.outputs.url }}
@@ -65,6 +62,11 @@ jobs:
 
   test:
     uses: ./.github/workflows/lava-test.yml
+    permissions:
+      checks: write # lava-test.yml
+      contents: read # lava-test.yml
+      packages: read # lava-test.yml
+      pull-requests: write # lava-test.yml
     secrets: inherit
     needs: retrieve-build-url
     with:
@@ -82,6 +84,13 @@ jobs:
     name: "Publish Tests Results"
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # EnricoMi/publish-unit-test-result-action
+      contents: read # EnricoMi/publish-unit-test-result-action
+      packages: read # actions/download-artifact
+      # EnricoMi/publish-unit-test-result-action
+      # thollander/actions-comment-pull-request
+      pull-requests: write
     steps:
       # Scope to the test suite's current results so a re-run doesn't pull stale
       # artifacts from superseded attempts and 404 on the orphaned ones. These

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # make sure we have latest packages first, to get latest fixes, to avoid
       # an automated update while we're building, and to prevent version skews

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -35,7 +35,7 @@ jobs:
       volumes:
         - /efs/qli/qcom-deb-images:/efs
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -83,7 +83,7 @@ jobs:
           sync
 
       - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         id: upload_artifacts
         with:
           path: artifacts

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -7,9 +7,8 @@ on:
   # allow manual runs
   workflow_dispatch:
 
-# implicitely set all other permissions to none
-permissions:
-  contents: read # actions/checkout
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
 
 env:
   # github runs are only unique per repository and may also be re-run; create a
@@ -25,6 +24,8 @@ jobs:
   build-u-boot-rb1:
     # don't run cron from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read # actions/checkout
     # for cross-builds
     runs-on: [self-hosted, qcom-u2404, amd64]
     # alternative for native builds, but overkill to do both


### PR DESCRIPTION
`zizmor` reported 53 findings across our workflows at the default `regular`
persona. `semgrep` also reduced some issues.
This clears the codebase of all of the issues; a run over the whole repo is now quiet.

Each audit is addressed in its own commit, so the reasoning stays attached to
each change.

Fixes: #166
Fixes: #167