### PR TITLE
feat(qcom-next): update to tag qcom-next-7.2-rc5-20260812

### DIFF
--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     with:
       kernel_name: qcom-next
-      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc3-20260731 prune.config qcom.config'
+      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc5-20260812 prune.config qcom.config'
       # stop after publishing the debs to EFS; the "Daily Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true


### PR DESCRIPTION
Move to the latest linux-qcom-next release tag qcom-next-7.2-rc5-20260812, which corresponds to kernel version v7.2-rc5.