### PR TITLE
feat(debos/rootfs): add default user to kvm group

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -368,10 +368,12 @@ actions:
       set -eux
       # pre-emptively create a sudo group if sudo isn't installed
       getent group sudo >/dev/null 2>&1 || groupadd --system sudo
+      # pre-emptively create a kvm group if udev isn't installed
+      getent group kvm >/dev/null 2>&1 || groupadd --system kvm
       # some useful groups for desktop scenarios, but also to run payloads
       # from the serial console, over SSH, or in containers - where the desktop
       # session has not updated ACLs to the device nodes
-      groups="adm,audio,render,sudo,users,video"
+      groups="adm,audio,kvm,render,sudo,users,video"
       # fastrpc group only exists when fastrpc-support is installed (Debian)
       if getent group fastrpc >/dev/null 2>&1; then
         groups="${groups},fastrpc"


### PR DESCRIPTION
/dev/kvm is owned root:kvm with mode 0660, so the default "debian"
user could not use KVM acceleration without root on deployed images.
Add the user to the kvm group, and pre-emptively create the group in
case udev - which normally ships the sysusers config creating it -
is absent, mirroring the existing sudo group handling.
