### PR TITLE
feat(debos/flash): reduce multi-DTB FIT image size to 2 MiB

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -534,6 +534,7 @@ actions:
               if "${QCOM_DTB_METADATA}/build-dtb-image.sh" \
                   --dtb-src build/dtbs/qcom \
                   --soc {{ $soc }} \
+                  --size 2 \
                   --out "${dtb_bin}" \
                   --prune; then
                   echo "Multi-DTB FIT image generated: ${dtb_bin}"


### PR DESCRIPTION
## Summary
dtb-multidtb-<soc>.bin was always built at build-dtb-image.sh's 4 MiB default.
glymur-crd's ptool partitions (dtb_a/dtb_b) are being reduced from 4 MiB to 2 MiB, so glymur's image needs to shrink to match.

Rather than special-casing glymur, reduce the default to 2 MiB for every SoC that generates a multidtb FIT image: actual FIT content for all current SoCs (glymur, hamoa, purwa, shikracqm, shikracqs, shikraiqs) is well under 2 MiB, and ptool partitions that stay at 4 MiB or larger are unaffected, since flashing a smaller image into a larger partition is harmless.

## Test
Built with these changes; confirmed `dtb-multidtb-<soc>.bin` is now 2.0 MiB for the SoCs (glymur, hamoa, purwa, shikracqm, shikracqs, shikraiqs)