### PR TITLE
ci: build qcom-next two hours earlier

### DIFF
--- a/.github/workflows/efs-maintenance.yml
+++ b/.github/workflows/efs-maintenance.yml
@@ -24,11 +24,11 @@
 name: EFS Maintenance
 
 on:
-  # run every Monday at 00:30am UTC, before the other workflows: the earliest of
-  # those is the daily qcom-next kernel build at 2:30am, and pruning artifacts
+  # run every Sunday at 10:30pm UTC, before the other workflows: the earliest of
+  # those is the daily qcom-next kernel build at 0:30am, and pruning artifacts
   # while a build is publishing to EFS is best avoided
   schedule:
-    - cron: '30 0 * * 1'
+    - cron: '30 22 * * 0'
   workflow_dispatch:
     inputs:
       create_new_location:

--- a/.github/workflows/linux-arduino.yml
+++ b/.github/workflows/linux-arduino.yml
@@ -1,7 +1,7 @@
 name: arduino linux build
 
 on:
-  # run daily at 6:30am, once the qcom-next build (2:30am) and the "Build"
+  # run daily at 6:30am, once the qcom-next build (0:30am) and the "Build"
   # workflow chained onto it have submitted their LAVA jobs
   schedule:
     - cron: '30 6 * * *'

--- a/.github/workflows/linux-qcom-next.yml
+++ b/.github/workflows/linux-qcom-next.yml
@@ -1,14 +1,18 @@
 name: qcom-next linux build
 
 on:
-  # run daily at 2:30am. qcom-next is what QLI ships, so it goes first of the
+  # run daily at 0:30am. qcom-next is what QLI ships, so it goes first of the
   # scheduled builds and gets an empty LAVA queue; the rest of the day's builds
   # are staggered behind it (arduino 6:30am, linux-next 8:30am, vanilla Debian
   # images 10:30am) so that they don't all submit LAVA jobs at once. The "Build"
   # workflow chains onto this one, so its LAVA jobs land later still, around
-  # 5:30am.
+  # 3:30am.
+  #
+  # the images the "Build" workflow produces are shared with the test teams and
+  # are expected by 8:00am IST (2:30am UTC); building from 0:30am leaves an hour
+  # of headroom, see issue #566.
   schedule:
-    - cron: '30 2 * * *'
+    - cron: '30 0 * * *'
   # allow manual runs
   workflow_dispatch:
 


### PR DESCRIPTION
The images built by the "Build" workflow, which chains onto the daily qcom-next kernel build, are shared with the test teams and are expected by 8:00am IST (2:30am UTC). Starting the kernel build at 2:30am UTC means the images only land around 3:30am UTC (9:00am IST): an hour late.

Move the qcom-next cron back two hours to 0:30am UTC so the images are ready around 1:30am UTC (7:00am IST) with an hour of headroom. The rest of the daily builds keep their slots and are still staggered behind it, so the LAVA queue is unaffected.

The weekly EFS maintenance ran on Monday at 0:30am UTC and would now collide with the kernel build; move it two hours earlier as well, to Sunday at 10:30pm UTC, keeping it ahead of every build that publishes to EFS.

Closes: #566