### PR TITLE
ci: allow manual runs of the workflows from any branch

### DIFF
--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -20,8 +20,13 @@ permissions: {}
 
 jobs:
   build-daily-debian:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:
@@ -40,8 +45,13 @@ jobs:
       debos_extra_args: -t qliaptrepo:false
 
   test-daily-debian:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -31,8 +31,13 @@ permissions: {}
 
 jobs:
   build-daily:
-    # don't run from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:
@@ -48,8 +53,13 @@ jobs:
       kernelpackages: efs/qcom-next
 
   test-daily:
-    # don't run from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -13,8 +13,13 @@ permissions: {}
 
 jobs:
   build:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     uses: ./.github/workflows/linux.yml
     permissions:
       checks: write

--- a/.github/workflows/linux-daily-linux-next.yml
+++ b/.github/workflows/linux-daily-linux-next.yml
@@ -13,8 +13,13 @@ permissions: {}
 
 jobs:
   build:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     uses: ./.github/workflows/linux.yml
     permissions:
       checks: write

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -17,8 +17,13 @@ permissions: {}
 
 jobs:
   build:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     uses: ./.github/workflows/linux.yml
     permissions:
       checks: write

--- a/.github/workflows/linux-weekly-mainline.yml
+++ b/.github/workflows/linux-weekly-mainline.yml
@@ -14,8 +14,13 @@ permissions: {}
 
 jobs:
   build:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     uses: ./.github/workflows/linux.yml
     permissions:
       checks: write

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,8 +97,15 @@ concurrency:
 
 jobs:
   build-linux-deb:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so that
+    # changes to the workflows can be tested before they are merged. when this
+    # workflow is called by another one, the event and the ref are the
+    # caller's, so dispatching one of the calling workflows works too
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     permissions:
       contents: read # actions/checkout
     # for cross-builds

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -23,8 +23,13 @@ concurrency:
 
 jobs:
   build-u-boot-rb1:
-    # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
     permissions:
       contents: read # actions/checkout
     # for cross-builds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,41 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write well-formed commit messages for each change, following the [commit messages](#commit-messages) documentation below.
 - It's a good idea to arrange a discussion with other developers to ensure there is consensus on large features, architecture changes, and other core code changes. PR reviews will go much faster when there are no surprises.
 
+## Running the GitHub workflows
+
+Pull requests automatically run the `*-on-pr.yml` workflows.
+
+The remaining workflows - the daily and weekly builds - are ran only for the `main` branch, driven by `schedule` and by the completion of other workflows, so they are never ran for a pull request.
+
+To exercise them, run them manually against a branch pushed directly to this repository (branches from forks are not supported):
+
+```bash
+BRANCH=my-branch-name
+
+# run the workflows
+gh workflow run build-daily-debian.yml --ref "$BRANCH"
+gh workflow run build-daily.yml --ref "$BRANCH"
+gh workflow run linux-daily-arduino.yml --ref "$BRANCH"
+gh workflow run linux-daily-linux-next.yml --ref "$BRANCH"
+gh workflow run linux-daily-qcom-next.yml --ref "$BRANCH"
+gh workflow run linux-weekly-mainline.yml --ref "$BRANCH"
+gh workflow run u-boot.yml --ref "$BRANCH"
+
+# list the workflows ran on this branch
+gh run list --branch "$BRANCH"
+```
+
+They can also be run from the *Actions* tab on GitHub: pick the workflow, *Run workflow* and select the branch.
+
+A few things to keep in mind:
+
+- The branch has to be pushed to the `qualcomm-linux/qcom-deb-images` repository; branches on a fork cannot be used, as the workflows check that they are running from the main repository and the LAVA credentials are not available elsewhere.
+  This requires write access, so ask a maintainer to run the workflow for you if you are working from a fork.
+- The workflow file must already exist with a `workflow_dispatch:` trigger on `main`, but the version that runs is the one on the branch you select.
+  Changes to an existing workflow can be tested before they are merged but a brand new workflow cannot be run until it lands on `main`.
+- Changes to a `schedule:`, `push:` or `workflow_run:` trigger itself cannot be tested this way, as GitHub always reads those from `main`.
+- These builds use the self-hosted runners and the LAVA boards, which are shared and limited. A full run takes a while; avoid queueing more of them than you need.
+
 # Commit messages
 
 When writing commit messages, follow the [well-formed git commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) guide.


### PR DESCRIPTION
The daily and weekly workflows have a `workflow_dispatch` trigger, so can be manually ran, but have a guard on the main branch; so they cannot be manually ran on development branches. This means changes to the workflows cannot be tested before they are merged: currently, the only way to find out whether a workflow change works is to merge it and wait for the next cron run.

Remove the branch guard when the workflows are manually ran from the `workflow_dispatch` trigger to allow branches pushed to the upstream repo to be tested.

Also document how to run the workflows manually in CONTRIBUTING.md.

---

To verify this, I ran:
```
$ gh workflow run linux-daily-qcom-next.yml --ref wip/obbardc/dispatch-workflows-from-branch
✓ Created workflow_dispatch event for linux-daily-qcom-next.yml at wip/obbardc/dispatch-workflows-from-branch
```
which created [this workflow](https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/31603984133). I'd like to wait for this workflow to complete before merging.