### PR TITLE
fix(debos/image): Add "quiet" to cmdline kernel options

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -76,7 +76,7 @@ actions:
   - action: filesystem-deploy
     description: Deploy root filesystem to mounted image
     setup-fstab: true
-    append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30
+    append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30 quiet
 
 {{- if $snapshot }}
   - action: run


### PR DESCRIPTION
Add "quiet" functionality while bootup for Debian build, significantly improving the boot time userspace performance, giving significant improvement in kernel (8585ms to 996ms) and userspace (15.585s to 2.176s) for the Glymur device.

previous:
```
Startup finished in 8.585s (kernel) + 15.585s (userspace) = 24.170s 
graphical.target reached after 15.584s in userspace.
```

after:
```
Startup finished in 13.752s (firmware) + 181ms (loader) + 996ms (kernel) + 2.177s (userspace) = 17.108s
graphical.target reached after 2.176s in userspace.
```
