### PR TITLE
feat(ci/lava): add monaco-arduino-monza

### DIFF
--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -64,7 +64,7 @@ jobs:
       # linux-next/qcom-next/arduino
       # kernels so far, not the distro kernel; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-arduino-monza", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      boards_exclude: '["glymur-crd", "lemans-evk", "monaco-arduino-monza", "monaco-evk", "qcs615-ride", "qcs8300-ride", "qrb2210-rb1"]'
       # failures here are about upstream Debian, not about qcom-deb-images;
       # they are reported through this workflow instead of gating our work
       report_test_results_externally: false

--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -60,10 +60,11 @@ jobs:
       suite: ${{ matrix.suite }}
       # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
       # glymur-crd can't boot the distro kernel, only qcom-next
-      # monaco-evk only validated against the linux-next/qcom-next/arduino
+      # monaco-arduino-monza and monaco-evk only validated against the
+      # linux-next/qcom-next/arduino
       # kernels so far, not the distro kernel; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      boards_exclude: '["qrb2210-rb1", "glymur-crd", "monaco-arduino-monza", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
       # failures here are about upstream Debian, not about qcom-deb-images;
       # they are reported through this workflow instead of gating our work
       report_test_results_externally: false

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -66,3 +66,5 @@ jobs:
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
+      boards_exclude: '["monaco-arduino-monza"]'

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -38,3 +38,5 @@ jobs:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # lava-test.yml
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
+      boards_exclude: '["monaco-arduino-monza"]'

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -31,5 +31,7 @@ jobs:
       # stop after publishing the debs to EFS; the "Daily Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
+      lava_boards_exclude: '["monaco-arduino-monza"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }} # linux.yml

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -76,6 +76,8 @@ jobs:
       # however the publish job below hard-codes this in its artifact
       # download patterns, so keep them in sync if this changes.
       suite: trixie
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
+      boards_exclude: '["monaco-arduino-monza"]'
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/ci/lava/monaco-arduino-monza/boot.yaml
+++ b/ci/lava/monaco-arduino-monza/boot.yaml
@@ -1,0 +1,74 @@
+actions:
+- deploy:
+    rootfs_image: disk-sdcard.img2
+    overlay_path: /
+    qcomflash:
+      headers:
+        Authorization: Q_S3_TOKEN
+      url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
+      apply-overlay: true
+    timeout:
+      minutes: 20
+    to: qdl
+- boot:
+    firehose_program: prog_firehose_ddr.elf
+    rawprogram: rawprogram0.xml
+    patch: patch0.xml
+    path: flash_monaco-arduino-monza_emmc
+    storage: emmc
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
+- command:
+    name: network_turn_on
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
+      - sudo su
+    method: minimal
+    prompts:
+    - root@debian
+    - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
+    timeout:
+      minutes: 3
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - from: git
+      name: "smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a"
+    - from: git
+      name: "wlan-smoke-test"
+      path: automated/linux/wlan-smoke/wlan-smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        WAIT_TIME: 60
+        DEVICE: wlp3s0
+context:
+  test_character_delay: 10
+device_type: monaco-arduino-monza
+job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+timeouts:
+  job:
+    minutes: 210
+visibility: public


### PR DESCRIPTION
Add LAVA templates for monaco-arduino-monza, identical to
qrb2210-rb1 which is also using eMMC storage, but setting the proper
expected wifi device name.

As soon as we add a CI template, it gets picked up by default unless
the workflow uses an explicit include list, so verify that this
works with various kernels.

Tested with:
- arduino (PASS) https://lava.infra.foundries.io/scheduler/job/353015
- mainline (PASS) https://lava.infra.foundries.io/scheduler/job/353161
- qcom-next (FAIL) https://lava.infra.foundries.io/scheduler/job/353160

Update excludes for Debian builds and qcom-next; don't exclude for
mainline/linux-next; arduino daily was pre-emptively including this
platform too.

Fixes: #537
