### PR TITLE
fix: remove U-Boot requirement for RB1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,6 @@ version 2.1 as it contains important fixes.
 
 ## Steps
 
-### (optional) Build and flash U-Boot
-
-U-Boot is needed for the RB1 board. If you are not targeting this board, you
-can go to the next section.
-
-Building U-Boot for the RB1 requires the following extra build-dependencies:
-
-```bash
-apt -y install git crossbuild-essential-arm64 make bison flex bc libssl-dev gnutls-dev xxd coreutils gzip mkbootimg
-```
-
-To build U-Boot for the RB1, run:
-
-```bash
-scripts/build-u-boot-rb1.sh
-```
-
 ### (optional) Build custom kernel
 
 By default the image recipes will install the kernel provided by Debian.
@@ -104,9 +87,6 @@ To build flashable assets for all supported boards, follow these steps:
 1. build flashable assets from downloaded boot binaries, the DTBs, and pointing at the UFS/SD card disk images
     ```bash
     make flash
-
-    # (optional) if you've built U-Boot for the RB1, run this instead:
-    #EXTRA_DEBOS_OPTS="-t u_boot_rb1:u-boot/rb1-boot.img" make flash
 
     # (optional) build only a subset of boards:
     #EXTRA_DEBOS_OPTS="-t target_boards:qcs615-ride,qcs6490-rb3gen2-vision-kit" make flash
@@ -169,8 +149,6 @@ For the image recipe:
 
 For the flash recipe:
 
-- `u_boot_rb1`: prebuilt U-Boot binary for RB1 in Android boot image format --
-  see below (NB: debos expects relative pathnames)
 - `target_boards`: comma-separated list of board names to build (default:
   `all`). Accepted values are the board names defined in the flash recipe, e.g.
   `qcs615-ride`, `qcs6490-rb3gen2-vision-kit`, `qcs8300-ride`,
@@ -179,7 +157,7 @@ For the flash recipe:
 Note: Boards whose required device tree (.dtb) is not present in `dtbs.tar.gz` are automatically skipped during flash asset generation.
 
 Deprecated flash options:
-- `build_qcs615`, `build_qcm6490`, `build_qcs8300`, `build_qcs9100`, `build_rb1`: these per-family/per-board toggles are deprecated and will be removed. Use `target_boards` instead to select which boards to build.
+- `build_qcs615`, `build_qcm6490`, `build_qcs8300`, `build_qcs9100`, `build_rb1`, `u_boot_rb1`: these per-family/per-board toggles are deprecated and will be removed. Use `target_boards` instead to select which boards to build.
 
 Here are some example invocations:
 

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -2,10 +2,6 @@
 {{- $build_qcm6490 := or .build_qcm6490 "true" }}
 {{- $build_qcs8300 := or .build_qcs8300 "true" }}
 {{- $build_qcs9100 := or .build_qcs9100 "true" }}
-{{- $build_rb1 := "false" -}}
-{{- if .u_boot_rb1 -}}
-{{- $build_rb1 = "true" }}
-{{- end -}}
 {{- $buildid := or .buildid "" }}
 
 {{- $target_boards := or .target_boards "all" }}
@@ -378,7 +374,6 @@ actions:
     "dtb" "qcom/lemans-evk.dtb"
 )}}
 {{- end }}
-{{- if eq $build_rb1 "true" }}
 {{- $boards = append $boards (dict
     "name" "qrb2210-rb1"
     "soc_id" "qcm2290"
@@ -390,10 +385,8 @@ actions:
         "filename" "qrb2210-rb1_rescue-image.zip"
         "sha256sum" "c75b6c63eb24c8ca36dad08ba4d4e93f3f4cd7dce60cf1b6dfb5790dc181cc3d"
     )
-    "u_boot_file" .u_boot_rb1
     "dtb" "qcom/qrb2210-rb1.dtb"
 )}}
-{{- end }}
 {{- $boards = append $boards (dict
     "name" "qrb2210-arduino-imola"
     "soc_id" "qcm2290"


### PR DESCRIPTION
RB1 is the only board which needed U-Boot to boot: it is appended to the board list solely when a prebuilt U-Boot image was passed in with `-t u_boot_rb1:<path>`, which in turn requires building U-Boot out of tree via scripts/build-u-boot-rb1.sh.

The stock EFI boot flow appears to work on this board now, so U-Boot is no longer needed. Drop the `u_boot_rb1` gate and build RB1 flash assets unconditionally; like every other board.

Update the README accordingly and remove U-Boot from everywhere else.

Fixes: #572

---
TODO:
- need to make sure it ACTUALLY boots fine without U-Boot (Arduino does). I suspect we need to use firmware from Arduino, maybe?
- remove RB1 U-Boot bits from other places in repo.

Verification:
- [mainline](https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/31822898165) - IN PROGRESS
- [linux-next](https://github.com/qualcomm-linux/qcom-deb-images/actions/workflows/linux-next.yml) - IN PROGRESS