### PR TITLE
fix(rootfs): precreate fastrpc group

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -361,6 +361,19 @@ actions:
       # /etc/hosts is created by netbase
       sed -i "1s/^/127.0.1.1	debian\n/" /etc/hosts
 
+  # The fastrpc system group used to be created when the fastrpc package was
+  # installed, but is now created at boot time from a systemd sysusers.d
+  # fragment. Precreate it here from that same fragment so the "debian" user
+  # can be added to it in the next action.
+  - action: run
+    description: Precreate the fastrpc group from its sysusers.d fragment
+    chroot: true
+    command: |
+      set -eux
+      if [ -f /usr/lib/sysusers.d/fastrpc.conf ]; then
+          systemd-sysusers /usr/lib/sysusers.d/fastrpc.conf
+      fi
+
   - action: run
     description: Add a "debian" user, add it to sudoers and various groups
     chroot: true
@@ -372,7 +385,7 @@ actions:
       # from the serial console, over SSH, or in containers - where the desktop
       # session has not updated ACLs to the device nodes
       groups="adm,audio,render,sudo,users,video"
-      # fastrpc group only exists when fastrpc-support is installed (Debian)
+      # fastrpc group is precreated above when fastrpc-support is installed
       if getent group fastrpc >/dev/null 2>&1; then
         groups="${groups},fastrpc"
       fi


### PR DESCRIPTION
The fastrpc group is no longer created when fastrpc-support is
installed; it is now created at boot time from the systemd
sysusers.d fragment shipped by the package. As a result, the
build-time "getent group fastrpc" check failed and the debian user
was never added to the fastrpc group.

Precreate the group at build time by running systemd-sysusers on
/usr/lib/sysusers.d/fastrpc.conf (guarded on its presence) before
creating the debian user, so the existing group-membership logic
works again.
