### PR TITLE
ci: integrate the Grype vulnerability scanner

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -304,12 +304,6 @@ jobs:
           # every -o above writes to a file, so echo the table to the log too
           cat rootfs-vulns.grype.txt
 
-      - name: Summarize Grype findings in the job summary
-        run: |
-          set -ux
-          scripts/grype-vulnerability-summary.py rootfs-vulns.grype.json |
-              tee -a "$GITHUB_STEP_SUMMARY"
-
       - name: Stage SBOMs and Vulnerability report for publishing
         run: |
           set -ux
@@ -337,6 +331,10 @@ jobs:
           echo "${build_url}" > build_url
           echo "## Download URL" >> $GITHUB_STEP_SUMMARY
           echo "[${build_url}](${build_url})" >> $GITHUB_STEP_SUMMARY
+          # append the Grype summary after the download link, so the link stays
+          # at the top of the job summary
+          scripts/grype-vulnerability-summary.py rootfs-vulns.grype.json \
+              >> $GITHUB_STEP_SUMMARY
       - name: Upload build URL
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -79,10 +79,8 @@ jobs:
 
       # mtools is needed for the flash recipe
       # file, device-tree-compiler and u-boot-tools are needed by qcom-dtb-metadata
-      # gettext-base is needed by cosign-installer, which uses envsubst internally
-      # curl is needed by cosign-installer and the Syft install script
       - name: Install debos and dependencies of the recipes and local tests
-        run: apt -y install curl debian-archive-keyring debos file gettext-base make mmdebstrap mtools python3-pexpect python3-pytest qemu-efi-aarch64 qemu-system-arm xmlstarlet python3-defusedxml device-tree-compiler u-boot-tools
+        run: apt -y install debian-archive-keyring debos file make mmdebstrap mtools python3-pexpect python3-pytest qemu-efi-aarch64 qemu-system-arm xmlstarlet python3-defusedxml device-tree-compiler u-boot-tools
 
       - name: Setup local APT repo
         run: |
@@ -217,23 +215,19 @@ jobs:
       - name: Unpack rootfs to generate SBOM
         run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar
 
-      - name: Install cosign
-        # Required so the syft and grype installers can verify the release
-        # signature (-v).
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      # Syft is not packaged in Debian; it's available as a binary tarball or
-      # as container image from upstream; it's available on arm64 and x86
+      # Use the "download-syft" sub-action to install Syft and keep it
+      # updated via Dependabot.
       - name: Install Syft
-        run: |
-          set -ux
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -v
+        id: syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Generate SBOMs with Syft
+        env:
+          SYFT: ${{ steps.syft.outputs.cmd }}
         run: |
           set -ux
-          bin/syft --version
-          SYFT_FORMAT_PRETTY=true bin/syft \
+          "$SYFT" --version
+          SYFT_FORMAT_PRETTY=true "$SYFT" \
               -o cyclonedx-json=rootfs-sbom.cyclonedx.json \
               -o spdx-json=rootfs-sbom.spdx.json \
               -o syft-json=rootfs-sbom.syft.json \

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -253,12 +253,11 @@ jobs:
               --rootfs rootfs rootfs-sbom.syft.json |
                   tee rootfs-sbom.syft-license-summary.csv.txt
 
-      # Grype is not packaged in Debian; like Syft it's available as a binary
-      # tarball or as container image from upstream, on arm64 and x86
+      # Use the "download-grype" sub-action to install Grype and keep it
+      # updated via Dependabot.
       - name: Install Grype
-        run: |
-          set -ux
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -v
+        id: grype
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
 
       # the vulnerability database is downloaded separately from the scan so
       # that a transient download failure is reported as its own step, and so
@@ -266,12 +265,14 @@ jobs:
       # lists the data providers, which is where the Debian Security Tracker
       # data comes from (provider "debian")
       - name: Update Grype vulnerability database
+        env:
+          GRYPE: ${{ steps.grype.outputs.cmd }}
         run: |
           set -ux
-          bin/grype --version
-          bin/grype db update -v
-          bin/grype db status
-          bin/grype db providers
+          "$GRYPE" --version
+          "$GRYPE" db update -v
+          "$GRYPE" db status
+          "$GRYPE" db providers
 
       # scan the SBOM generated above by Syft rather than the rootfs directory:
       # it's much faster and it guarantees both reports describe exactly the
@@ -290,9 +291,11 @@ jobs:
       # failing the build on severity would make every build red; the reports
       # are published as artifacts for review instead
       - name: Scan SBOM for vulnerabilities with Grype
+        env:
+          GRYPE: ${{ steps.grype.outputs.cmd }}
         run: |
           set -ux
-          bin/grype \
+          "$GRYPE" \
               -o json=rootfs-vulns.grype.json \
               -o table=rootfs-vulns.grype.txt \
               -o cyclonedx-json=rootfs-vulns.grype.cyclonedx.json \

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -218,7 +218,8 @@ jobs:
         run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar
 
       - name: Install cosign
-        # Required so the syft installer can verify the release signature (-v).
+        # Required so the syft and grype installers can verify the release
+        # signature (-v).
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Syft is not packaged in Debian; it's available as a binary tarball or
@@ -252,12 +253,69 @@ jobs:
               --rootfs rootfs rootfs-sbom.syft.json |
                   tee rootfs-sbom.syft-license-summary.csv.txt
 
-      - name: Stage SBOMs for publishing
+      # Grype is not packaged in Debian; like Syft it's available as a binary
+      # tarball or as container image from upstream, on arm64 and x86
+      - name: Install Grype
+        run: |
+          set -ux
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -v
+
+      # the vulnerability database is downloaded separately from the scan so
+      # that a transient download failure is reported as its own step, and so
+      # the database metadata (built date, schema) shows up in the logs; it also
+      # lists the data providers, which is where the Debian Security Tracker
+      # data comes from (provider "debian")
+      - name: Update Grype vulnerability database
+        run: |
+          set -ux
+          bin/grype --version
+          bin/grype db update -v
+          bin/grype db status
+          bin/grype db providers
+
+      # scan the SBOM generated above by Syft rather than the rootfs directory:
+      # it's much faster and it guarantees both reports describe exactly the
+      # same set of packages
+      #
+      # the distro is not overridden with --distro: the SBOM already records the
+      # Debian release from the rootfs' os-release, and that is what Grype needs
+      # to select the Debian provider's data. passing a codename Grype doesn't
+      # map to a release (e.g. forky while it's still testing) would silently
+      # match nothing at all
+      #
+      # --by-cve reports CVE identifiers instead of Debian-specific DSA/DLA ids,
+      # which is what downstream tooling and reports expect
+      #
+      # no --fail-on: a Debian image always carries known unfixed CVEs, so
+      # failing the build on severity would make every build red; the reports
+      # are published as artifacts for review instead
+      - name: Scan SBOM for vulnerabilities with Grype
+        run: |
+          set -ux
+          bin/grype \
+              -o json=rootfs-vulns.grype.json \
+              -o table=rootfs-vulns.grype.txt \
+              -o cyclonedx-json=rootfs-vulns.grype.cyclonedx.json \
+              -o sarif=rootfs-vulns.grype.sarif \
+              --by-cve \
+              --sort-by severity \
+              -v \
+              sbom:rootfs-sbom.syft.json
+          # every -o above writes to a file, so echo the table to the log too
+          cat rootfs-vulns.grype.txt
+
+      - name: Summarize Grype findings in the job summary
+        run: |
+          set -ux
+          scripts/grype-vulnerability-summary.py rootfs-vulns.grype.json |
+              tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Stage SBOMs and Vulnerability report for publishing
         run: |
           set -ux
           dir="sboms"
           mkdir -v sboms
-          for f in rootfs-sbom.*; do
+          for f in rootfs-sbom.* rootfs-vulns.*; do
               gzip -c "$f" >"${dir}/${PREFIX}-${f}.gz"
           done
 

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# input is a Grype JSON file as the first argument; output is a
+# human-readable summary of the vulnerabilities found, in Markdown format
+# suitable for a GitHub job summary
+
+import json
+import argparse
+from collections import defaultdict
+
+# severities in reporting order; anything Grype reports that isn't in this
+# list is collected under "Unknown"
+SEVERITIES = ["Critical", "High", "Medium", "Low", "Negligible", "Unknown"]
+
+# only vulnerabilities at or above this severity are listed individually; the
+# others are only counted, to keep the summary readable
+DETAIL_SEVERITIES = ["Critical", "High"]
+
+
+def load_grype_json(file_path):
+    with open(file_path, 'r') as f:
+        return json.load(f)
+
+
+def normalize_severity(severity):
+    severity = (severity or "").capitalize()
+    return severity if severity in SEVERITIES else "Unknown"
+
+
+def collect_matches(data):
+    # a single CVE can match several binary packages built from the same
+    # source package, so group by (severity, vulnerability) and collect the
+    # affected packages
+    grouped = defaultdict(lambda: {
+        "packages": set(),
+        "fix_versions": set(),
+        "fix_state": set()
+    })
+    for match in data.get("matches", []):
+        vulnerability = match.get("vulnerability", {})
+        artifact = match.get("artifact", {})
+        vuln_id = vulnerability.get("id", "unknown")
+        severity = normalize_severity(vulnerability.get("severity"))
+        key = (severity, vuln_id)
+        name = artifact.get("name", "unknown")
+        version = artifact.get("version", "")
+        grouped[key]["packages"].add(f"{name} {version}".strip())
+        fix = vulnerability.get("fix", {})
+        grouped[key]["fix_state"].add(fix.get("state", "unknown"))
+        for fix_version in fix.get("versions", []):
+            grouped[key]["fix_versions"].add(fix_version)
+    return grouped
+
+
+def count_by_severity(grouped):
+    counts = defaultdict(int)
+    for severity, _ in grouped:
+        counts[severity] += 1
+    return counts
+
+
+def print_summary(grouped, data):
+    counts = count_by_severity(grouped)
+    distro = data.get("distro", {})
+    distro_name = distro.get("name", "unknown")
+    distro_version = distro.get("version") or distro.get("idLike") or ""
+    db = data.get("descriptor", {}).get("db", {})
+
+    print("## Vulnerability summary (Grype)")
+    print()
+    print(f"Distribution: `{distro_name} {distro_version}`".rstrip() + "  ")
+    print(f"Vulnerability database built: "
+          f"`{db.get('built', 'unknown')}`  ")
+    print(f"Total unique vulnerabilities: **{len(grouped)}**")
+    print()
+
+    print("| Severity | Count |")
+    print("| --- | --- |")
+    for severity in SEVERITIES:
+        print(f"| {severity} | {counts[severity]} |")
+    print()
+
+    detailed = sorted(
+        (key for key in grouped if key[0] in DETAIL_SEVERITIES),
+        key=lambda key: (DETAIL_SEVERITIES.index(key[0]), key[1])
+    )
+    if not detailed:
+        print(f"No {' or '.join(DETAIL_SEVERITIES).lower()} "
+              "severity vulnerabilities found.")
+        return
+
+    print(f"### {' and '.join(DETAIL_SEVERITIES)} severity vulnerabilities")
+    print()
+    print("| Severity | Vulnerability | Packages | Fixed in |")
+    print("| --- | --- | --- | --- |")
+    for severity, vuln_id in detailed:
+        entry = grouped[(severity, vuln_id)]
+        packages = ", ".join(sorted(entry["packages"]))
+        if entry["fix_versions"]:
+            fix = ", ".join(sorted(entry["fix_versions"]))
+        else:
+            fix = ", ".join(sorted(entry["fix_state"]))
+        print(f"| {severity} | {vuln_id} | {packages} | {fix} |")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+                 description="Summarize Grype vulnerability data.")
+    parser.add_argument("grype_json", help="Path to the Grype JSON file")
+    args = parser.parse_args()
+
+    grype_data = load_grype_json(args.grype_json)
+    grype_grouped = collect_matches(grype_data)
+    print_summary(grype_grouped, grype_data)


### PR DESCRIPTION
Run Anchore's [Grype](https://github.com/anchore/grype) in the `debos` build workflow to scan every image we build for known vulnerabilities, and publish the reports alongside the existing Syft SBOMs.

This is the follow-on to the Syft integration: same vendor, same install mechanism, and it consumes the SBOM Syft already produces. The motivation is CRA compliance -- we need vulnerability data for the images we ship, in machine-readable formats, retained per build.

## Notable decisions

- **No `--fail-on`.** A Debian image always carries known unfixed CVEs, so gating on severity would turn every build red. Reports are published for review instead.
- **No `--distro` override.** The SBOM already records the Debian release from the rootfs' `os-release`, which is what Grype needs to select the Debian provider. Passing a codename Grype doesn't map to a release (e.g. `forky` while it is still testing) would silently match *nothing* rather than error.
- **`--by-cve`** so we report CVE ids rather than Debian-specific DSA/DLA ids.
- The summary script groups by `(severity, CVE)` and collects affected packages, because one CVE typically matches several binary packages from the same source package. Only Critical and High are listed individually; the rest are counted, to keep the job summary readable.

Closes #545
Assisted-by: Claude:claude-opus-5