### PR TITLE
feat(ci): update to qcom-next-7.2-rc3-20260731

### DIFF
--- a/.github/workflows/linux-daily-glymur.yml
+++ b/.github/workflows/linux-daily-glymur.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write # linux.yml
     with:
       kernel_name: glymur
-      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'
+      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260731 prune.config qcom.config'
       debos_extra_args: '-t dtb:qcom/glymur-crd.dtb'
       # we hardcode the DT, and that's not compatible with the QEMU machine model
       skip_qemu_tests: true

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -22,6 +22,6 @@ jobs:
       pull-requests: write # linux.yml
     with:
       kernel_name: qcom-next
-      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260722 prune.config qcom.config'
+      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260731 prune.config qcom.config'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml


### PR DESCRIPTION
Update our workflows to build the latest qcom-next tag based on
7.2-rc3: qcom-next-7.2-rc3-20260731.
