### PR TITLE
ci: skip qrb2210-rb1 in the mainline and linux-next LAVA tests

### DIFF
--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -27,6 +27,8 @@ jobs:
       # reference build: we want the debs and the LAVA results to compare
       # against, but its failures must not gate qcom-deb-images work
       lava_report_test_results_externally: false
-      lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      # qrb2210-rb1 doesn't boot with mainline, only qcom-next; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/424
+      lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk", "qrb2210-rb1"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -30,6 +30,8 @@ jobs:
       # monaco-evk only validated against the linux-next/qcom-next/arduino
       # kernels so far; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      lava_boards_exclude: '["glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      # qrb2210-rb1 doesn't boot with mainline, only qcom-next; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/424
+      lava_boards_exclude: '["glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk", "qrb2210-rb1"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}


### PR DESCRIPTION
qrb2210-rb1 never reaches a login prompt on the mainline kernel: as adsprpcd.service and adsprpcd_audiopd.service start, fastrpc fails an mmap for the aDSP:

  qcom,fastrpc-cb [...]:fastrpc:compute-cb@3: mem mmap error, fd 11,
    vaddr ffff9dc10000, size 262144
  qcom_q6v5_pas ab00000.remoteproc: fatal error received: SFR Init:
    wdog or kernel error suspected.
  remoteproc remoteproc1: crash detected in adsp: type fatal error

The SoC then hard resets with no panic and no call trace. That repeats for the timeout the minimal-boot action allows, so the login-action times out and the job is marked as Incomplete.

See https://lava.infra.foundries.io/scheduler/job/356726 for a sample job.

Exclude the board from both runs until the aDSP side is fixed. The qcom-next runs still cover qrb2210-rb1.

Link: https://github.com/qualcomm-linux/qcom-deb-images/issues/424