### PR TITLE
feat(debos/rootfs): install fastrpc-support

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -334,6 +334,8 @@ actions:
       - e2fsprogs
       # tools to read/write EFI variables
       - efivar
+      # support for Qualcomm xDSPs
+      - fastrpc-support
       # fwupd tools, enable OTA EFI firmware capsule updates
       - fwupd
       # defaults to "systemd-sysv"; perhaps not needed


### PR DESCRIPTION
Full support for Qualcomm xDSPs (ADSP/CDSP etc.) needs the
fastrpc-support package, so it should really be listed as a
foundational package. Until recently it wasn't available in
trixie-backports, yet it was still being pulled via fastrpc-tests
which only lived in Qualcomm overlays (qsc-deb-releases or QLI
debusine APT repo).

Unconditionally install fastrpc-support, paving the way to proper
support in vanilla Debian images while keeping fastrpc-tests
included where possible.
