### PR TITLE
ci: qcom-next: drop excluding glymur-crd

### DIFF
--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -23,6 +23,5 @@ jobs:
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'
-      lava_boards_exclude: '["glymur-crd"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml


### PR DESCRIPTION
- Enable glymur-crd testing on lava