### PR TITLE
fix(debos/rootfs): add fastrpc-tests unconditionally

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -361,20 +361,14 @@ actions:
       # WPA / WPA2 / WPA3 client support
       - wpasupplicant
 
-{{- if eq $suite "trixie" }}
-{{- if ne $overlays "none" }}
-{{- range $overlay := split "," $overlays }}
-{{- if eq $overlay "qsc-deb-releases" }}
-  # fastrpc-tests is only available in trixie-overlay
+{{- if ne $suite "unstable" }}
+  # fastrpc-tests is available from QLI overlays for trixie and forky
   - action: apt
-    description: Install fastrpc-tests (trixie only)
+    description: Install fastrpc-tests from QLI overlay
     recommends: true
     packages:
-      # fastrpc support. fastrpc-tests pulls in the required stack
+      # fastrpc-tests pulls in fastrpc-support
       - fastrpc-tests
-{{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 
   - action: run


### PR DESCRIPTION
fastrpc-tests is no longer limited to the trixie qsc-deb-releases
overlay; instead it's available from QLI trixie and forky
repositories which are enabled unconditionally.
