### PR TITLE
chore(debos): prefer wireplumber from backports

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -156,7 +156,8 @@ actions:
       "src:linux:any"
       "src:linux-signed-arm64:any"
       "src:mesa:any"
-      "src:u-boot-efi-dtb" }}
+      "src:u-boot-efi-dtb"
+      "src:wireplumber:any" }}
 
   - action: run
     description: Add Debian {{ $suite }}-backports APT configuration


### PR DESCRIPTION
WirePlumber 0.5.12 is available in trixie-backports and is needed for AudioReach validation on Glymur. Add the wireplumber source package to the existing backports preference list so wireplumber and libwireplumber-0.5-0 are selected together during image builds.

PipeWire is intentionally not added here. Glymur testing showed QCOM PipeWire 1.4.2-1~qcom1 with WirePlumber 0.5.12 keeps playback working, while Debian backports PipeWire 1.4.9 regressed playback. WirePlumber 0.5.12 only requires pipewire >= 1.0.2, which the QCOM PipeWire package satisfies.