### PR TITLE
ci(qcom-next): build with the qcom_debug.config fragment

### DIFF
--- a/.github/workflows/linux-qcom-next.yml
+++ b/.github/workflows/linux-qcom-next.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     with:
       kernel_name: qcom-next
-      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc5-20260812 prune.config qcom.config'
+      build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc5-20260812 prune.config qcom.config qcom_debug.config'
       # stop after publishing the debs to EFS; the "Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true


### PR DESCRIPTION
Stability issues can be hard to triage with the kernel we currently ship: neither the DCC (Data Capture and Compare) nor the memory dump drivers are enabled so there is little to inspect after a hang or a crash.

The kernel tree already collects the relevant options in the qcom_debug.config fragment:

    CONFIG_QCOM_DCC=y
    CONFIG_QCOM_DCC_DEV=y
    CONFIG_QCOM_MEMORY_DUMP_V2=y
    CONFIG_QCOM_MEMORY_DUMP_DEV=y

Merge that fragment on top of qcom.config when building the qcom-next kernel so those drivers are available at runtime.

Note this applies to all images built from the qcom-next kernel. We ship the qcom-next kernel in all of our images, so carrying the debug drivers there is a bit awkward.

Long term these drivers should be restricted to a separate debug build and should probably move to a separate debugging image variant instead.

Closes: #568

---

Leaving as a draft until we decide that the `qcom_debug.conf` options can be shipped.
Also, seems like we cannot test the kernel change from this PR - our workflow isn't sophisticated enough to do that...