### PR TITLE
ci: revert EnricoMi action to version tag

### DIFF
--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -190,7 +190,12 @@ jobs:
           ls -R $GITHUB_WORKSPACE
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
+        # not pinned to a SHA: the enterprise allowed-actions policy matches
+        # this third-party action by version tag, so a bare commit SHA is
+        # rejected at workflow startup (startup_failure). See PR #503 / run
+        # https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/30561677856
+        # nosemgrep: github-actions-mutable-action-tag
+        uses: EnricoMi/publish-unit-test-result-action@v2 # zizmor: ignore[unpinned-uses]
         with:
           files: "${{ github.workspace }}/artifacts/**/*.xml"
 

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -121,7 +121,12 @@ jobs:
           ls -R $GITHUB_WORKSPACE
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
+        # not pinned to a SHA: the enterprise allowed-actions policy matches
+        # this third-party action by version tag, so a bare commit SHA is
+        # rejected at workflow startup (startup_failure). See PR #503 / run
+        # https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/30561677856
+        # nosemgrep: github-actions-mutable-action-tag
+        uses: EnricoMi/publish-unit-test-result-action@v2 # zizmor: ignore[unpinned-uses]
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json


### PR DESCRIPTION
The enterprise allowed-actions policy matches
EnricoMi/publish-unit-test-result-action by version tag, so pinning
it to a bare commit SHA (PR #503, commit c07b8d9) made GitHub reject
the workflow at startup:

  The action EnricoMi/publish-unit-test-result-action@d0a4676... is
  not allowed ... all actions must be from a repository owned by
  your enterprise, created by GitHub...

Only build-on-push.yml (push to main) reaches this action via
lava-test.yml, so PR #503's own checks never exercised it and the
startup_failure surfaced only after merge. See run 30561677856.

Restore the @v2 tag and suppress the zizmor/semgrep mutable-tag
findings inline. test-on-pr.yml carries the same pin and would fail the
same way on its next run, so revert it too.
