### PR TITLE
ci: drop duplicated workflow frequency

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -4,7 +4,7 @@
 #
 # This workflow tracks the state of upstream Debian on supported boards.
 
-name: Build (Vanilla Debian)
+name: Build Debian
 
 on:
   # run daily at 10:30am, last of the daily builds: this tracks upstream Debian

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -4,7 +4,7 @@
 #
 # This workflow tracks the state of upstream Debian on supported boards.
 
-name: Daily Build (Vanilla Debian)
+name: Build (Vanilla Debian)
 
 on:
   # run daily at 10:30am, last of the daily builds: this tracks upstream Debian
@@ -19,7 +19,7 @@ on:
 permissions: {}
 
 jobs:
-  build-daily-debian:
+  build-debian:
     # don't run cron from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
@@ -44,7 +44,7 @@ jobs:
       # which follows the bootstrap only ever pulls in packages from Debian
       debos_extra_args: -t qliaptrepo:false
 
-  test-daily-debian:
+  test-debian:
     # don't run cron from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
@@ -57,7 +57,7 @@ jobs:
       matrix:
         suite: [trixie, forky]
     uses: ./.github/workflows/lava-test.yml
-    needs: build-daily-debian
+    needs: build-debian
     permissions:
       checks: write
       contents: read
@@ -66,7 +66,7 @@ jobs:
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
-      url: ${{ needs.build-daily-debian.outputs.artifacts_url }}
+      url: ${{ needs.build-debian.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
       # qrb2210-rb1 testing is disabled until it can be resurrected; see #424
       # glymur-crd can't boot the distro kernel, only qcom-next

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       suite: ${{ matrix.suite }}
       # QLI targets qcom-next; consume the debs published to EFS by the
-      # "Daily qcom-next linux build" workflow rather than a kernel from an
+      # "qcom-next linux build" workflow rather than a kernel from an
       # APT repository
       kernelpackages: efs/qcom-next
   schema-check:

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 jobs:
-  build-daily:
+  build:
     strategy:
       fail-fast: false
       matrix:
@@ -19,7 +19,7 @@ jobs:
     with:
       suite: ${{ matrix.suite }}
       # QLI targets qcom-next; consume the debs published to EFS by the
-      # "Daily qcom-next linux build" workflow rather than a kernel from an
+      # "qcom-next linux build" workflow rather than a kernel from an
       # APT repository
       kernelpackages: efs/qcom-next
   schema-check:
@@ -28,7 +28,7 @@ jobs:
       contents: read
   test:
     uses: ./.github/workflows/lava-test.yml
-    needs: [build-daily, schema-check]
+    needs: [build, schema-check]
     permissions:
       checks: write
       contents: read
@@ -37,6 +37,6 @@ jobs:
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
-      url: ${{ needs.build-daily.outputs.artifacts_url }}
+      url: ${{ needs.build.outputs.artifacts_url }}
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
       boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 #
 # This workflow tracks the state of QLI Debian on supported boards.
 
-name: Daily Build
+name: Build
 
 # runs once the daily qcom-next kernel build is done, so that the images are
 # built from the debs it has just published to EFS; this also runs when that
@@ -20,7 +20,7 @@ name: Daily Build
 # route does not apply.
 on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
-    workflows: ["Daily qcom-next linux build"]
+    workflows: ["qcom-next linux build"]
     types:
       - completed
   # allow manual runs
@@ -30,7 +30,7 @@ on: # zizmor: ignore[dangerous-triggers]
 permissions: {}
 
 jobs:
-  build-daily:
+  build:
     # don't run from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
@@ -48,11 +48,11 @@ jobs:
     with:
       suite: ${{ matrix.suite }}
       # QLI targets qcom-next; consume the debs published to EFS by the
-      # "Daily qcom-next linux build" workflow rather than a kernel from an
+      # "qcom-next linux build" workflow rather than a kernel from an
       # APT repository
       kernelpackages: efs/qcom-next
 
-  test-daily:
+  test:
     # don't run from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
@@ -65,7 +65,7 @@ jobs:
       matrix:
         suite: [trixie, forky]
     uses: ./.github/workflows/lava-test.yml
-    needs: build-daily
+    needs: build
     permissions:
       checks: write
       contents: read
@@ -74,7 +74,7 @@ jobs:
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
-      url: ${{ needs.build-daily.outputs.artifacts_url }}
+      url: ${{ needs.build.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
       boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -98,7 +98,7 @@ jobs:
               mkdir -v local-apt-repo/kernel
               # get kernel from EFS; the directory is a symlink published by
               # the matching kernel workflow (linux.yml via e.g.
-              # linux-daily-qcom-next.yml), so report a missing or empty one
+              # linux-qcom-next.yml), so report a missing or empty one
               # rather than failing later with a confusing APT error
               efs_kernel_dir="/efs/${KERNEL_PACKAGES#efs/}"
               if [ ! -d "$efs_kernel_dir" ]; then

--- a/.github/workflows/linux-arduino.yml
+++ b/.github/workflows/linux-arduino.yml
@@ -1,8 +1,8 @@
-name: Daily arduino linux build
+name: arduino linux build
 
 on:
-  # run daily at 6:30am, once the qcom-next build (2:30am) and the "Daily Build"
-  # chained onto it have submitted their LAVA jobs
+  # run daily at 6:30am, once the qcom-next build (2:30am) and the "Build"
+  # workflow chained onto it have submitted their LAVA jobs
   schedule:
     - cron: '30 6 * * *'
   # allow manual runs

--- a/.github/workflows/linux-mainline.yml
+++ b/.github/workflows/linux-mainline.yml
@@ -1,10 +1,11 @@
-name: Daily linux-next linux build
+name: mainline linux build
 
 on:
-  # run daily at 8:30am, two hours behind the arduino kernel build, so that our
-  # LAVA jobs don't queue up behind its own
+  # run weekly on Monday at 2:30pm, after the daily builds and the weekly u-boot
+  # build have finished for the day, so this doesn't add its LAVA jobs on top of
+  # theirs
   schedule:
-    - cron: '30 8 * * *'
+    - cron: '30 14 * * 1'
   # allow manual runs
   workflow_dispatch:
 
@@ -27,11 +28,13 @@ jobs:
       packages: read
       pull-requests: write
     with:
-      kernel_name: linux-next
-      build_linux_deb_extra_args: '--linux-next'
+      kernel_name: mainline
       # reference build: we want the debs and the LAVA results to compare
       # against, but its failures must not gate qcom-deb-images work
       lava_report_test_results_externally: false
-      lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      # monaco-evk only validated against the linux-next/qcom-next/arduino
+      # kernels so far; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
+      lava_boards_exclude: '["glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-next.yml
+++ b/.github/workflows/linux-next.yml
@@ -1,11 +1,10 @@
-name: Weekly mainline linux build
+name: linux-next linux build
 
 on:
-  # run weekly on Monday at 2:30pm, after the daily builds and the weekly u-boot
-  # build have finished for the day, so this doesn't add its LAVA jobs on top of
-  # theirs
+  # run daily at 8:30am, two hours behind the arduino kernel build, so that our
+  # LAVA jobs don't queue up behind its own
   schedule:
-    - cron: '30 14 * * 1'
+    - cron: '30 8 * * *'
   # allow manual runs
   workflow_dispatch:
 
@@ -28,13 +27,11 @@ jobs:
       packages: read
       pull-requests: write
     with:
-      kernel_name: mainline
+      kernel_name: linux-next
+      build_linux_deb_extra_args: '--linux-next'
       # reference build: we want the debs and the LAVA results to compare
       # against, but its failures must not gate qcom-deb-images work
       lava_report_test_results_externally: false
-      # monaco-evk only validated against the linux-next/qcom-next/arduino
-      # kernels so far; see
-      # https://github.com/qualcomm-linux/qcom-deb-images/issues/440
-      lava_boards_exclude: '["glymur-crd", "monaco-evk", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
+      lava_boards_exclude: '["glymur-crd", "qcs615-ride", "qcs8300-ride", "lemans-evk"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-qcom-next.yml
+++ b/.github/workflows/linux-qcom-next.yml
@@ -1,12 +1,12 @@
-name: Daily qcom-next linux build
+name: qcom-next linux build
 
 on:
   # run daily at 2:30am. qcom-next is what QLI ships, so it goes first of the
   # scheduled builds and gets an empty LAVA queue; the rest of the day's builds
   # are staggered behind it (arduino 6:30am, linux-next 8:30am, vanilla Debian
-  # images 10:30am) so that they don't all submit LAVA jobs at once. The "Daily
-  # Build" workflow chains onto this one, so its LAVA jobs land later still,
-  # around 5:30am.
+  # images 10:30am) so that they don't all submit LAVA jobs at once. The "Build"
+  # workflow chains onto this one, so its LAVA jobs land later still, around
+  # 5:30am.
   schedule:
     - cron: '30 2 * * *'
   # allow manual runs
@@ -33,7 +33,7 @@ jobs:
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc5-20260812 prune.config qcom.config'
-      # stop after publishing the debs to EFS; the "Daily Build" workflow
+      # stop after publishing the debs to EFS; the "Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,12 +74,12 @@ To exercise them, run them manually against a branch pushed directly to this rep
 BRANCH=my-branch-name
 
 # run the workflows
-gh workflow run build-daily-debian.yml --ref "$BRANCH"
-gh workflow run build-daily.yml --ref "$BRANCH"
-gh workflow run linux-daily-arduino.yml --ref "$BRANCH"
-gh workflow run linux-daily-linux-next.yml --ref "$BRANCH"
-gh workflow run linux-daily-qcom-next.yml --ref "$BRANCH"
-gh workflow run linux-weekly-mainline.yml --ref "$BRANCH"
+gh workflow run build-debian.yml --ref "$BRANCH"
+gh workflow run build.yml --ref "$BRANCH"
+gh workflow run linux-arduino.yml --ref "$BRANCH"
+gh workflow run linux-next.yml --ref "$BRANCH"
+gh workflow run linux-qcom-next.yml --ref "$BRANCH"
+gh workflow run linux-mainline.yml --ref "$BRANCH"
 gh workflow run u-boot.yml --ref "$BRANCH"
 
 # list the workflows ran on this branch

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tuned!
 | Variant | Kernel build | Image build & boot test |
 | ------- | --- | --- |
 | Qualcomm Linux | [![qcom-next kernel][qcom-next-badge]][qcom-next] | [![images][images-badge]][images] |
-| Debian | *uses kernel from Debian Archive* | [![Vanilla Debian images][debian-images-badge]][debian-images] |
+| Debian | *uses kernel from Debian Archive* | [![Debian images][debian-images-badge]][debian-images] |
 | Reference upstream kernels | [![linux-next][linux-next-badge]][linux-next] [![mainline][mainline-badge]][mainline] | *covered by the kernel build* [^1] |
 | Project-specific builds | [![arduino][arduino-badge]][arduino] | *covered by the kernel build* [^1] |
 
@@ -385,7 +385,7 @@ This project is licensed under the [BSD-3-clause License](https://spdx.org/licen
 [images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build.yml
 [images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build.yml?label=images
 [debian-images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-debian.yml
-[debian-images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-debian.yml?label=Vanilla%20Debian%20images
+[debian-images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-debian.yml?label=Debian%20images
 [linux-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-next.yml
 [linux-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-next.yml?label=linux-next
 [mainline]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-mainline.yml

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ tuned!
 
 | Variant | Kernel build | Image build & boot test |
 | ------- | --- | --- |
-| Qualcomm Linux | [![qcom-next kernel, daily][qcom-next-badge]][qcom-next] | [![images, daily][images-badge]][images] |
-| Debian | *uses kernel from Debian Archive* | [![Vanilla Debian images, daily][debian-images-badge]][debian-images] |
-| Reference upstream kernels | [![linux-next, daily][linux-next-badge]][linux-next] [![mainline, weekly][mainline-badge]][mainline] | *covered by the kernel build* [^1] |
-| Project-specific builds | [![arduino, daily][arduino-badge]][arduino] | *covered by the kernel build* [^1] |
+| Qualcomm Linux | [![qcom-next kernel][qcom-next-badge]][qcom-next] | [![images][images-badge]][images] |
+| Debian | *uses kernel from Debian Archive* | [![Vanilla Debian images][debian-images-badge]][debian-images] |
+| Reference upstream kernels | [![linux-next][linux-next-badge]][linux-next] [![mainline][mainline-badge]][mainline] | *covered by the kernel build* [^1] |
+| Project-specific builds | [![arduino][arduino-badge]][arduino] | *covered by the kernel build* [^1] |
 
 [^1]: these builds compile the kernel, build an image and boot test the image in a single workflow, so the Kernel build reports all three.
 
@@ -380,15 +380,15 @@ This project is licensed under the [BSD-3-clause License](https://spdx.org/licen
 <!-- link targets for the CI status badges at the top of this file; each
      workflow needs two: the shields.io image and the Actions page it links to -->
 
-[qcom-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-qcom-next.yml
-[qcom-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-qcom-next.yml?label=qcom-next%20daily
-[images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-daily.yml
-[images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-daily.yml?label=images%20daily
-[debian-images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-daily-debian.yml
-[debian-images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-daily-debian.yml?label=Vanilla%20Debian%20images%20daily
-[linux-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-linux-next.yml
-[linux-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-linux-next.yml?label=linux-next%20daily
-[mainline]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-weekly-mainline.yml
-[mainline-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-weekly-mainline.yml?label=mainline%20weekly
-[arduino]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-daily-arduino.yml
-[arduino-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-daily-arduino.yml?label=arduino%20daily
+[qcom-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-qcom-next.yml
+[qcom-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-qcom-next.yml?label=qcom-next
+[images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build.yml
+[images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build.yml?label=images
+[debian-images]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/build-debian.yml
+[debian-images-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/build-debian.yml?label=Vanilla%20Debian%20images
+[linux-next]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-next.yml
+[linux-next-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-next.yml?label=linux-next
+[mainline]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-mainline.yml
+[mainline-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-mainline.yml?label=mainline
+[arduino]: https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-arduino.yml
+[arduino-badge]: https://img.shields.io/github/actions/workflow/status/qualcomm-linux/qcom-deb-images/linux-arduino.yml?label=arduino


### PR DESCRIPTION
 The scheduled workflows carry the job cadence in both the filenames
and workflow/job names, for instance: `linux-weekly-mainline.yml` and
`Weekly mainline linux build`. The schedule is set by the cron
expression in the workflow, so keeping the schedule information in
multiple places is just repeating ourselves.

Instead, rename the workflow files after what they build/test and
remove the duplicated schedule information across the repository.