### PR TITLE
ci(lava): drop unused overlay_path from boot templates

### DIFF
--- a/ci/lava/glymur-crd/boot.yaml
+++ b/ci/lava/glymur-crd/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-sdcard.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/lemans-evk/boot.yaml
+++ b/ci/lava/lemans-evk/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-ufs.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/monaco-arduino-monza/boot.yaml
+++ b/ci/lava/monaco-arduino-monza/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-sdcard.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/monaco-evk/boot.yaml
+++ b/ci/lava/monaco-evk/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-ufs.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/qcs615-ride/boot.yaml
+++ b/ci/lava/qcs615-ride/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-ufs.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-vision-kit/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-ufs.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/qcs8300-ride/boot.yaml
+++ b/ci/lava/qcs8300-ride/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-ufs.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN

--- a/ci/lava/qrb2210-rb1/boot.yaml
+++ b/ci/lava/qrb2210-rb1/boot.yaml
@@ -1,7 +1,6 @@
 actions:
 - deploy:
     rootfs_image: disk-sdcard.img2
-    overlay_path: /
     qcomflash:
       headers:
         Authorization: Q_S3_TOKEN


### PR DESCRIPTION
The `overlay_path` key was removed from the LAVA qdl deploy action in
LAVA commit d440bb9263405a4fec336aa5e9e6941b7b9c42cc ("lava_dispatcher:
remove overlay_path from qdl deployment"), released in LAVA 2026.07.

Since that release, LAVA throws a warning for jobs which still set it:

    Invalid job definition:
    extra keys not allowed @ data['actions[0]']['deploy']['qdl']['overlay_path']

Remove it from all the board boot templates.

Signed-off-by: Christopher Obbard <chris.obbard@oss.qualcomm.com>
