### PR TITLE
Add armhf image support

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -25,6 +25,7 @@ jobs:
     uses: ./.github/workflows/debos.yml
     with:
       suite: ${{ matrix.suite }}
+      build_armhf: true
 
   test-daily:
     # don't run cron from forks of the main repository or from other branches

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -26,5 +26,6 @@ jobs:
     uses: ./.github/workflows/debos.yml
     with:
       suite: ${{ matrix.suite }}
+      build_armhf: true
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/debos.yml
     with:
       suite: ${{ matrix.suite }}
+      build_armhf: true
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
   test:

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -27,6 +27,13 @@ on:
         description: Skip QEMU tests
         type: boolean
         default: false
+      build_armhf:
+        description: >
+          Also build an armhf rootfs and disk images; armhf always uses the
+          recipe's default kernel (Debian's linux-image-armmp) since the
+          kernelpackages input refers to arm64-only kernels
+        type: boolean
+        default: false
 
     outputs:
       artifacts_url:
@@ -148,6 +155,24 @@ jobs:
               --print-recipe \
               debos-recipes/qualcomm-linux-debian-rootfs.yaml
 
+      - name: Build armhf rootfs with debos
+        if: ${{ inputs.build_armhf }}
+        env:
+          OVERLAYS: ${{ inputs.overlays }}
+        run: |
+          set -ux
+          # NB: no kernelpackages/aptlocalrepo here; the default-ci and EFS
+          # kernels are arm64 only, so armhf sticks to the recipe's default
+          # kernel (Debian's linux-image-armmp)
+          debos \
+              -t architecture:armhf \
+              -t overlays:"$OVERLAYS" \
+              -t xfcedesktop:true \
+              -t "buildid:${BUILD_ID}" \
+              ${DEBOS_EXTRA_ARGS} \
+              --print-recipe \
+              debos-recipes/qualcomm-linux-debian-rootfs.yaml
+
       - name: Build UFS and SD card images with debos
         run: |
           set -ux
@@ -160,6 +185,15 @@ jobs:
           # builds both disk images and the unsuffixed compatibility symlinks
           # the flashing pipeline expects
           make arm64 FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
+
+      - name: Build armhf UFS and SD card images with debos
+        if: ${{ inputs.build_armhf }}
+        run: |
+          set -ux
+          # rootfs-armhf.tar was built by the armhf rootfs step above, so make
+          # only runs the image recipe here (same pattern as for arm64)
+          make disk-ufs-armhf.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
+          make disk-sdcard-armhf.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
 
       - name: Build flashable files with debos
         run: |
@@ -179,6 +213,13 @@ jobs:
           gzip -c disk-ufs-arm64.img >"${dir}/${PREFIX}-disk-ufs.img.gz"
           gzip -c disk-sdcard-arm64.img >"${dir}/${PREFIX}-disk-sdcard.img.gz"
           cp -av dtbs-arm64.tar.gz "${dir}/${PREFIX}-dtbs.tar.gz"
+          # armhf artifacts are only present when the build_armhf input is set
+          if [ -f rootfs-armhf.tar ]; then
+              gzip -c rootfs-armhf.tar >"${dir}/${PREFIX}-rootfs-armhf.tar.gz"
+              gzip -c disk-ufs-armhf.img >"${dir}/${PREFIX}-disk-ufs-armhf.img.gz"
+              gzip -c disk-sdcard-armhf.img >"${dir}/${PREFIX}-disk-sdcard-armhf.img.gz"
+              cp -av dtbs-armhf.tar.gz "${dir}/${PREFIX}-dtbs-armhf.tar.gz"
+          fi
           # create tarballs with support for all UFS and all eMMC boards
           scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}"
           # generate sha256sums for all artifacts

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -104,6 +104,8 @@ jobs:
           )
 
       - name: Build rootfs with debos
+        env:
+          OVERLAYS: ${{ inputs.overlays }}
         run: |
           set -ux
           kernel_packages="$KERNEL_PACKAGES"
@@ -137,7 +139,7 @@ jobs:
           esac
 
           debos \
-              -t overlays:'${{ inputs.overlays }}' \
+              -t overlays:"$OVERLAYS" \
               -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
               -t kernelpackages:"$kernel_packages" \

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -157,8 +157,9 @@ jobs:
           # qemu backend also requires to set scratchsize, otherwise the
           # whole build is done from memory and the out of memory killer
           # gets triggered
-          make disk-ufs.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
-          make disk-sdcard.img FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
+          # builds both disk images and the unsuffixed compatibility symlinks
+          # the flashing pipeline expects
+          make arm64 FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="--print-recipe ${DEBOS_EXTRA_ARGS}"
 
       - name: Build flashable files with debos
         run: |
@@ -171,11 +172,13 @@ jobs:
           # create a directory for the current run
           dir="debos-artifacts"
           mkdir -v "${dir}"
-          # compress output files directly into the staging directory
-          gzip -c rootfs.tar >"${dir}/${PREFIX}-rootfs.tar.gz"
-          gzip -c disk-ufs.img >"${dir}/${PREFIX}-disk-ufs.img.gz"
-          gzip -c disk-sdcard.img >"${dir}/${PREFIX}-disk-sdcard.img.gz"
-          cp -av dtbs.tar.gz "${dir}/${PREFIX}-dtbs.tar.gz"
+          # compress output files directly into the staging directory; the
+          # published arm64 artifacts keep the names they had before the build
+          # artifacts gained an architecture suffix
+          gzip -c rootfs-arm64.tar >"${dir}/${PREFIX}-rootfs.tar.gz"
+          gzip -c disk-ufs-arm64.img >"${dir}/${PREFIX}-disk-ufs.img.gz"
+          gzip -c disk-sdcard-arm64.img >"${dir}/${PREFIX}-disk-sdcard.img.gz"
+          cp -av dtbs-arm64.tar.gz "${dir}/${PREFIX}-dtbs.tar.gz"
           # create tarballs with support for all UFS and all eMMC boards
           scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}"
           # generate sha256sums for all artifacts
@@ -192,7 +195,7 @@ jobs:
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
 
       - name: Unpack rootfs to generate SBOM
-        run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar
+        run: mkdir -v rootfs && tar -C rootfs -xf rootfs-arm64.tar
 
       - name: Install cosign
         # Required so the syft installer can verify the release signature (-v).

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,20 @@
 disk-sdcard.img*
 disk-ufs.img*
+# sparse images made from the disk images
+disk-*.simg*
 dtbs.tar.gz
-dtb-multidtb.bin
+# one multi-DTB FIT image per SoC
+dtb-multidtb*.bin
 dtb-combineddtb.bin
 *.deb
 *.buildinfo
 *.changes
 rootfs.tar*
+# root filesystem unpacked from the tarball, e.g. to generate an SBOM
+rootfs/
+# per-board flashing directories built by the flash recipe
+flash_*/
 fake-scratch.img.*
+# left behind by the test suite
+__pycache__/
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
-disk-sdcard.img*
-disk-ufs.img*
+disk-sdcard*.img*
+disk-ufs*.img*
 # sparse images made from the disk images
 disk-*.simg*
-dtbs.tar.gz
+dtbs*.tar.gz
 # one multi-DTB FIT image per SoC
 dtb-multidtb*.bin
 dtb-combineddtb.bin
 *.deb
 *.buildinfo
 *.changes
-rootfs.tar*
+rootfs*.tar*
 # root filesystem unpacked from the tarball, e.g. to generate an SBOM
 rootfs/
 # per-board flashing directories built by the flash recipe

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,15 @@ all: arm64
 .PHONY: arm64
 arm64: disk-ufs-arm64.img disk-sdcard-arm64.img $(COMPAT_LINKS)
 
+# armhf images are not built by default; ask for them with `make armhf`
+.PHONY: armhf
+armhf: disk-ufs-armhf.img disk-sdcard-armhf.img
+
 rootfs-arm64.tar dtbs-arm64.tar.gz: debos-recipes/qualcomm-linux-debian-rootfs.yaml
 	$(DEBOS_CMD) -t architecture:arm64 $<
+
+rootfs-armhf.tar dtbs-armhf.tar.gz: debos-recipes/qualcomm-linux-debian-rootfs.yaml
+	$(DEBOS_CMD) -t architecture:armhf $<
 
 DISK_UFS_ARM64_IMAGES := disk-ufs-arm64.img \
 	disk-ufs-arm64.img1 \
@@ -74,12 +81,25 @@ DISK_UFS_ARM64_IMAGES := disk-ufs-arm64.img \
 $(DISK_UFS_ARM64_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs-arm64.tar
 	$(DEBOS_CMD) -t architecture:arm64 $<
 
+# armhf images have no ESP, so there is no second partition to extract
+DISK_UFS_ARMHF_IMAGES := disk-ufs-armhf.img \
+	disk-ufs-armhf.img1
+
+$(DISK_UFS_ARMHF_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs-armhf.tar
+	$(DEBOS_CMD) -t architecture:armhf $<
+
 DISK_SDCARD_ARM64_IMAGES := disk-sdcard-arm64.img \
 	disk-sdcard-arm64.img1 \
 	disk-sdcard-arm64.img2
 
 $(DISK_SDCARD_ARM64_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs-arm64.tar
 	$(DEBOS_CMD) -t architecture:arm64 -t imagetype:sdcard $<
+
+DISK_SDCARD_ARMHF_IMAGES := disk-sdcard-armhf.img \
+	disk-sdcard-armhf.img1
+
+$(DISK_SDCARD_ARMHF_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs-armhf.tar
+	$(DEBOS_CMD) -t architecture:armhf -t imagetype:sdcard $<
 
 rootfs.tar: rootfs-arm64.tar
 	ln -sf $< $@
@@ -104,10 +124,10 @@ test: disk-ufs-arm64.img
 
 .PHONY: clean
 clean:
-	rm -f $(DISK_UFS_ARM64_IMAGES)
-	rm -f $(DISK_SDCARD_ARM64_IMAGES)
-	rm -f rootfs-arm64.tar
-	rm -f dtbs-arm64.tar.gz
+	rm -f $(DISK_UFS_ARM64_IMAGES) $(DISK_UFS_ARMHF_IMAGES)
+	rm -f $(DISK_SDCARD_ARM64_IMAGES) $(DISK_SDCARD_ARMHF_IMAGES)
+	rm -f rootfs-arm64.tar rootfs-armhf.tar
+	rm -f dtbs-arm64.tar.gz dtbs-armhf.tar.gz
 	rm -f $(COMPAT_LINKS)
 	rm -f dtb-multidtb.bin
 	rm -f dtb-combineddtb.bin

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ test: disk-ufs-arm64.img
 	# rootfs/ is a build artifact, so should not be scanned for tests
 	py.test-3 --ignore=rootfs
 
+.PHONY: test-armhf
+test-armhf: disk-ufs-armhf.img
+	py.test-3 --ignore=rootfs -k armhf
+
 .PHONY: clean
 clean:
 	rm -f $(DISK_UFS_ARM64_IMAGES) $(DISK_UFS_ARMHF_IMAGES)

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,9 @@ ifeq ($(USE_CONTAINER),auto)
 endif
 
 ifeq ($(USE_CONTAINER),yes)
-	# Only pass --device /dev/kvm if KVM is available on the host
-	KVM_DEVICE := $(if $(wildcard /dev/kvm),--device /dev/kvm)
+	# Only pass --device /dev/kvm if KVM is available on the host; also add
+	# the device's owning group so the (non-root) container user may open it
+	KVM_DEVICE := $(if $(wildcard /dev/kvm),--device /dev/kvm --group-add $(shell stat -c %g /dev/kvm))
 	# Working directory as seen from inside the container
 	DEBOS_WORKDIR := /recipes
 	DEBOS_CMD := docker run --rm --interactive --tty \

--- a/Makefile
+++ b/Makefile
@@ -50,41 +50,65 @@ endif
 http_proxy ?= $(shell apt-config dump --format '%v%n' Acquire::http::Proxy)
 export http_proxy
 
+# arm64 used to be the only architecture and its artifacts had no architecture
+# in their name. The flashing pipeline, the published artifacts and existing
+# flashing instructions still use those names, so keep them available as
+# symlinks to the arm64 artifacts.
+COMPAT_LINKS := rootfs.tar dtbs.tar.gz \
+	disk-ufs.img disk-ufs.img1 disk-ufs.img2 \
+	disk-sdcard.img disk-sdcard.img1 disk-sdcard.img2
+
 .PHONY: all
-all: disk-ufs.img disk-sdcard.img
+all: arm64
 
-rootfs.tar dtbs.tar.gz: debos-recipes/qualcomm-linux-debian-rootfs.yaml
-	$(DEBOS_CMD) $<
+.PHONY: arm64
+arm64: disk-ufs-arm64.img disk-sdcard-arm64.img $(COMPAT_LINKS)
 
-DISK_UFS_IMAGES := disk-ufs.img \
-	disk-ufs.img1 \
-	disk-ufs.img2
+rootfs-arm64.tar dtbs-arm64.tar.gz: debos-recipes/qualcomm-linux-debian-rootfs.yaml
+	$(DEBOS_CMD) -t architecture:arm64 $<
 
-$(DISK_UFS_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar
-	$(DEBOS_CMD) $<
+DISK_UFS_ARM64_IMAGES := disk-ufs-arm64.img \
+	disk-ufs-arm64.img1 \
+	disk-ufs-arm64.img2
 
-DISK_SDCARD_IMAGES := disk-sdcard.img \
-	disk-sdcard.img1 \
-	disk-sdcard.img2
+$(DISK_UFS_ARM64_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs-arm64.tar
+	$(DEBOS_CMD) -t architecture:arm64 $<
 
-$(DISK_SDCARD_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs.tar
-	$(DEBOS_CMD) -t imagetype:sdcard $<
+DISK_SDCARD_ARM64_IMAGES := disk-sdcard-arm64.img \
+	disk-sdcard-arm64.img1 \
+	disk-sdcard-arm64.img2
+
+$(DISK_SDCARD_ARM64_IMAGES): debos-recipes/qualcomm-linux-debian-image.yaml rootfs-arm64.tar
+	$(DEBOS_CMD) -t architecture:arm64 -t imagetype:sdcard $<
+
+rootfs.tar: rootfs-arm64.tar
+	ln -sf $< $@
+
+dtbs.tar.gz: dtbs-arm64.tar.gz
+	ln -sf $< $@
+
+disk-ufs.img disk-ufs.img1 disk-ufs.img2: disk-ufs%: disk-ufs-arm64%
+	ln -sf $< $@
+
+disk-sdcard.img disk-sdcard.img1 disk-sdcard.img2: disk-sdcard%: disk-sdcard-arm64%
+	ln -sf $< $@
 
 .PHONY: flash
 flash: debos-recipes/qualcomm-linux-debian-flash.yaml dtbs.tar.gz
 	$(DEBOS_CMD) $<
 
 .PHONY: test
-test: disk-ufs.img
+test: disk-ufs-arm64.img
 	# rootfs/ is a build artifact, so should not be scanned for tests
 	py.test-3 --ignore=rootfs
 
 .PHONY: clean
 clean:
-	rm -f $(DISK_UFS_IMAGES)
-	rm -f $(DISK_SDCARD_IMAGES)
-	rm -f rootfs.tar
-	rm -f dtbs.tar.gz
+	rm -f $(DISK_UFS_ARM64_IMAGES)
+	rm -f $(DISK_SDCARD_ARM64_IMAGES)
+	rm -f rootfs-arm64.tar
+	rm -f dtbs-arm64.tar.gz
+	rm -f $(COMPAT_LINKS)
 	rm -f dtb-multidtb.bin
 	rm -f dtb-combineddtb.bin
 

--- a/README.md
+++ b/README.md
@@ -107,15 +107,18 @@ To build flashable assets for all supported boards, follow these steps:
 
     # both of the above, plus the unsuffixed compatibility symlinks:
     #make arm64
+
+    # (optional) armhf (32-bit ARM) variants of the above:
+    #make armhf
     ```
 
     Build artifacts are named after the architecture they were built for
-    (`rootfs-arm64.tar`, `disk-ufs-arm64.img`, ...). arm64 was once the only
+    (`rootfs-arm64.tar`, `disk-ufs-armhf.img`, ...). arm64 was once the only
     architecture and its artifacts had no architecture in their name, so
     `make arm64` also creates symlinks under those names (`rootfs.tar`,
     `disk-ufs.img`, ...) for the flashing pipeline and for existing scripts.
     The artifacts published by CI are unaffected: they keep their historical
-    names.
+    names for arm64, and only armhf ones carry a `-armhf` suffix.
 
 1. build flashable assets from downloaded boot binaries, the DTBs, and pointing at the UFS/SD card disk images
     ```bash
@@ -152,6 +155,9 @@ debos --fakemachine-backend qemu --memory 1GiB --scratchsize 6GiB debos-recipes/
 
 A few options are provided in the debos recipes; for the root filesystem recipe:
 
+- `architecture`: Debian architecture to build for, either `arm64` (the
+  default) or `armhf`; the output artifacts are named after the architecture
+  they were built for (e.g. `rootfs-arm64.tar`, `dtbs-armhf.tar.gz`)
 - `localdebs`: path to a directory with local deb packages to install (NB:
   debos expects relative pathnames)
 - `xfcedesktop`: install an Xfce desktop environment; default: console only
@@ -160,8 +166,9 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackages`: a `,`-separated list of kernel packages to install from
-  apt; defaults to Debian's `linux-image-arm64`. Can (and should) be set to
-  `none` if you are providing local kernel package instead.
+  apt; defaults to Debian's `linux-image-arm64` on arm64 and to Debian's
+  `linux-image-armmp` on armhf. Can (and should) be set to `none` if you are
+  providing local kernel package instead.
 - `kernelpackage`: **deprecated**, superseded by `kernelpackages`; still
   accepted as a single package name for backwards compatibility.
 - `suite`: Debian suite to use, defaults to `trixie`.
@@ -171,11 +178,19 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 
 For the image recipe:
 
+- `architecture`: Debian architecture of the image, either `arm64` (the
+  default) or `armhf`; must match the architecture used for the root
+  filesystem recipe. Each architecture consumes the matching rootfs tarball
+  (e.g. `rootfs-armhf.tar`) and names its image after the architecture
+  (e.g. `disk-ufs-armhf.img`); the root partition GPT type
+  UUID is set according to the architecture. The 32-bit Qualcomm platforms
+  supported by these recipes are not booted by EFI, so armhf images carry no
+  ESP and no systemd-boot, just a single root partition
 - `dtb`: override the firmware provided device tree with one from the Linux
   kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override
 - `imagetype`: either `ufs` (the default) or `sdcard`; UFS images are named
-  disk-ufs-arm64.img and use 4096-byte sectors and SD card images are named
-  disk-sdcard-arm64.img and use 512-byte sectors
+  disk-ufs-<architecture>.img and use 4096-byte sectors and SD card images
+  are named disk-sdcard-<architecture>.img and use 512-byte sectors
 - `imagesize`: set the output disk image size; default: `6GiB`
 
 For the flash recipe:

--- a/README.md
+++ b/README.md
@@ -89,22 +89,33 @@ To build flashable assets for all supported boards, follow these steps:
 
 1. build tarballs of the root filesystem and DTBs
     ```bash
-    make rootfs.tar
+    make rootfs-arm64.tar
 
     # (optional) if you've built a local kernel, copy it to `debos-recipes/local-debs/`
     # and run this instead:
-    #EXTRA_DEBOS_OPTS="-t localdebs:local-debs/ -t kernelpackages:none" make rootfs.tar
+    #EXTRA_DEBOS_OPTS="-t localdebs:local-debs/ -t kernelpackages:none" make rootfs-arm64.tar
     ```
 
 1. build disk and filesystem images from the root filesystem tarball
     ```bash
     # the default is to build a UFS image
-    make disk-ufs.img
+    make disk-ufs-arm64.img
 
     # (optional) if you want SD card images or support for eMMC boards, run
     # this as well:
-    make disk-sdcard.img
+    make disk-sdcard-arm64.img
+
+    # both of the above, plus the unsuffixed compatibility symlinks:
+    #make arm64
     ```
+
+    Build artifacts are named after the architecture they were built for
+    (`rootfs-arm64.tar`, `disk-ufs-arm64.img`, ...). arm64 was once the only
+    architecture and its artifacts had no architecture in their name, so
+    `make arm64` also creates symlinks under those names (`rootfs.tar`,
+    `disk-ufs.img`, ...) for the flashing pipeline and for existing scripts.
+    The artifacts published by CI are unaffected: they keep their historical
+    names.
 
 1. build flashable assets from downloaded boot binaries, the DTBs, and pointing at the UFS/SD card disk images
     ```bash
@@ -149,7 +160,7 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `overlays`: a `,`-separated list of rootfs overlays to add from
   `debos-recipes/overlays/`. See the *Supported overlays* section below.
 - `kernelpackages`: a `,`-separated list of kernel packages to install from
-  apt; defaults to `Debian’s linux-image-arm64`. Can (and should) be set to
+  apt; defaults to Debian's `linux-image-arm64`. Can (and should) be set to
   `none` if you are providing local kernel package instead.
 - `kernelpackage`: **deprecated**, superseded by `kernelpackages`; still
   accepted as a single package name for backwards compatibility.
@@ -163,8 +174,8 @@ For the image recipe:
 - `dtb`: override the firmware provided device tree with one from the Linux
   kernel, e.g. `qcom/qcs6490-rb3gen2.dtb`; default: don't override
 - `imagetype`: either `ufs` (the default) or `sdcard`; UFS images are named
-  disk-ufs.img and use 4096-byte sectors and SD card images are named
-  disk-sdcard.img and use 512-byte sectors
+  disk-ufs-arm64.img and use 4096-byte sectors and SD card images are named
+  disk-sdcard-arm64.img and use 512-byte sectors
 - `imagesize`: set the output disk image size; default: `6GiB`
 
 For the flash recipe:
@@ -176,7 +187,7 @@ For the flash recipe:
   `qcs615-ride`, `qcs6490-rb3gen2-vision-kit`, `qcs8300-ride`,
   `qcs9100-ride-r3`, `qrb2210-rb1`.
 
-Note: Boards whose required device tree (.dtb) is not present in `dtbs.tar.gz` are automatically skipped during flash asset generation.
+Note: Boards whose required device tree (.dtb) is not present in `dtbs-arm64.tar.gz` are automatically skipped during flash asset generation.
 
 Deprecated flash options:
 - `build_qcs615`, `build_qcm6490`, `build_qcs8300`, `build_qcs9100`, `build_rb1`: these per-family/per-board toggles are deprecated and will be removed. Use `target_boards` instead to select which boards to build.
@@ -208,7 +219,7 @@ directory, notably to set large enough memory and scratchsize settings. To pass
 extra options to debos invocations, use `EXTRA_DEBOS_OPTS`, e.g.:
 
 ```
-make EXTRA_DEBOS_OPTS="-t xfcedesktop:true" disk-ufs.img
+make EXTRA_DEBOS_OPTS="-t xfcedesktop:true" disk-ufs-arm64.img
 ```
 
 #### Supported overlays
@@ -238,9 +249,9 @@ Here is the list of supported overlays:
 
 ### Flash the image
 
-The `disk-sdcard.img` disk image can simply be written to an SD card, albeit most Qualcomm boards boot from internal storage by default. With an SD card, the board will use boot firmware from internal storage (eMMC or UFS) and do an EFI boot from the SD card if the firmware can't boot from internal storage.
+The `disk-sdcard-arm64.img` disk image can simply be written to an SD card, albeit most Qualcomm boards boot from internal storage by default. With an SD card, the board will use boot firmware from internal storage (eMMC or UFS) and do an EFI boot from the SD card if the firmware can't boot from internal storage.
 
-For UFS boards, if there is no need to update the boot firmware, the `disk-ufs.img` disk image can also be flashed on the first LUN of the internal UFS storage with [qdl](https://github.com/linux-msm/qdl) and the provided `rawprogram-ufs.xml` file.
+For UFS boards, if there is no need to update the boot firmware, the `disk-ufs-arm64.img` disk image can also be flashed on the first LUN of the internal UFS storage with [qdl](https://github.com/linux-msm/qdl) and the provided `rawprogram-ufs.xml` file.
 
 Put the board in "emergency download mode" (EDL; see next section) and run:
 ```bash
@@ -288,7 +299,7 @@ Dependencies:
 
 Basic usage:
 ```bash
-# Auto-detects disk-ufs.img or disk-sdcard.img in the current directory
+# Auto-detects disk-ufs-arm64.img or disk-sdcard-arm64.img in the current directory
 scripts/run-qemu.py
 
 # Explicit storage type (sector size set accordingly)
@@ -296,7 +307,7 @@ scripts/run-qemu.py --storage ufs
 scripts/run-qemu.py --storage sdcard
 
 # Use a specific image path
-scripts/run-qemu.py --image /path/to/disk-ufs.img
+scripts/run-qemu.py --image /path/to/disk-ufs-arm64.img
 
 # Run headless (no GUI), with serial console on stdio
 scripts/run-qemu.py --headless
@@ -309,7 +320,7 @@ scripts/run-qemu.py --qemu-args "-smp 4 -m 4096"
 ```
 
 Notes:
-- If neither `disk-ufs.img` nor `disk-sdcard.img` is found and `--image` is not provided, the script will exit with an error.
+- If neither `disk-ufs-arm64.img` nor `disk-sdcard-arm64.img` is found and `--image` is not provided, the script will exit with an error.
 - On Linux, the script looks for `/usr/share/qemu-efi-aarch64/QEMU_EFI.fd`. On macOS with Homebrew, it uses `share/qemu/edk2-aarch64-code.fd` from the `qemu` formula.
 - The overlay is cleaned up automatically when QEMU exits. Use `--no-cow` to make changes persistent on the base image.
 

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -13,27 +14,113 @@ import pexpect
 import pytest
 
 
+def _cow_disk(image, tmpdir):
+    """A copy-on-write overlay on top of image, so that a test never modifies
+    the image it was given"""
+    qcow_path = os.path.join(tmpdir, "disk1.qcow")
+    subprocess.run(
+        [
+            "qemu-img",
+            "create",
+            "-b",
+            os.path.join(os.getcwd(), image),
+            "-f",
+            "qcow",
+            "-F",
+            "raw",
+            qcow_path,
+        ],
+        check=True,
+    )
+    return qcow_path
+
+
+def _spawn(command, args):
+    """Start qemu and hand back its serial console"""
+    child = pexpect.spawn(
+        command,
+        args,
+        # Emulated ARM (no KVM) on a loaded CI runner is slow, so give
+        # every expect() a generous default. The initial boot still
+        # overrides this with a longer per-call timeout below.
+        timeout=120,
+    )
+    child.logfile = sys.stdout.buffer
+    return child
+
+
+def _e2fsprogs(tool):
+    """Path of an e2fsprogs tool; these live in /usr/sbin, which is not in
+    PATH for regular users"""
+    return shutil.which(tool, path=f"{os.defpath}:/usr/sbin:/sbin") or tool
+
+
+def _debugfs(partition, command):
+    """Run a debugfs command on an ext4 partition image; this reads the
+    filesystem without needing root or a loop mount"""
+    return subprocess.run(
+        [_e2fsprogs("debugfs"), "-R", command, partition],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _extract_boot_files(partition, destdir):
+    """Copy the kernel and initrd out of an ext4 root partition image
+
+    armhf images are not booted by EFI and carry neither an ESP nor a
+    bootloader, so qemu has to be handed the kernel and initrd directly.
+    """
+    versions = []
+    for line in _debugfs(partition, "ls -p /boot").splitlines():
+        # debugfs "ls -p" prints /inode/mode/uid/gid/name/size/
+        fields = line.split("/")
+        if len(fields) > 5 and fields[5].startswith("vmlinuz-"):
+            versions.append(fields[5].removeprefix("vmlinuz-"))
+    assert versions, f"no kernel in /boot of {partition}"
+    # these images ship a single kernel; if that ever changes, the last one
+    # sorts close enough to the newest to boot
+    version = sorted(versions)[-1]
+
+    kernel = os.path.join(destdir, "vmlinuz")
+    initrd = os.path.join(destdir, "initrd.img")
+    _debugfs(partition, f"dump /boot/vmlinuz-{version} {kernel}")
+    _debugfs(partition, f"dump /boot/initrd.img-{version} {initrd}")
+    return kernel, initrd
+
+
+def _fs_uuid(partition):
+    """UUID of the filesystem in a partition image, to boot it by UUID like
+    the image's own fstab does"""
+    output = subprocess.run(
+        [_e2fsprogs("dumpe2fs"), "-h", partition],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    for line in output.splitlines():
+        if line.startswith("Filesystem UUID:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"no filesystem UUID in {partition}")
+
+
+def _shutdown(child):
+    # No need to be nice; that would take time
+    child.kill(signal.SIGKILL)
+
+    # If this blocks then we have a problem. Better to hang than build up
+    # excess qemu processes that won't die.
+    child.wait()
+
+
 @pytest.fixture
 def vm():
     """A pexpect.spawn object attached to the serial console of a VM freshly
     booting with a CoW base of disk-ufs-arm64.img"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        qcow_path = os.path.join(tmpdir, "disk1.qcow")
-        subprocess.run(
-            [
-                "qemu-img",
-                "create",
-                "-b",
-                os.path.join(os.getcwd(), "disk-ufs-arm64.img"),
-                "-f",
-                "qcow",
-                "-F",
-                "raw",
-                qcow_path,
-            ],
-            check=True,
-        )
-        child = pexpect.spawn(
+        qcow_path = _cow_disk("disk-ufs-arm64.img", tmpdir)
+        child = _spawn(
             "qemu-system-aarch64",
             [
                 "-cpu",
@@ -52,28 +139,67 @@ def vm():
                 "-bios",
                 "/usr/share/AAVMF/AAVMF_CODE.fd",
             ],
-            # Emulated aarch64 (no KVM) on a loaded CI runner is slow, so give
-            # every expect() a generous default. The initial boot still
-            # overrides this with a longer per-call timeout below.
-            timeout=120,
         )
-        child.logfile = sys.stdout.buffer
         yield child
 
-        # No need to be nice; that would take time
-        child.kill(signal.SIGKILL)
-
-        # If this blocks then we have a problem. Better to hang than build up
-        # excess qemu processes that won't die.
-        child.wait()
+        _shutdown(child)
 
 
-def test_password_reset_required(vm):
-    """On first login, there should be a mandatory reset password flow"""
-    # https://github.com/qualcomm-linux/qcom-deb-images/issues/69
+@pytest.fixture
+def vm_armhf():
+    """A pexpect.spawn object attached to the serial console of a VM freshly
+    booting with a CoW base of disk-ufs-armhf.img"""
+    image = "disk-ufs-armhf.img"
+    # an armhf image has no ESP, so its root filesystem is the first partition
+    partition = "disk-ufs-armhf.img1"
+    for path in (image, partition):
+        if not os.path.exists(path):
+            pytest.skip(f"{path} has not been built")
 
-    # This takes a minute or two on a ThinkPad T14s Gen 6 Snapdragon
-    vm.expect_exact("debian login:", timeout=240)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        qcow_path = _cow_disk(image, tmpdir)
+        kernel, initrd = _extract_boot_files(partition, tmpdir)
+        child = _spawn(
+            "qemu-system-arm",
+            [
+                "-cpu",
+                "cortex-a15",
+                "-m",
+                "2048",
+                # Debian's ARM multiplatform kernel is not LPAE, so it cannot
+                # address the PCIe window that the virt machine places above
+                # 4GiB by default; highmem=off keeps everything below it
+                "-M",
+                "virt,highmem=off",
+                # nothing in the image boots itself, see _extract_boot_files()
+                "-kernel",
+                kernel,
+                "-initrd",
+                initrd,
+                "-append",
+                f"root=UUID={_fs_uuid(partition)} rw console=ttyAMA0",
+                "-drive",
+                f"if=none,file={qcow_path},format=qcow,id=disk1,cache=unsafe",
+                "-device",
+                "virtio-scsi-pci,id=scsi1",
+                "-device",
+                "scsi-hd,bus=scsi1.0,drive=disk1,physical_block_size=4096,logical_block_size=4096",
+                "-nographic",
+            ],
+        )
+        yield child
+
+        _shutdown(child)
+
+
+def _first_login(vm, timeout):
+    """Log in as the default user, which walks through the mandatory password
+    reset of a freshly built image"""
+    # an image whose initramfs cannot mount the root filesystem lands in a
+    # rescue shell and would otherwise keep the test waiting for the full
+    # timeout, so catch that and report what actually happened
+    prompt = vm.expect_exact(["debian login:", "(initramfs)"], timeout=timeout)
+    assert prompt == 0, "the initramfs could not mount the root filesystem"
 
     vm.send("debian\r\n")
     vm.expect_exact("Password:")
@@ -87,9 +213,27 @@ def test_password_reset_required(vm):
     vm.send("new password\r\n")
     vm.expect_exact("debian@debian:~$")
 
+
+def test_password_reset_required(vm):
+    """On first login, there should be a mandatory reset password flow"""
+    # https://github.com/qualcomm-linux/qcom-deb-images/issues/69
+
+    # This takes a minute or two on a ThinkPad T14s Gen 6 Snapdragon
+    _first_login(vm, timeout=240)
+
     # The /boot/efi/loader/random-seed file should not be readable to users
     # https://github.com/qualcomm-linux/qcom-deb-images/issues/279
     vm.send("journalctl | grep 'is world accessible, which is a security hole' || echo not found\r\n")
     # Need to match twice because of the serial echo of the command above
     vm.expect_exact("not found")
     vm.expect_exact("not found")
+
+
+def test_armhf_image_boots(vm_armhf):
+    """An armhf image should boot to a login prompt on an armhf userland"""
+    # 32-bit ARM is emulated with TCG even on an arm64 host, so this is
+    # several times slower than the arm64 boot above
+    _first_login(vm_armhf, timeout=900)
+
+    vm_armhf.send("dpkg --print-architecture\r\n")
+    vm_armhf.expect_exact("armhf")

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -16,7 +16,7 @@ import pytest
 @pytest.fixture
 def vm():
     """A pexpect.spawn object attached to the serial console of a VM freshly
-    booting with a CoW base of disk-ufs.img"""
+    booting with a CoW base of disk-ufs-arm64.img"""
     with tempfile.TemporaryDirectory() as tmpdir:
         qcow_path = os.path.join(tmpdir, "disk1.qcow")
         subprocess.run(
@@ -24,7 +24,7 @@ def vm():
                 "qemu-img",
                 "create",
                 "-b",
-                os.path.join(os.getcwd(), "disk-ufs.img"),
+                os.path.join(os.getcwd(), "disk-ufs-arm64.img"),
                 "-f",
                 "qcow",
                 "-F",

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -1,16 +1,27 @@
+{{- $architecture := or .architecture "arm64" }}
 {{- $dtb := or .dtb "firmware" }}
 {{- $imagesize := or .imagesize "6GiB" }}
 {{- $imagetype := or .imagetype "ufs" }}
-{{- $image := printf "disk-%s.img" $imagetype }}
 {{- $snapshot := or .snapshot "" }}
 
-architecture: arm64
+# only arm64 is supported so far
+{{- if ne $architecture "arm64" }}
+# Call an unexisting template to err out of the recipe
+{{ template "ERR" }}
+{{- end }}
+
+# artifacts are named after the architecture they were built for; the root
+# filesystem name must match the one the root filesystem recipe writes
+{{- $rootfs := printf "rootfs-%s.tar" $architecture }}
+{{- $image := printf "disk-%s-%s.img" $imagetype $architecture }}
+
+architecture: {{ $architecture }}
 sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
 
 actions:
   - action: unpack
     description: Unpack root filesystem
-    file: rootfs.tar
+    file: {{ $rootfs }}
 
 {{- if ne $dtb "firmware" }}
   - action: run

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -4,8 +4,8 @@
 {{- $imagetype := or .imagetype "ufs" }}
 {{- $snapshot := or .snapshot "" }}
 
-# only arm64 is supported so far
-{{- if ne $architecture "arm64" }}
+# only arm64 and armhf are supported architectures
+{{- if not (has $architecture (list "arm64" "armhf")) }}
 # Call an unexisting template to err out of the recipe
 {{ template "ERR" }}
 {{- end }}
@@ -14,6 +14,13 @@
 # filesystem name must match the one the root filesystem recipe writes
 {{- $rootfs := printf "rootfs-%s.tar" $architecture }}
 {{- $image := printf "disk-%s-%s.img" $imagetype $architecture }}
+
+# On Qualcomm platforms, armhf images have no ESP, so the root filesystem is
+# the first partition
+{{- $rootpartnum := 2 }}
+{{- if eq $architecture "armhf" }}
+{{- $rootpartnum = 1 }}
+{{- end }}
 
 architecture: {{ $architecture }}
 sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
@@ -35,6 +42,26 @@ actions:
 
   # parttype values are from:
   # https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
+{{- if eq $architecture "armhf" }}
+  # the 32-bit Qualcomm platforms supported by these recipes are not booted by
+  # EFI, so their images have a single root partition and no ESP
+  - action: image-partition
+    description: Create an image file
+    imagename: {{ $image }}
+    imagesize: {{ $imagesize }}
+    partitiontype: gpt
+    partitions:
+      - name: root
+        # Root Partition (32-bit ARM)
+        parttype: 69dad710-2ce4-4e3c-b16c-21a1d49abed3
+        fs: ext4
+        start: 4MiB
+        end: 100%
+        fsck: true
+    mountpoints:
+      - mountpoint: /
+        partition: root
+{{- else }}
   - action: image-partition
     description: Create an image file
     imagename: {{ $image }}
@@ -82,6 +109,7 @@ actions:
           - errors=remount-ro
       - mountpoint: /
         partition: root
+{{- end }}
 
   # XXX these kernel options might be specific to a kernel version or board
   - action: filesystem-deploy
@@ -99,6 +127,9 @@ actions:
       apt-get update
 {{- end }}
 
+{{- if ne $architecture "armhf" }}
+  # On Qualcomm platforms, armhf images have no ESP to install a bootloader
+  # or DTBs into
   - action: apt
     description: Make system bootable with systemd-boot
     recommends: true
@@ -135,6 +166,7 @@ actions:
       latest_kernel=$(echo "$kernel_list" | linux-version sort --reverse | head -1)
       dtb_path="/usr/lib/linux-image-${latest_kernel}"
       cp -LRT "$dtb_path" "/boot/efi/dtb"
+{{- end }}
 
   - action: run
     description: Create task to grow root filesystem on first boot
@@ -149,13 +181,13 @@ actions:
           awk '$2 == "/" {gsub("UUID=", "/dev/disk/by-uuid/"); print $1}' \
               /etc/fstab
           )
-      # generate systemd unit to grow the second partition with above UUID
+      # generate systemd unit to grow the root partition with above UUID
       cat >/etc/systemd/system/debos-grow-rootfs.service <<EOF
       [Unit]
       Description=Grow root partition and filesystem (debos)
       [Service]
       Type=oneshot
-      ExecStartPre=-sh -c 'growpart /dev/\`lsblk -n -o pkname $ROOTFS_DEV\` 2'
+      ExecStartPre=-sh -c 'growpart /dev/\`lsblk -n -o pkname $ROOTFS_DEV\` {{ $rootpartnum }}'
       ExecStart=resize2fs $ROOTFS_DEV
       ExecStartPost=/usr/bin/systemctl disable debos-grow-rootfs.service
       [Install]

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -3,22 +3,10 @@
 {{- $gnomedesktop := or .gnomedesktop "false" }}
 {{- $localdebs := or .localdebs "none" }}
 {{- $aptlocalrepo := or .aptlocalrepo "none" }}
-# $kernelpackage (singular) is deprecated, superseded by $kernelpackages
-{{- $kernelpackages := or .kernelpackages .kernelpackage "linux-image-arm64" }}
 {{- $overlays := or .overlays "qsc-deb-releases" }}
 {{- $buildid := or .buildid "" }}
 {{- $snapshot := or .snapshot "" }}
 {{- $suite := or .suite "trixie" }}
-
-# only arm64 is supported so far
-{{- if ne $architecture "arm64" }}
-# Call an unexisting template to err out of the recipe
-{{ template "ERR" }}
-{{- end }}
-
-# output artifacts are named after the architecture they were built for
-{{- $rootfs := printf "rootfs-%s.tar" $architecture }}
-{{- $dtbs := printf "dtbs-%s.tar.gz" $architecture }}
 
 {{- $variantid := "console" }}
 {{- if eq $xfcedesktop "true" }}
@@ -31,6 +19,26 @@
 {{- if eq $suite "sid" }}
 {{- $suite = "unstable" }}
 {{- end }}
+
+# only arm64 and armhf are supported architectures
+{{- if not (has $architecture (list "arm64" "armhf")) }}
+# Call an unexisting template to err out of the recipe
+{{ template "ERR" }}
+{{- end }}
+
+# Debian ships a dedicated kernel flavour for arm64 and a multiplatform one
+# for armhf
+{{- $defaultkernelpackages := "linux-image-arm64" }}
+{{- if eq $architecture "armhf" }}
+{{- $defaultkernelpackages = "linux-image-armmp" }}
+{{- end }}
+
+# $kernelpackage (singular) is deprecated, superseded by $kernelpackages
+{{- $kernelpackages := or .kernelpackages .kernelpackage $defaultkernelpackages }}
+
+# output artifacts are named after the architecture they were built for
+{{- $rootfs := printf "rootfs-%s.tar" $architecture }}
+{{- $dtbs := printf "dtbs-%s.tar.gz" $architecture }}
 
 architecture: {{ $architecture }}
 
@@ -347,11 +355,11 @@ actions:
       # WPA / WPA2 / WPA3 client support
       - wpasupplicant
 
-{{- if eq $suite "trixie" }}
+{{- if and (eq $suite "trixie") (eq $architecture "arm64") }}
 {{- if ne $overlays "none" }}
 {{- range $overlay := split "," $overlays }}
 {{- if eq $overlay "qsc-deb-releases" }}
-  # fastrpc-tests is only available in trixie-overlay
+  # fastrpc-tests is only available in trixie-overlay, and only for arm64
   - action: apt
     description: Install fastrpc-tests (trixie only)
     recommends: true
@@ -424,8 +432,10 @@ actions:
     packages:
       - alsa-utils
       - clinfo
-      # used to debug clock issues
+{{- if eq $architecture "arm64" }}
+      # used to debug clock issues; only built for arm64 in Debian
       - debugcc
+{{- end }}
       - device-tree-compiler
       - docker.io
       # used to debug ethernet speed auto-neg issues

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -1,3 +1,4 @@
+{{- $architecture := or .architecture "arm64" }}
 {{- $xfcedesktop := or .xfcedesktop "false" }}
 {{- $gnomedesktop := or .gnomedesktop "false" }}
 {{- $localdebs := or .localdebs "none" }}
@@ -8,6 +9,16 @@
 {{- $buildid := or .buildid "" }}
 {{- $snapshot := or .snapshot "" }}
 {{- $suite := or .suite "trixie" }}
+
+# only arm64 is supported so far
+{{- if ne $architecture "arm64" }}
+# Call an unexisting template to err out of the recipe
+{{ template "ERR" }}
+{{- end }}
+
+# output artifacts are named after the architecture they were built for
+{{- $rootfs := printf "rootfs-%s.tar" $architecture }}
+{{- $dtbs := printf "dtbs-%s.tar.gz" $architecture }}
 
 {{- $variantid := "console" }}
 {{- if eq $xfcedesktop "true" }}
@@ -21,7 +32,7 @@
 {{- $suite = "unstable" }}
 {{- end }}
 
-architecture: arm64
+architecture: {{ $architecture }}
 
 actions:
 {{- if .kernelpackage }}
@@ -722,12 +733,12 @@ actions:
       tar \
           -C "${latest_kernel}" \
           --transform='s|^\./||' \
-          -cvzf "$ARTIFACTDIR/dtbs.tar.gz" \
+          -cvzf "$ARTIFACTDIR/{{ $dtbs }}" \
           .
 
   - action: pack
     description: Create root filesystem tarball
-    file: rootfs.tar
+    file: {{ $rootfs }}
     compression: none
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -661,6 +661,35 @@ actions:
       - kmod
       - linux-base
 
+{{- if eq $architecture "armhf" }}
+  # initramfs-tools asks dracut-install to install whole module directories
+  # (e.g. "=drivers/scsi"), which dracut-install expands with glibc's fts(3).
+  # fts reads directories with the 32-bit readdir(), which fails with
+  # EOVERFLOW on the 64-bit directory cookies ext4 hands out, so on 32-bit
+  # architectures every such directory looks empty and is skipped without an
+  # error, leaving an initramfs with no storage drivers at all:
+  #   https://bugs.debian.org/1110545 - missing modules break boot on armhf
+  #   https://bugs.debian.org/1079080 - the dracut-install failure is ignored
+  #   https://bugzilla.kernel.org/show_bug.cgi?id=205957 - the ext4 side
+  # Modules requested by name are unaffected, so name the ones the qemu boot
+  # test needs. Drivers for real hardware (MMC, UFS) are still missing, so
+  # this is a workaround for testing, not a fix.
+  - action: run
+    description: Name the modules the qemu boot test needs (see Debian #1110545)
+    chroot: true
+    command: |
+      set -eux
+      cat >>/etc/initramfs-tools/modules <<'EOF'
+
+      # Storage drivers for the qemu boot test; on 32-bit architectures they
+      # have to be named because the module directories initramfs-tools adds
+      # are silently dropped (https://bugs.debian.org/1110545)
+      sd_mod
+      virtio_blk
+      virtio_scsi
+      EOF
+{{- end }}
+
   - action: apt
     description: Install kernel and firmware packages
     recommends: true

--- a/scripts/bundle-flash-dirs.sh
+++ b/scripts/bundle-flash-dirs.sh
@@ -54,10 +54,13 @@ do
 done
 echo "multidtb_bins: $multidtb_bins"
 
+# the partition images are symlinks to the arm64 artifacts, and the rawprogram
+# XMLs in the flash directories refer to them under these names, so archive the
+# files they point at rather than the symlinks
 # word splitting is a feature in this case
 # shellcheck disable=SC2086
-tar -cvzf "$output_dir/$prefix-flash-emmc.tar.gz" disk-sdcard.img1 disk-sdcard.img2 $multidtb_bins $emmc_dirs
+tar -chvzf "$output_dir/$prefix-flash-emmc.tar.gz" disk-sdcard.img1 disk-sdcard.img2 $multidtb_bins $emmc_dirs
 
 # word splitting is a feature in this case
 # shellcheck disable=SC2086
-tar -cvzf "$output_dir/$prefix-flash-ufs.tar.gz" disk-ufs.img1 disk-ufs.img2 $multidtb_bins $ufs_dirs
+tar -chvzf "$output_dir/$prefix-flash-ufs.tar.gz" disk-ufs.img1 disk-ufs.img2 $multidtb_bins $ufs_dirs

--- a/scripts/run-qemu.py
+++ b/scripts/run-qemu.py
@@ -11,7 +11,7 @@ Usage:
     run-qemu.py --storage sdcard
 
 - Set image file, detect storage type:
-    run-qemu.py --image /path/to/disk-ufs.img
+    run-qemu.py --image /path/to/disk-ufs-arm64.img
 
 - Disable COW overlay (write to disk image):
     run-qemu.py --no-cow
@@ -27,8 +27,8 @@ import platform
 import shlex
 from typing import Optional
 
-DEFAULT_UFS_IMAGE = "disk-ufs.img"
-DEFAULT_SDCARD_IMAGE = "disk-sdcard.img"
+DEFAULT_UFS_IMAGE = "disk-ufs-arm64.img"
+DEFAULT_SDCARD_IMAGE = "disk-sdcard-arm64.img"
 
 
 def find_bios_path() -> Optional[str]:
@@ -83,7 +83,7 @@ def main():
         "--image",
         help=(
             "Path to the base disk image (.img). Default is to auto-detect "
-            "disk-ufs.img or disk-sdcard.img."
+            "disk-ufs-arm64.img or disk-sdcard-arm64.img."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Qualcomm has a number of 32-bit ARM platforms that cannot run the arm64 images this project produces, so there is currently no way to get a ready-made Debian image for them. This PR makes the architecture a first-class parameter of the debos recipes, so that armhf images can be built alongside the arm64 ones.

Making room for a second architecture means the artifacts have to say which one they belong to, so every build artifact is now named after the architecture it was built for (`rootfs-arm64.tar`, `disk-ufs-armhf.img`, ...). This renames the arm64 artifacts, but only inside the build tree: the artifacts published by CI keep exactly the names they have today, the flashing pipeline and its rawprogram XMLs are untouched, and the old names stay available as symlinks so that existing scripts and instructions keep working.

armhf platforms don't boot via EFI, so the armhf images deliberately drop the ESP and systemd-boot and consist of a single root partition; the kernel defaults to Debian's `linux-image-armmp`, since the arm64 kernel packages don't apply. CI builds and publishes the armhf artifacts in the distro build workflows (PR/push/daily), but not in the kernel-validation pipelines, whose EFS kernels are arm64-only.

Nothing checked that a produced image can actually boot, so the qemu tests grew an armhf boot test, and it immediately paid for itself: the armhf images could not mount their root filesystem at all. Their initramfs contains none of the storage drivers, because initramfs-tools asks dracut-install to install whole module directories, dracut-install expands those with glibc's `fts(3)`, and fts reads directories with the 32-bit `readdir()`, which fails with `EOVERFLOW` on the 64-bit directory cookies ext4 hands out. On a 32-bit architecture every such directory therefore looks empty and is skipped without an error. This is Debian [#1110545](https://bugs.debian.org/1110545), with [#1079080](https://bugs.debian.org/1079080) for the failure going unreported. Naming the few modules the boot test needs works around it here, but an armhf image still lacks the MMC and UFS drivers it would need on real hardware: that has to be fixed in Debian, and the workaround says so.

The first commits are independent fixes made along the way: containerized `make` builds could not open `/dev/kvm` as the non-root container user, which broke the KVM fakemachine backend those builds force; the `overlays` workflow input was interpolated straight into a `run:` script, which both zizmor and Semgrep flag (also sent separately as #511, so this commit disappears if that lands first); and a build left several kinds of files untracked.

Validated locally: both armhf images build with `make USE_CONTAINER=yes`, carry an armhf userland with the armmp kernel and the expected single-partition GPT layout with the 32-bit ARM root partition type, and the boot test takes the rebuilt image all the way to a login prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
