### PR TITLE
feat(ci/lava): add qrb2210-arduino-imola

### DIFF
--- a/.github/workflows/build-daily-debian.yml
+++ b/.github/workflows/build-daily-debian.yml
@@ -70,11 +70,11 @@ jobs:
       suite: ${{ matrix.suite }}
       # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
       # glymur-crd can't boot the distro kernel, only qcom-next
-      # monaco-arduino-monza and monaco-evk only validated against the
-      # linux-next/qcom-next/arduino
+      # monaco-arduino-monza, monaco-evk and qrb2210-arduino-imola only
+      # validated against the linux-next/qcom-next/arduino
       # kernels so far, not the distro kernel; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      boards_exclude: '["glymur-crd", "lemans-evk", "monaco-arduino-monza", "monaco-evk", "qcs615-ride", "qcs8300-ride", "qrb2210-rb1"]'
+      boards_exclude: '["glymur-crd", "lemans-evk", "monaco-arduino-monza", "monaco-evk", "qcs615-ride", "qcs8300-ride", "qrb2210-arduino-imola", "qrb2210-rb1"]'
       # failures here are about upstream Debian, not about qcom-deb-images;
       # they are reported through this workflow instead of gating our work
       report_test_results_externally: false

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -77,4 +77,4 @@ jobs:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      boards_exclude: '["monaco-arduino-monza"]'
+      boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -39,4 +39,4 @@ jobs:
     with:
       url: ${{ needs.build-daily.outputs.artifacts_url }}
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      boards_exclude: '["monaco-arduino-monza"]'
+      boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'

--- a/.github/workflows/linux-daily-arduino.yml
+++ b/.github/workflows/linux-daily-arduino.yml
@@ -36,6 +36,6 @@ jobs:
       # workaround-initramfs-firmware-monaco adds firmware to initramfs; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/258
       debos_extra_args: '-t overlays:qsc-deb-releases,workaround-hexagon-dsp-binaries-monza,workaround-initramfs-firmware-monaco'
-      lava_boards_include: '["monaco-arduino-monza", "monaco-evk"]'
+      lava_boards_include: '["monaco-arduino-monza", "monaco-evk", "qrb2210-arduino-imola"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-daily-qcom-next.yml
+++ b/.github/workflows/linux-daily-qcom-next.yml
@@ -37,6 +37,6 @@ jobs:
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      lava_boards_exclude: '["monaco-arduino-monza"]'
+      lava_boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -77,7 +77,7 @@ jobs:
       # download patterns, so keep them in sync if this changes.
       suite: trixie
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      boards_exclude: '["monaco-arduino-monza"]'
+      boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/ci/lava/qrb2210-arduino-imola/boot.yaml
+++ b/ci/lava/qrb2210-arduino-imola/boot.yaml
@@ -1,0 +1,72 @@
+actions:
+- deploy:
+    rootfs_image: disk-sdcard.img2
+    qcomflash:
+      headers:
+        QLIAuthorization: Q_QLI_S3_TOKEN
+      url: "{{BUILD_DOWNLOAD_URL}}/{{SUITE}}-flash-emmc.tar.gz"
+      apply-overlay: true
+    timeout:
+      minutes: 20
+    to: qdl
+- boot:
+    firehose_program: prog_firehose_ddr.elf
+    rawprogram: rawprogram0.xml
+    patch: patch0.xml
+    path: flash_qrb2210-arduino-imola_emmc
+    storage: emmc
+    debug: true
+    timeout:
+      minutes: 15
+    method: qdl
+- command:
+    name: network_turn_on
+- boot:
+    auto_login:
+      login_prompt: 'login:'
+      username: debian
+      password_prompt: 'Password'
+      password: debian
+      login_commands:
+      - "debian"
+      - "new password"
+      - "new password"
+      - sudo su
+    method: minimal
+    prompts:
+    - root@debian
+    - debian@debian
+    - "Current password"
+    - "New password"
+    - "Retype new password"
+    timeout:
+      minutes: 3
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - from: git
+      name: "smoke-test"
+      path: automated/linux/smoke/smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        TESTS: "pwd, uname -a, ip a"
+    - from: git
+      name: "wlan-smoke-test"
+      path: automated/linux/wlan-smoke/wlan-smoke.yaml
+      repository: https://github.com/linaro/test-definitions.git
+      parameters:
+        SKIP_INSTALL: "True"
+        WAIT_TIME: 60
+context:
+  test_character_delay: 10
+device_type: qrb2210-arduino-imola
+job_name: smoke tests {{GITHUB_REPOSITORY}} {{GITHUB_RUN_ID}}-{{GITHUB_RUN_ATTEMPT}}
+metadata:
+  build-commit: '{{GITHUB_SHA}}'
+priority: 50
+timeouts:
+  job:
+    minutes: 210
+visibility: public


### PR DESCRIPTION
Add LAVA job template for qrb2210-arduino-imola (Arduino UNO Q), based
on the existing LAVA job template for qrb2210-rb1 as the devices are
similar.

----

To verify this change, I ran manual LAVA tests using manual runs of the workflows in this repo. Results:
- vanilla debian trixie (FAILED): https://lava.infra.foundries.io/scheduler/job/359253
- vanilla debian forky (FAILED): https://lava.infra.foundries.io/scheduler/job/359256
- qcom-next trixie (FAILED): https://lava.infra.foundries.io/scheduler/job/359270
- qcom-next forky (FAILED): https://lava.infra.foundries.io/scheduler/job/359269
- linux mainline trixie (PASSED): https://lava.infra.foundries.io/scheduler/job/359257
- linux-next trixie (PASSED): https://lava.infra.foundries.io/scheduler/job/359265
- arduino trixie (PASSED): https://lava.infra.foundries.io/scheduler/job/359306
