### PR TITLE
ci: drop redundant called-workflow comments

### DIFF
--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -28,7 +28,7 @@ jobs:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
     permissions:
-      contents: read # debos.yml
+      contents: read
     with:
       suite: ${{ matrix.suite }}
       # plain Debian kernel: the Debian kernel and none of the Qualcomm overlays
@@ -49,12 +49,12 @@ jobs:
     uses: ./.github/workflows/lava-test.yml
     needs: build-daily-debian
     permissions:
-      checks: write # lava-test.yml
-      contents: read # lava-test.yml
-      packages: read # lava-test.yml
-      pull-requests: write # lava-test.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       url: ${{ needs.build-daily-debian.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -39,7 +39,7 @@ jobs:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
     permissions:
-      contents: read # debos.yml
+      contents: read
     with:
       suite: ${{ matrix.suite }}
       # QLI targets qcom-next; consume the debs published to EFS by the
@@ -57,12 +57,12 @@ jobs:
     uses: ./.github/workflows/lava-test.yml
     needs: build-daily
     permissions:
-      checks: write # lava-test.yml
-      contents: read # lava-test.yml
-      packages: read # lava-test.yml
-      pull-requests: write # lava-test.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -26,7 +26,7 @@ jobs:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
     permissions:
-      contents: read # debos.yml
+      contents: read
     with:
       suite: ${{ matrix.suite }}
       # QLI targets qcom-next; consume the debs published to EFS by the
@@ -36,4 +36,4 @@ jobs:
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
     permissions:
-      contents: read # lava-schema-check.yml
+      contents: read

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -15,7 +15,7 @@ jobs:
         suite: [trixie, forky]
     uses: ./.github/workflows/debos.yml
     permissions:
-      contents: read # debos.yml
+      contents: read
     with:
       suite: ${{ matrix.suite }}
       # QLI targets qcom-next; consume the debs published to EFS by the
@@ -25,16 +25,16 @@ jobs:
   schema-check:
     uses: ./.github/workflows/lava-schema-check.yml
     permissions:
-      contents: read # lava-schema-check.yml
+      contents: read
   test:
     uses: ./.github/workflows/lava-test.yml
     needs: [build-daily, schema-check]
     permissions:
-      checks: write # lava-test.yml
-      contents: read # lava-test.yml
-      packages: read # lava-test.yml
-      pull-requests: write # lava-test.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -17,10 +17,10 @@ jobs:
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
     permissions:
-      checks: write # linux.yml
-      contents: read # linux.yml
-      packages: read # linux.yml
-      pull-requests: write # linux.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     with:
       kernel_name: arduino
       build_linux_deb_extra_args: '--repo https://github.com/qualcomm-linux/kernel-topics --ref early/hwe/arduino'
@@ -33,4 +33,4 @@ jobs:
       debos_extra_args: '-t overlays:qsc-deb-releases,workaround-hexagon-dsp-binaries-monza,workaround-initramfs-firmware-monaco'
       lava_boards_include: '["monaco-arduino-monza", "monaco-evk"]'
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -17,10 +17,10 @@ jobs:
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
     permissions:
-      checks: write # linux.yml
-      contents: read # linux.yml
-      packages: read # linux.yml
-      pull-requests: write # linux.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     with:
       kernel_name: linux-next
       build_linux_deb_extra_args: '--linux-next'
@@ -29,4 +29,4 @@ jobs:
       lava_report_test_results_externally: false
       lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -21,10 +21,10 @@ jobs:
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
     permissions:
-      checks: write # linux.yml
-      contents: read # linux.yml
-      packages: read # linux.yml
-      pull-requests: write # linux.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260731 prune.config qcom.config'
@@ -32,4 +32,4 @@ jobs:
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -18,10 +18,10 @@ jobs:
     if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/linux.yml
     permissions:
-      checks: write # linux.yml
-      contents: read # linux.yml
-      packages: read # linux.yml
-      pull-requests: write # linux.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     with:
       kernel_name: mainline
       # reference build: we want the debs and the LAVA results to compare
@@ -32,4 +32,4 @@ jobs:
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
       lava_boards_exclude: '["glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -180,7 +180,7 @@ jobs:
     needs: build-linux-deb
     uses: ./.github/workflows/debos.yml
     permissions:
-      contents: read # debos.yml
+      contents: read
     with:
       kernelpackages: efs/${{ inputs.kernel_name || 'mainline' }}
       debos_extra_args: ${{ inputs.debos_extra_args }}
@@ -191,12 +191,12 @@ jobs:
     uses: ./.github/workflows/lava-test.yml
     needs: debos-linux-deb
     permissions:
-      checks: write # lava-test.yml
-      contents: read # lava-test.yml
-      packages: read # lava-test.yml
-      pull-requests: write # lava-test.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       url: ${{ needs.debos-linux-deb.outputs.artifacts_url }}
       suite: trixie

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -13,8 +13,8 @@ jobs:
   preflight:
     name: Run QC Preflight Checks
     permissions:
-      contents: read # reusable-qcom-preflight-checks-orchestrator.yml
-      security-events: write # reusable-qcom-preflight-checks-orchestrator.yml
+      contents: read
+      security-events: write
     uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@15377d14305caeaeacbda9b24f93f57258e55b37 # v2.0.8
     with:
       enable-semgrep-scan: true

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -63,12 +63,12 @@ jobs:
   test:
     uses: ./.github/workflows/lava-test.yml
     permissions:
-      checks: write # lava-test.yml
-      contents: read # lava-test.yml
-      packages: read # lava-test.yml
-      pull-requests: write # lava-test.yml
+      checks: write
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     needs: retrieve-build-url
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}


### PR DESCRIPTION
The `permissions:` and `secrets:` blocks of a job with a single `uses:` only apply to that called workflow; so annotating each entry with the workflow name adds no additional context. The additional comments containing each called workflow were only useful when several reasons could justify granting the permissions; as discussed in the linked issue.

Comments naming an action (e.g. `# actions/checkout`) are kept; as those jobs run several steps.

Link: https://github.com/qualcomm-linux/qcom-deb-images/pull/503#discussion_r3684388807