### PR TITLE
ci: update LAVA templates to new auth tokens

### DIFF
--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/lemans-evk/boot.yaml
+++ b/ci/lava/lemans-evk/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/monaco-arduino-monza/boot.yaml
+++ b/ci/lava/monaco-arduino-monza/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/qcs615-ride/boot.yaml
+++ b/ci/lava/qcs615-ride/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/qcs8300-ride/boot.yaml
+++ b/ci/lava/qcs8300-ride/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-ufs.tar.gz"
       apply-overlay: true
     timeout:

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -4,7 +4,7 @@ actions:
     overlay_path: /
     qcomflash:
       headers:
-        Authorization: Q_S3_TOKEN
+        QLIAuthorization: Q_QLI_S3_TOKEN
       url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
       apply-overlay: true
     timeout:


### PR DESCRIPTION
Update authorization headers and tokens in LAVA job templates. This was requested by Qualcomm's IT. The reason is that new tokens will allow for more granular access control.