### PR TITLE
feat: add Weston & multimedia image variants

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -24,11 +24,13 @@ jobs:
       fail-fast: false
       matrix:
         suite: [trixie, forky]
+        variant: [default, weston-multimedia]
     uses: ./.github/workflows/debos.yml
     permissions:
       contents: read
     with:
       suite: ${{ matrix.suite }}
+      variant: ${{ matrix.variant }}
       # QLI targets qcom-next; consume the debs published to EFS by the
       # "qcom-next linux build" workflow rather than a kernel from an
       # APT repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,13 @@ jobs:
       fail-fast: false
       matrix:
         suite: [trixie, forky]
+        variant: [default, weston-multimedia]
     uses: ./.github/workflows/debos.yml
     permissions:
       contents: read
     with:
       suite: ${{ matrix.suite }}
+      variant: ${{ matrix.variant }}
       # QLI targets qcom-next; consume the debs published to EFS by the
       # "qcom-next linux build" workflow rather than a kernel from an
       # APT repository

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -22,6 +22,15 @@ on:
         description: Extra arguments to pass to debos (e.g. -t dtb:qcom/some.dtb)
         type: string
         default: ''
+      variant:
+        description: >
+          Name of the image variant to build (e.g. multimedia); it selects the
+          debos arguments listed in the "Select debos arguments for the image
+          variant" step below and is appended to the name of every published
+          artifact, so that variants of the same suite don't overwrite each
+          other. Empty or "default" builds the default image.
+        type: string
+        default: ''
       # useful if for some reason the kernel/image can't start in QEMU
       skip_qemu_tests:
         description: Skip QEMU tests
@@ -44,11 +53,12 @@ env:
   KERNEL_PACKAGES: ${{ inputs.kernelpackages }}
   OVERLAYS: ${{ inputs.overlays }}
   DEBOS_EXTRA_ARGS: -t suite:${{ inputs.suite }} ${{ inputs.debos_extra_args }}
-  PREFIX: ${{ inputs.suite }}
+  # e.g. "trixie" for the default image, "trixie-multimedia" for a variant
+  PREFIX: ${{ (inputs.variant && inputs.variant != 'default') && format('{0}-{1}', inputs.suite, inputs.variant) || inputs.suite }}
 
 jobs:
   build-debos:
-    name: Build and upload debos recipes (${{ inputs.suite }})
+    name: Build and upload debos recipes (${{ inputs.variant && format('{0}, {1}', inputs.suite, inputs.variant) || inputs.suite }})
     permissions:
       contents: read # actions/checkout
     outputs:
@@ -60,6 +70,29 @@ jobs:
         - /efs/qli/qcom-deb-images:/efs
       options: --privileged
     steps:
+      # runs first so that an unknown variant fails the job in seconds rather
+      # than after a full image build
+      - name: Select debos arguments for the image variant
+        env:
+          VARIANT: ${{ inputs.variant }}
+        run: |
+          set -u
+          # debos arguments building each image variant, keyed on its name; to
+          # add a variant, add a case here and pass its name as the "variant"
+          # input; its artifacts are named after it (see PREFIX above)
+          case "$VARIANT" in
+            ''|default)
+              variant_args='-t xfcedesktop:true'
+              ;;
+            *)
+              echo "ERROR: unknown image variant '${VARIANT}'" >&2
+              echo "add it to this step to build it" >&2
+              exit 1
+              ;;
+          esac
+          # every debos invocation below passes this alongside DEBOS_EXTRA_ARGS
+          echo "DEBOS_VARIANT_ARGS=${variant_args}" >>"$GITHUB_ENV"
+
       # make sure we have latest packages first, to get latest fixes and to
       # avoid an automated update while we're building
       - name: Update OS packages
@@ -155,11 +188,11 @@ jobs:
 
           debos \
               -t "overlays:$OVERLAYS" \
-              -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
               -t kernelpackages:"$kernel_packages" \
               -t "buildid:${BUILD_ID}" \
               ${DEBOS_EXTRA_ARGS} \
+              ${DEBOS_VARIANT_ARGS} \
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-rootfs.yaml
 
@@ -172,13 +205,13 @@ jobs:
           # qemu backend also requires to set scratchsize, otherwise the
           # whole build is done from memory and the out of memory killer
           # gets triggered
-          make disk-ufs.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
-          make disk-sdcard.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
+          make disk-ufs.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS} ${DEBOS_VARIANT_ARGS}"
+          make disk-sdcard.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS} ${DEBOS_VARIANT_ARGS}"
 
       - name: Build flashable files with debos
         run: |
           set -ux
-          make flash FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="-t u_boot_rb1:rb1-boot.img -t buildid:${BUILD_ID} --print-recipe ${DEBOS_EXTRA_ARGS}"
+          make flash FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="-t u_boot_rb1:rb1-boot.img -t buildid:${BUILD_ID} --print-recipe ${DEBOS_EXTRA_ARGS} ${DEBOS_VARIANT_ARGS}"
 
       - name: Stage debos artifacts for publishing
         run: |

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -84,6 +84,10 @@ jobs:
             ''|default)
               variant_args='-t xfcedesktop:true'
               ;;
+            weston-multimedia)
+              # configures a Weston session and installs the accelerated multimedia stack
+              variant_args='-t westonsession:true -t multimedia:true'
+              ;;
             *)
               echo "ERROR: unknown image variant '${VARIANT}'" >&2
               echo "add it to this step to build it" >&2

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `xfcedesktop`: install an Xfce desktop environment; default: console only
   environment
 - `gnomedesktop`: install a GNOME desktop environment; default: console only environment
+- `westonsession`: install a Weston session; default: console only environment
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackages`: a `,`-separated list of kernel packages to install from

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
   environment
 - `gnomedesktop`: install a GNOME desktop environment; default: console only environment
 - `westonsession`: install a Weston session; default: console only environment
+- `multimedia`: install the Qualcomm accelerated multimedia stack; default: don't install
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackages`: a `,`-separated list of kernel packages to install from

--- a/debos-recipes/overlays/weston-session/etc/greetd/weston-session.toml
+++ b/debos-recipes/overlays/weston-session/etc/greetd/weston-session.toml
@@ -1,0 +1,11 @@
+# greetd configuration for the Weston session.
+[terminal]
+vt = 7
+
+[default_session]
+# Start agreety to provide a login prompt, then launch Weston.
+# Set Weston to log to "$XDG_RUNTIME_DIR/weston.log"
+# XDG_RUNTIME_DIR usually resolves to "/run/user/<UID>" so the log is only kept
+# for the lifetime of the user's login session.
+command = "/usr/sbin/agreety --cmd 'weston --log=$XDG_RUNTIME_DIR/weston.log'"
+user = "_greetd"

--- a/debos-recipes/overlays/weston-session/etc/systemd/system/greetd.service.d/10-weston-session.conf
+++ b/debos-recipes/overlays/weston-session/etc/systemd/system/greetd.service.d/10-weston-session.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=greetd --config /etc/greetd/weston-session.toml

--- a/debos-recipes/overlays/weston-session/etc/xdg/weston/weston.ini
+++ b/debos-recipes/overlays/weston-session/etc/xdg/weston/weston.ini
@@ -1,0 +1,10 @@
+[core]
+# desktop shell is used if no shell is specified
+#shell=desktop
+
+# start even when no input devices are detected
+require-input=false
+
+# keep the display active
+# this also disables desktop-shell's screensaver
+idle-time=0

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -1,5 +1,6 @@
 {{- $xfcedesktop := or .xfcedesktop "false" }}
 {{- $gnomedesktop := or .gnomedesktop "false" }}
+{{- $westonsession := or .westonsession "false" }}
 {{- $localdebs := or .localdebs "none" }}
 {{- $aptlocalrepo := or .aptlocalrepo "none" }}
 # $kernelpackage (singular) is deprecated, superseded by $kernelpackages
@@ -15,6 +16,8 @@
 {{- $variantid = "xfce" }}
 {{- else if eq $gnomedesktop "true" }}
 {{- $variantid = "gnome" }}
+{{- else if eq $westonsession "true" }}
+{{- $variantid = "weston" }}
 {{- end }}
 
 # Rename sid to unstable to reduce if/else complexity
@@ -688,6 +691,39 @@ actions:
       - gstreamer1.0-libcamera
       - libcamera-tools
       - libcamera-v4l2
+{{- end }}
+
+{{- if eq $westonsession "true" }}
+# Install Weston, a lightweight Wayland compositor.
+#
+# The Weston package does not have any mechanism to start automatically at boot
+# so greetd is used to create a user session and start Weston.
+#
+# The agreety text greeter provides a console login interface similar to getty,
+# authenticates the user through PAM then launches Weston after login.
+#
+# greetd/agreety does not discover the installed compositors from
+# /usr/share/wayland-sessions/*.desktop so Weston is set as the command to run
+# after login.
+#
+# Weston logs to "$XDG_RUNTIME_DIR/weston.log", XDG_RUNTIME_DIR usually resolves
+# to "/run/user/<UID>", so the log is only kept for the lifetime of the user's
+# login session.
+#
+# greetd is configured through /etc/greetd/weston-session.toml rather than
+# /etc/greetd/config.toml - the latter is a dpkg conffile shipped by the
+# greetd package and may be overwritten on package upgrades.
+
+  - action: apt
+    description: Install Weston session packages
+    recommends: false
+    packages:
+      - weston
+      - greetd
+
+  - action: overlay
+    description: Configure Weston session
+    source: overlays/weston-session
 {{- end }}
 
   - action: run

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -399,6 +399,8 @@ actions:
       - fastrpc-support
       # fwupd tools, enable OTA EFI firmware capsule updates
       - fwupd
+      # firmware for the Qualcomm xDSPs
+      - hexagon-dsp-binaries
       # defaults to "systemd-sysv"; perhaps not needed
       - init
       # Bluetooth audio support in PipeWire

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -1,6 +1,7 @@
 {{- $xfcedesktop := or .xfcedesktop "false" }}
 {{- $gnomedesktop := or .gnomedesktop "false" }}
 {{- $westonsession := or .westonsession "false" }}
+{{- $multimedia := or .multimedia "false" }}
 {{- $localdebs := or .localdebs "none" }}
 {{- $aptlocalrepo := or .aptlocalrepo "none" }}
 # $kernelpackage (singular) is deprecated, superseded by $kernelpackages
@@ -18,6 +19,9 @@
 {{- $variantid = "gnome" }}
 {{- else if eq $westonsession "true" }}
 {{- $variantid = "weston" }}
+{{- end }}
+{{- if eq $multimedia "true" }}
+{{- $variantid = printf "%s-multimedia" $variantid }}
 {{- end }}
 
 # Rename sid to unstable to reduce if/else complexity
@@ -774,6 +778,64 @@ actions:
     packages:
       # marks the current Android boot partition as booted successfully
       - qbootctl
+
+{{- if eq $multimedia "true" }}
+# Install the accelerated multimedia stack: out-of-tree kernel drivers and
+# closed source user-space from the Qualcomm Linux APT repository.
+
+{{- if ne $qliaptrepo "true" }}
+# Call an unexisting template to err out of the recipe
+{{ template "ERR" }}
+{{- end }}
+
+  - action: apt
+    description: Install DKMS
+    packages:
+      - gcc
+      - dkms
+
+  # CI does not use fakemachine. Limit DKMS build parallelism when
+  # running under fakemachine, where the default 1GB memory can be exhausted
+  # by multiple compiler jobs running in parallel.
+  # $IN_FAKE_MACHINE is only set when not running in chroot.
+  - action: run
+    description: Configure DKMS for low-memory fakemachine builds
+    chroot: false
+    command: |
+      set -eux
+      if [ "${IN_FAKE_MACHINE:-}" = "yes" ]; then
+        mkdir -p "${ROOTDIR}/etc/dkms/framework.conf.d"
+        echo "parallel_jobs=1" > "${ROOTDIR}/etc/dkms/framework.conf.d/fakemachine.conf"
+      fi
+
+  - action: apt
+    description: Install accelerated multimedia stack
+    recommends: false
+    packages:
+      # Adreno GPU driver
+      - kgsl-dkms
+      - adreno-gles2
+      - adreno-egl1
+      - libgbm-msm1
+      - adreno-opencl-icd
+      - adreno-vulkan-icd
+
+      # CamX - only firmware available for now
+      # camx-dkms fails to build in fakemachine; see https://github.com/qualcomm-linux/pkg-camx-dkms/pull/42
+      #- camx-dkms
+      - camx-firmware-glymur
+      - camx-firmware-hamoa
+
+      # Iris Video Processing Unit
+      - iris-vpu-dkms
+
+  - action: run
+    description: Remove temporary DKMS configuration
+    chroot: true
+    command: |
+      set -eux
+      rm -rf /etc/dkms/framework.conf.d/fakemachine.conf
+{{- end }}
 
 {{- if ne $localdebs "none" }}
   - action: overlay


### PR DESCRIPTION
Add an opt-in `westonsession` image variant to start a Weston session on boot.
Add an opt-in `multimedia` image variant to install the QTI multimedia packages.

Fixes: #481



Verification:
- confirmed dkms packages build fine in CI
- confirmed greetd comes up and can start a weston session on RB3gen2 (with both freedreno and adreno).
- adreno drivers are used over freedreno by default and Weston works fine with adreno on RB3gen2:
```
$ sudo apt install --yes mesa-utils
$ eglinfo -B
GBM platform:
EGL API version: 1.5
EGL vendor string: Qualcomm Inc.
EGL version string: 1.5
EGL client APIs: OpenGL_ES
...
OpenGL ES profile vendor: Qualcomm
OpenGL ES profile renderer: Adreno (TM) 635
OpenGL ES profile version: OpenGL ES 3.2 
OpenGL ES profile shading language version: OpenGL ES GLSL ES 3.20
...
```

- confirm opencl loader works on RB3gen2 and can use the adreno provider (should not need kgsl)
On Debian trixie, clinfo currently segfaults when both the Adreno and Rusticl OpenCL ICDs are enabled. To test the Adreno implementation in isolation:
```
$ sudo rm /usr/lib/aarch64-linux-gnu/libRusticlOpenCL.so*
$ clinfo -l
Platform #0: QUALCOMM Snapdragon(TM)
 `-- Device #0: QUALCOMM Adreno(TM) 635
```
on forky, no need to remove rusticl opencl binaries.

- fastrpc-tests on RB3gen2 with both trixie/forky:
```
$ fastrpc_test 

Demonstrating FARF run-time logging

hap_example function PASSED
Please look at the mini-dm logs or the adb logcat logs for DSP output

Demonstrating HAP_mem.h APIs

hap_example function PASSED
Please look at the mini-dm logs or the adb logcat logs for DSP output

Demonstrating HAP_perf.h APIs

hap_example function PASSED
Please look at the mini-dm logs or the adb logcat logs for DSP output
[PASS] libhap_example.so


Allocate 4000 bytes from ION heap
Creating sequence of numbers from 0 to 999
Compute sum on domain 3

Call calculator_sum on the DSP
Sum = 499500

Call calculator_max on the DSP
Max value = 999
[PASS] libcalculator.so

Test PASSED
Please look at the mini-dm logs or the adb logcat logs for DSP output
[PASS] libmultithreading.so


========================================
Test Summary:
  Total tests run:    3
  Passed:             3
  Failed:             0
  Skipped:            0
========================================

RESULT: All applicable tests PASSED
```