### PR TITLE
ci: fix wifi device name on glymur-crd to wlP4p1s0

### DIFF
--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -70,6 +70,7 @@ actions:
       parameters:
         SKIP_INSTALL: "True"
         WAIT_TIME: 60
+        DEVICE: wlP4p1s0
 context:
   test_character_delay: 10
 device_type: glymur-crd


### PR DESCRIPTION
Devices of type glymur-crd enumerate their wifi device as wlP4p1s0, so
we need to set the LAVA test action to use this instead of default
wlan0.
