### PR TITLE
ci: pass the overlays input to debos via the environment

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -104,6 +104,8 @@ jobs:
           )
 
       - name: Build rootfs with debos
+        env:
+          OVERLAYS: ${{ inputs.overlays }}
         run: |
           set -ux
           kernel_packages="$KERNEL_PACKAGES"
@@ -137,7 +139,7 @@ jobs:
           esac
 
           debos \
-              -t overlays:'${{ inputs.overlays }}' \
+              -t overlays:"$OVERLAYS" \
               -t xfcedesktop:true \
               -t aptlocalrepo:${PWD}/local-apt-repo \
               -t kernelpackages:"$kernel_packages" \


### PR DESCRIPTION
While adding armhf builds in #510, GitHub code scanning (zizmor and Semgrep) flagged the new step for interpolating `${{ inputs.overlays }}` directly into a `run:` script — a shell-injection vector, since Actions expands the template before the shell parses the script. That was fixed in #510 for the new step, but the pre-existing arm64 rootfs step uses the same pattern and carries the same risk; the scanners would flag it the next time the file is touched.

This follow-up applies the same remediation to the arm64 step: the input is passed through a step-level environment variable and expanded by the shell under normal quoting, where it cannot become code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
