### PR TITLE
ci: copy unstripped vmlinux to the image artifacts

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -121,6 +121,21 @@ jobs:
               apt-ftparchive release . >Release
           )
 
+      - name: Copy unstripped vmlinux from EFS
+        run: |
+          set -ux
+          # the kernel workflow publishes the unstripped vmlinux next to the
+          # debs; pick it up so it gets published with the image artifacts.
+          case "$KERNEL_PACKAGES" in
+            efs/*)
+              efs_kernel_dir="/efs/${KERNEL_PACKAGES#efs/}"
+              # kernel builds predating the vmlinux artifact have none
+              if [ -f "${efs_kernel_dir}/vmlinux" ]; then
+                  cp -av "${efs_kernel_dir}/vmlinux" .
+              fi
+            ;;
+          esac
+
       - name: Build rootfs with debos
         run: |
           set -ux
@@ -178,6 +193,12 @@ jobs:
           gzip -c disk-ufs.img >"${dir}/${PREFIX}-disk-ufs.img.gz"
           gzip -c disk-sdcard.img >"${dir}/${PREFIX}-disk-sdcard.img.gz"
           cp -av dtbs.tar.gz "${dir}/${PREFIX}-dtbs.tar.gz"
+          # publish the unstripped vmlinux of the kernel installed in the image
+          # to facilitate debugging oops/panic backtraces; absent when the kernel
+          # comes from APT rather than from an EFS kernel build.
+          if [ -f vmlinux ]; then
+              gzip -c vmlinux >"${dir}/${PREFIX}-vmlinux.gz"
+          fi
           # create tarballs with support for all UFS and all eMMC boards
           scripts/bundle-flash-dirs.sh "${dir}" "${PREFIX}"
           # generate sha256sums for all artifacts


### PR DESCRIPTION
Commit 6116f3656e22 ("ci(linux): publish unstripped vmlinux as artifact") copies linux/vmlinux next to the kernel debs so kernel crashes can be debugged. Since the kernel and image builds are split into separate workflows, each publishing to its own artifacts directory, that vmlinux only lands in the kernel build directory and consumers of the image artifacts have no matching vmlinux to use.

Pick up the vmlinux published on EFS alongside the kernel debs when the image installs an EFS kernel and stage it compressed as <suite>-vmlinux.gz with the other image artifacts so it is uploaded to S3 and covered by the sha256sums file. Images installing a kernel from APT get no vmlinux and neither do EFS kernels built before 6116f3656e22.

Fixes: #551

--

This was verified by making sure the `${SUITE}-vmlinux.gz` file was uploaded in the S3 bucket, along with the checksum for the into the `${SUITE}-sha256sums.txt files, for both `trixie` and `forky` suites for the `build-on-pr.yml` workflow.

I also ensured that that the vmlinux file from the kernel build workflow itself isn't compressed (e.g. ensured that we don't compress the file twice).