### PR TITLE
fix(build-linux-deb): honour --local-dir for config

### DIFF
--- a/scripts/build-linux-deb.py
+++ b/scripts/build-linux-deb.py
@@ -299,7 +299,7 @@ def main():
         subprocess.run(
             merge_command,
             check=True,
-            cwd="linux",
+            cwd=linux_dir,
             env={"ARCH": "arm64", **subprocess.os.environ}
         )
 
@@ -307,7 +307,7 @@ def main():
         subprocess.run(
             make_base_command + ["olddefconfig"],
             check=True,
-            cwd="linux"
+            cwd=linux_dir
         )
 
     log_i("Building Linux deb")


### PR DESCRIPTION
The merge_config.sh and olddefconfig invocations passed a hardcoded
cwd="linux" while the defconfig and bindeb-pkg invocations used
linux_dir. With --local-dir pointing anywhere other than ./linux,
the config phase fails with FileNotFoundError: 'linux'.

Use linux_dir consistently. The default clone path is unaffected, as
linux_dir is Path("linux") there.
