### PR TITLE
Revert "ci: revert EnricoMi action to version tag"

### DIFF
--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -190,12 +190,7 @@ jobs:
           ls -R $GITHUB_WORKSPACE
 
       - name: Publish Test Results
-        # not pinned to a SHA: the enterprise allowed-actions policy matches
-        # this third-party action by version tag, so a bare commit SHA is
-        # rejected at workflow startup (startup_failure). See PR #503 / run
-        # https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/30561677856
-        # nosemgrep: github-actions-mutable-action-tag
-        uses: EnricoMi/publish-unit-test-result-action@v2 # zizmor: ignore[unpinned-uses]
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           files: "${{ github.workspace }}/artifacts/**/*.xml"
 

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -121,12 +121,7 @@ jobs:
           ls -R $GITHUB_WORKSPACE
 
       - name: Publish Test Results
-        # not pinned to a SHA: the enterprise allowed-actions policy matches
-        # this third-party action by version tag, so a bare commit SHA is
-        # rejected at workflow startup (startup_failure). See PR #503 / run
-        # https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/30561677856
-        # nosemgrep: github-actions-mutable-action-tag
-        uses: EnricoMi/publish-unit-test-result-action@v2 # zizmor: ignore[unpinned-uses]
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json


### PR DESCRIPTION
This reverts commit 05fa5ce9ff06e9c7286cd304e5dca070ec1f9fe7.

GitHub configuration has been updated to allow this particular SHA.
