### PR TITLE
ci!: use qcom-next as the default kernel

### DIFF
--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -7,9 +7,11 @@
 name: Daily Build (Vanilla Debian)
 
 on:
-  # run daily at 6:30am
+  # run daily at 10:30am, last of the daily builds: this tracks upstream Debian
+  # rather than what QLI ships, so it gets the LAVA queue once the kernel builds
+  # are done with it
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '30 10 * * *'
   # allow manual runs
   workflow_dispatch:
 

--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -1,0 +1,67 @@
+# Builds & Tests Vanilla Debian images:
+#  - kernel installed from the Debian archive
+#  - no Qualcomm overlay repos or packages
+#
+# This workflow tracks the state of upstream Debian on supported boards.
+
+name: Daily Build (Vanilla Debian)
+
+on:
+  # run daily at 6:30am
+  schedule:
+    - cron: '30 6 * * *'
+  # allow manual runs
+  workflow_dispatch:
+
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
+
+jobs:
+  build-daily-debian:
+    # don't run cron from forks of the main repository or from other branches
+    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [trixie, forky]
+    uses: ./.github/workflows/debos.yml
+    permissions:
+      contents: read # debos.yml
+    with:
+      suite: ${{ matrix.suite }}
+      # plain Debian kernel: the Debian kernel and none of the Qualcomm overlays
+      # so that we simply test the state of upstream Debian
+      overlays: none
+      kernelpackages: linux-image-arm64
+      # ... and none of the Qualcomm APT sources either, so that the upgrade
+      # which follows the bootstrap only ever pulls in packages from Debian
+      debos_extra_args: -t qliaptrepo:false
+
+  test-daily-debian:
+    # don't run cron from forks of the main repository or from other branches
+    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [trixie, forky]
+    uses: ./.github/workflows/lava-test.yml
+    needs: build-daily-debian
+    permissions:
+      checks: write # lava-test.yml
+      contents: read # lava-test.yml
+      packages: read # lava-test.yml
+      pull-requests: write # lava-test.yml
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
+    with:
+      url: ${{ needs.build-daily-debian.outputs.artifacts_url }}
+      suite: ${{ matrix.suite }}
+      # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
+      # glymur-crd can't boot the distro kernel, only qcom-next
+      # monaco-evk only validated against the linux-next/qcom-next/arduino
+      # kernels so far, not the distro kernel; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
+      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      # failures here are about upstream Debian, not about qcom-deb-images;
+      # they are reported through this workflow instead of gating our work
+      report_test_results_externally: false

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -1,3 +1,9 @@
+# Builds & Tests QLI Debian images:
+#  - qcom-next kernel
+#  - Qualcomm overlay repos and packages
+#
+# This workflow tracks the state of QLI Debian on supported boards.
+
 name: Daily Build
 
 on:
@@ -23,6 +29,10 @@ jobs:
       contents: read # debos.yml
     with:
       suite: ${{ matrix.suite }}
+      # QLI targets qcom-next; consume the debs published to EFS by the
+      # "Daily qcom-next linux build" workflow rather than a kernel from an
+      # APT repository
+      kernelpackages: efs/qcom-next
 
   test-daily:
     # don't run cron from forks of the main repository or from other branches
@@ -43,9 +53,3 @@ jobs:
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
-      # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
-      # glymur-crd can't boot the distro kernel, only qcom-next
-      # monaco-evk only validated against the linux-next/qcom-next/arduino
-      # kernels so far, not the distro kernel; see
-      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -6,10 +6,23 @@
 
 name: Daily Build
 
-on:
-  # run daily at 6:30am
-  schedule:
-    - cron: '30 6 * * *'
+# runs once the daily qcom-next kernel build is done, so that the images are
+# built from the debs it has just published to EFS; this also runs when that
+# build fails, in which case EFS still holds the previous kernel debs and the
+# images are worth building and testing anyway.
+#
+# workflow_run is required to chain onto that build: it is the only trigger
+# that fires when another workflow completes. The triggering workflow only
+# runs from schedule or workflow_dispatch on main of this repository, so its
+# event payload is never attacker-controlled, the jobs below are additionally
+# guarded on the repository and ref. Nothing here checks out or executes
+# code from the triggering run, so the usual workflow_run privilege-escalation
+# route does not apply.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["Daily qcom-next linux build"]
+    types:
+      - completed
   # allow manual runs
   workflow_dispatch:
 
@@ -18,7 +31,7 @@ permissions: {}
 
 jobs:
   build-daily:
-    # don't run cron from forks of the main repository or from other branches
+    # don't run from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
@@ -35,7 +48,7 @@ jobs:
       kernelpackages: efs/qcom-next
 
   test-daily:
-    # don't run cron from forks of the main repository or from other branches
+    # don't run from forks of the main repository or from other branches
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -29,6 +29,10 @@ jobs:
       contents: read # debos.yml
     with:
       suite: ${{ matrix.suite }}
+      # QLI targets qcom-next; consume the debs published to EFS by the
+      # "Daily qcom-next linux build" workflow rather than a kernel from an
+      # APT repository
+      kernelpackages: efs/qcom-next
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
     permissions:

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -18,6 +18,10 @@ jobs:
       contents: read # debos.yml
     with:
       suite: ${{ matrix.suite }}
+      # QLI targets qcom-next; consume the debs published to EFS by the
+      # "Daily qcom-next linux build" workflow rather than a kernel from an
+      # APT repository
+      kernelpackages: efs/qcom-next
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
     permissions:
@@ -34,8 +38,3 @@ jobs:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
-      # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
-      # monaco-evk only validated against the linux-next/qcom-next/arduino
-      # kernels so far; see
-      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -97,8 +97,22 @@ jobs:
           case "$KERNEL_PACKAGES" in
             efs/*)
               mkdir -v local-apt-repo/kernel
-              # get kernel from EFS
-              cp -av "/efs/${KERNEL_PACKAGES#efs/}/"*.deb local-apt-repo/kernel
+              # get kernel from EFS; the directory is a symlink published by
+              # the matching kernel workflow (linux.yml via e.g.
+              # linux-daily-qcom-next.yml), so report a missing or empty one
+              # rather than failing later with a confusing APT error
+              efs_kernel_dir="/efs/${KERNEL_PACKAGES#efs/}"
+              if [ ! -d "$efs_kernel_dir" ]; then
+                  echo "ERROR: ${efs_kernel_dir} does not exist" >&2
+                  echo "run the workflow publishing '${KERNEL_PACKAGES#efs/}' kernel debs first" >&2
+                  exit 1
+              fi
+              cp -av "${efs_kernel_dir}/"*.deb local-apt-repo/kernel
+              if ! ls local-apt-repo/kernel/linux-image-*.deb >/dev/null 2>&1; then
+                  echo "ERROR: ${efs_kernel_dir} contains no linux-image-*.deb" >&2
+                  echo "run the workflow publishing '${KERNEL_PACKAGES#efs/}' kernel debs first" >&2
+                  exit 1
+              fi
             ;;
           esac
 

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -272,4 +272,8 @@ jobs:
            # instead but all at once. See #74 and #159.
 
            # rootfs/ is a build artifact, so should not be scanned for tests
-           py.test-3 --ignore=rootfs
+           # --verbose enables verbose output which shows each test's full name
+           #   and full result which makes CI failures much easier to diagnose
+           # --capture=no so pytest doesn't swallow stdout and only prints it
+           #   after a job fails. Instead, stream the log live.
+           py.test-3 --verbose --capture=no --ignore=rootfs

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -17,7 +17,7 @@ on:
           repositories (e.g. linux-image-arm64) or name of a EFS kernel
           package directory (e.g. efs/mainline)
         type: string
-        default: default-ci
+        default: linux-image-arm64
       debos_extra_args:
         description: Extra arguments to pass to debos (e.g. -t dtb:qcom/some.dtb)
         type: string
@@ -43,7 +43,6 @@ env:
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
   KERNEL_PACKAGES: ${{ inputs.kernelpackages }}
   OVERLAYS: ${{ inputs.overlays }}
-  SUITE: ${{ inputs.suite }}
   DEBOS_EXTRA_ARGS: -t suite:${{ inputs.suite }} ${{ inputs.debos_extra_args }}
   PREFIX: ${{ inputs.suite }}
 
@@ -126,7 +125,6 @@ jobs:
         run: |
           set -ux
           kernel_packages="$KERNEL_PACKAGES"
-          suite="$SUITE"
           case "$kernel_packages" in
             # NB: this is slightly weak as we collapse
             # kernelpackages which is potentially a list and only
@@ -139,19 +137,6 @@ jobs:
             # 
             efs/*)
               kernel_packages="$(find local-apt-repo/kernel -type f \( -name 'linux-image-*' -o -name 'linux-headers-*' \) -not -name '*dbg*'|xargs -n1 basename|cut -f1 -d_|sort|paste -sd,)"
-              ;;
-            default-ci)
-              case "$suite" in
-                trixie)
-                  # the package name will be passed to APT which interprets the trailing
-                  # plus sign in the package name as a request to install the package, so
-                  # use two plus signs
-                  kernel_packages="linux-image-6.16.7-qcom1++"
-                  ;;
-                *)
-                  kernel_packages="linux-image-arm64"
-                  ;;
-              esac
               ;;
           esac
 

--- a/.github/workflows/efs-maintenance.yml
+++ b/.github/workflows/efs-maintenance.yml
@@ -24,9 +24,11 @@
 name: EFS Maintenance
 
 on:
-  # run every Monday at 5:00am UTC, before the other workflows
+  # run every Monday at 00:30am UTC, before the other workflows: the earliest of
+  # those is the daily qcom-next kernel build at 2:30am, and pruning artifacts
+  # while a build is publishing to EFS is best avoided
   schedule:
-    - cron: '0 5 * * 1'
+    - cron: '30 0 * * 1'
   workflow_dispatch:
     inputs:
       create_new_location:

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -18,6 +18,15 @@ on:
         description: JSON array of board names to exclude (empty = none excluded)
         type: string
         default: ''
+      report_test_results_externally:
+        description: >
+          Report results outside this workflow run: as a check run attached to
+          the commit and as a comment on any associated pull request. Set to
+          false for builds whose failures say something about the code under
+          test rather than about qcom-deb-images; results then stay in the job
+          summary, which is written either way.
+        type: boolean
+        default: true
     # this is the only workflow that consumes a secret; like permissions:, it
     # has to be named again by every caller down the chain
     secrets:
@@ -193,6 +202,13 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           files: "${{ github.workspace }}/artifacts/**/*.xml"
+          # when not reporting externally, failures must not show up as a red
+          # check on the commit (which may well be on main) or as a pull
+          # request comment; the job summary keeps the full table either way.
+          # note the action never fails this job on test failures: that would
+          # need action_fail, which defaults to false and we leave alone.
+          check_run: ${{ inputs.report_test_results_externally }}
+          comment_mode: ${{ inputs.report_test_results_externally && 'always' || 'off' }}
 
       - name: Publish Test Job Details
         run: |

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -1,9 +1,10 @@
 name: Daily arduino linux build
 
 on:
-  # run daily at 6:30am
+  # run daily at 6:30am, once the qcom-next build (2:30am) and the "Daily Build"
+  # chained onto it have submitted their LAVA jobs
   schedule:
-    - cron: '30 5 * * *'
+    - cron: '30 6 * * *'
   # allow manual runs
   workflow_dispatch:
 

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -23,6 +23,9 @@ jobs:
     with:
       kernel_name: linux-next
       build_linux_deb_extra_args: '--linux-next'
+      # reference build: we want the debs and the LAVA results to compare
+      # against, but its failures must not gate qcom-deb-images work
+      lava_report_test_results_externally: false
       lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -1,9 +1,10 @@
 name: Daily linux-next linux build
 
 on:
-  # run daily at 7:30am
+  # run daily at 8:30am, two hours behind the arduino kernel build, so that our
+  # LAVA jobs don't queue up behind its own
   schedule:
-    - cron: '30 7 * * *'
+    - cron: '30 8 * * *'
   # allow manual runs
   workflow_dispatch:
 

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -1,9 +1,14 @@
 name: Daily qcom-next linux build
 
 on:
-  # run daily at 6:30am
+  # run daily at 2:30am. qcom-next is what QLI ships, so it goes first of the
+  # scheduled builds and gets an empty LAVA queue; the rest of the day's builds
+  # are staggered behind it (arduino 6:30am, linux-next 8:30am, vanilla Debian
+  # images 10:30am) so that they don't all submit LAVA jobs at once. The "Daily
+  # Build" workflow chains onto this one, so its LAVA jobs land later still,
+  # around 5:30am.
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '30 2 * * *'
   # allow manual runs
   workflow_dispatch:
 

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -23,5 +23,8 @@ jobs:
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260731 prune.config qcom.config'
+      # stop after publishing the debs to EFS; the "Daily Build" workflow
+      # picks them up and builds and tests the images on every suite
+      skip_image_build: true
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -1,9 +1,11 @@
 name: Weekly mainline linux build
 
 on:
-  # run weekly on Monday at 6:30am
+  # run weekly on Monday at 2:30pm, after the daily builds and the weekly u-boot
+  # build have finished for the day, so this doesn't add its LAVA jobs on top of
+  # theirs
   schedule:
-    - cron: '30 6 * * 1'
+    - cron: '30 14 * * 1'
   # allow manual runs
   workflow_dispatch:
 

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -22,6 +22,9 @@ jobs:
       pull-requests: write # linux.yml
     with:
       kernel_name: mainline
+      # reference build: we want the debs and the LAVA results to compare
+      # against, but its failures must not gate qcom-deb-images work
+      lava_report_test_results_externally: false
       # monaco-evk only validated against the linux-next/qcom-next/arduino
       # kernels so far; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,13 @@ on:
         required: false
         type: string
         default: ''
+      skip_image_build:
+        description: >
+          Skip building image. The LAVA tests boot that image, so the test
+          job is skipped along with it
+        required: false
+        type: boolean
+        default: false
       skip_qemu_tests:
         description: Skip QEMU tests
         required: false
@@ -160,6 +167,7 @@ jobs:
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
 
   debos-linux-deb:
+    if: ${{ !inputs.skip_image_build }}
     needs: build-linux-deb
     uses: ./.github/workflows/debos.yml
     permissions:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,6 +45,15 @@ on:
         required: false
         type: string
         default: ''
+      lava_report_test_results_externally:
+        description: >
+          Report LAVA results as a check run on the commit and a comment on
+          associated pull requests. Set false for kernels we track for
+          reference but don't gate development on; their results then stay in
+          the job summary
+        required: false
+        type: boolean
+        default: true
     secrets:
       LAVATOKEN:
         description: API token used to submit jobs to LAVA
@@ -193,3 +202,4 @@ jobs:
       suite: trixie
       boards_include: ${{ inputs.lava_boards_include }}
       boards_exclude: ${{ inputs.lava_boards_exclude }}
+      report_test_results_externally: ${{ inputs.lava_report_test_results_externally }}

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -76,11 +76,6 @@ jobs:
       # however the publish job below hard-codes this in its artifact
       # download patterns, so keep them in sync if this changes.
       suite: trixie
-      # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
-      # monaco-evk only validated against the linux-next/qcom-next/arduino
-      # kernels so far; see
-      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -1,9 +1,10 @@
 name: Build U-Boot for RB1
 
 on:
-  # run weekly on Monday at 8:30am
+  # run weekly on Monday at 12:30pm, once the daily builds are done with the
+  # self-hosted runners for the day
   schedule:
-    - cron: '30 6 * * 1'
+    - cron: '30 12 * * 1'
   # allow manual runs
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -59,23 +59,12 @@ scripts/build-u-boot-rb1.sh
 
 ### (optional) Build custom kernel
 
-Building a Linux kernel deb requires the following build-dependencies:
-```bash
-apt -y install git crossbuild-essential-arm64 make flex bison bc libdw-dev libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev debhelper-compat kmod python3 rsync coreutils
-```
+By default the image recipes will install the kernel provided by Debian.
 
-Note that to install `libssl-dev:arm64` on a non-arm64 host, you will need to
-enable arm64 as a foreign architecture first by running
-`dpkg --add-architecture arm64 && apt update`.
-
-Then, you can build a local Linux kernel deb from mainline with recommended config fragments:
-
-```bash
-scripts/build-linux-deb.py kernel-configs/*.config
-
-# or from linux-next:
-scripts/build-linux-deb.py --linux-next kernel-configs/*.config
-```
+Build a custom kernel if you want to run `qcom-next`, the kernel which the CI
+images use and recommended for maximum hardware compatibility, `mainline` or
+`linux-next`. See the [Kernel](#kernel) section for the build-dependencies and
+the build instructions, then come back here.
 
 ### Build the image
 
@@ -149,8 +138,9 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackages`: a `,`-separated list of kernel packages to install from
-  apt; defaults to `Debian’s linux-image-arm64`. Can (and should) be set to
-  `none` if you are providing local kernel package instead.
+  apt; defaults to `linux-image-arm64`. Set it to `none` when you are installing
+  a local kernel package. See the [Kernel](#kernel) section below for
+  more information.
 - `kernelpackage`: **deprecated**, superseded by `kernelpackages`; still
   accepted as a single package name for backwards compatibility.
 - `qliaptrepo`: configure the Qualcomm Linux APT repository in the root
@@ -273,6 +263,62 @@ NB: It's also possible to run qdl from the host while the board is not connected
 Once the image has booted, you can log in as the `debian` user, with the
 default `debian` password. The image should then ask you to change this default
 password to a safe one.
+
+## Kernel
+
+When building an image locally, by default the recipe will install the latest
+kernel from Debian.
+
+All of the CI-built images instead install
+[`qcom-next`](https://github.com/qualcomm-linux/kernel/tree/qcom-next), the
+Qualcomm Linux integration branch, which carries additional platform support.
+
+Build it yourself to get the same kernel the CI images use.
+
+Building a Linux kernel deb requires the following build-dependencies:
+```bash
+apt -y install git crossbuild-essential-arm64 make flex bison bc libdw-dev libelf-dev libssl-dev libssl-dev:arm64 dpkg-dev debhelper-compat kmod python3 rsync coreutils
+```
+
+Note that to install `libssl-dev:arm64` on a non-arm64 host, you will need to
+enable arm64 as a foreign architecture first by running
+`dpkg --add-architecture arm64 && apt update`.
+
+Then build `qcom-next` with the recommended config fragments:
+
+```bash
+# CI pins an exact version with `--ref`; without one this builds the qcom-next
+# branch tip.
+scripts/build-linux-deb.py --qcom-next prune.config qcom.config kernel-configs/*.config
+```
+
+Other trees can be built for comparison, for instance to check whether a
+problem also affects upstream:
+
+```bash
+# mainline
+scripts/build-linux-deb.py kernel-configs/*.config
+
+# linux-next
+scripts/build-linux-deb.py --linux-next kernel-configs/*.config
+```
+
+To build an image with a locally-built kernel, copy the resulting debs to
+`debos-recipes/local-debs/` and disable the apt-installed kernel when building
+the root filesystem:
+
+```bash
+EXTRA_DEBOS_OPTS="-t localdebs:local-debs/ -t kernelpackages:none" make rootfs.tar
+```
+
+Prebuilt Qualcomm kernel packages are also available from the overlay apt
+repository, as an alternative to building one:
+
+```bash
+# the trailing plus sign is doubled because apt reads a single one in a package
+# name as a request to install the package
+EXTRA_DEBOS_OPTS="-t kernelpackages:linux-image-<version>-qcom1++" make rootfs.tar
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
   `none` if you are providing local kernel package instead.
 - `kernelpackage`: **deprecated**, superseded by `kernelpackages`; still
   accepted as a single package name for backwards compatibility.
+- `qliaptrepo`: configure the Qualcomm Linux APT repository in the root
+  filesystem; defaults to `true`. Set it to `false` to leave the image with no
+  Qualcomm Linux APT sources.
 - `suite`: Debian suite to use, defaults to `trixie`.
 - `snapshot`: use snapshot apt archives for a reproducible build
   (`YYYYMMDDTHHMMSSZ`); logged to `/etc/buildinfo` as `SNAPSHOT=<date>`.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Qualcomm Linux deb images
 
-[![build on push status](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-on-push.yml?label=build%20on%20push)](https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-on-push.yml)
-[![daily build status](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-daily.yml?label=daily%20build)](https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-daily.yml)
-[![daily qcom-next build status](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-qcom-next.yml?label=daily%20qcom-next%20build)](https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-qcom-next.yml)
-[![daily linux-next build status](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-linux-next.yml?label=daily%20linux-next%20build)](https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-linux-next.yml)
-[![weekly mainline build status](https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-weekly-mainline.yml?label=weekly%20mainline%20build)](https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-weekly-mainline.yml)
-
 A collection of recipes to build Qualcomm Linux images for deb based
 operating systems.
 
@@ -23,6 +17,18 @@ recipes based on Debian trixie for boards such as:
 
 We are also working towards providing ready-to-use, pre-built images – stay
 tuned!
+
+## CI Status
+
+| Variant | Kernel build | Image build & boot test |
+| ------- | --- | --- |
+| Qualcomm Linux | [![qcom-next kernel, daily][qcom-next-badge]][qcom-next] | [![images, daily][images-badge]][images] |
+| Debian | *uses kernel from Debian Archive* | [![Vanilla Debian images, daily][debian-images-badge]][debian-images] |
+| Reference upstream kernels | [![linux-next, daily][linux-next-badge]][linux-next] [![mainline, weekly][mainline-badge]][mainline] | *covered by the kernel build* [^1] |
+| Project-specific builds | [![arduino, daily][arduino-badge]][arduino] | *covered by the kernel build* [^1] |
+
+[^1]: these builds compile the kernel, build an image and boot test the image in a single workflow, so the Kernel build reports all three.
+
 
 ## Requirements
 
@@ -370,3 +376,19 @@ We'd love to hear if you run into issues or have ideas for improvements. [Report
 ## License
 
 This project is licensed under the [BSD-3-clause License](https://spdx.org/licenses/BSD-3-Clause.html). See [LICENSE.txt](LICENSE.txt) for the full license text.
+
+<!-- link targets for the CI status badges at the top of this file; each
+     workflow needs two: the shields.io image and the Actions page it links to -->
+
+[qcom-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-qcom-next.yml
+[qcom-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-qcom-next.yml?label=qcom-next%20daily
+[images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-daily.yml
+[images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-daily.yml?label=images%20daily
+[debian-images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-daily-debian.yml
+[debian-images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-daily-debian.yml?label=Vanilla%20Debian%20images%20daily
+[linux-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-linux-next.yml
+[linux-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-linux-next.yml?label=linux-next%20daily
+[mainline]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-weekly-mainline.yml
+[mainline-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-weekly-mainline.yml?label=mainline%20weekly
+[arduino]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-arduino.yml
+[arduino-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-arduino.yml?label=arduino%20daily

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -73,7 +73,7 @@ def test_password_reset_required(vm):
     # https://github.com/qualcomm-linux/qcom-deb-images/issues/69
 
     # This takes a minute or two on a ThinkPad T14s Gen 6 Snapdragon
-    vm.expect_exact("debian login:", timeout=240)
+    vm.expect_exact("debian login:", timeout=420)
 
     vm.send("debian\r\n")
     vm.expect_exact("Password:")

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -5,6 +5,7 @@
 # $kernelpackage (singular) is deprecated, superseded by $kernelpackages
 {{- $kernelpackages := or .kernelpackages .kernelpackage "linux-image-arm64" }}
 {{- $overlays := or .overlays "qsc-deb-releases" }}
+{{- $qliaptrepo := or .qliaptrepo "true" }}
 {{- $buildid := or .buildid "" }}
 {{- $snapshot := or .snapshot "" }}
 {{- $suite := or .suite "trixie" }}
@@ -224,7 +225,9 @@ actions:
 {{- end }}
 
 # Qualcomm Linux maintains overlays for trixie/forky
-{{- if ne $suite "unstable" }}
+# but only configure the sources when enabled. Some builds (e.g. Vanilla Debian)
+# may not want to setup the QLI repo.
+{{- if and (eq $qliaptrepo "true") (ne $suite "unstable") }}
   - action: run
     description: Create Qualcomm Linux APT sources for {{ $suite }}
     chroot: true

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -364,7 +364,7 @@ actions:
       # WPA / WPA2 / WPA3 client support
       - wpasupplicant
 
-{{- if ne $suite "unstable" }}
+{{- if and (eq $qliaptrepo "true") (ne $suite "unstable") }}
   # fastrpc-tests is available from QLI overlays for trixie and forky
   - action: apt
     description: Install fastrpc-tests from QLI overlay


### PR DESCRIPTION
The current image recipes (in both CI and local development builds) mix several different kernel sources:
- the kernel from the Qualcomm `qsc-deb-releases` artifactory;
- the Debian kernel;
- separate `qcom-next`, `mainline` and `linux-next` kernels but by this repo's CI.

This can make failures difficult to diagnose and adds a layer of complexity.

Make `qcom-next` the default development kernel.

This also reorganises the surrounding CI so each kernel has a clear purpose:
- build and test all supported platforms with `qcom-next` in the default workflows;
- publish the `qcom-next` kernel packages first, then trigger image builds against the built packages;
- add a dedicated image build using the Debian kernel;
- mark `linux-next` and `mainline` kernel testing as experimental so failures remain visible without blocking development;
- make kernel selection explicit and fail early when expected kernel packages are missing;
- document which CI workflows gate development and which are reference/experimental builds.

The default image artifacts now install the `qcom-next` kernel on both trixie and forky. Debian kernel coverage remains available through a new workflow.

The additional `qcom-next` platform coverage also means the PR workflow now creates LAVA checks for boards which were previously excluded. The required status checks in the branch protection configuration will need updating before this is merged.

Fixes: #289
Fixes: #487
Fixed: #530