### PR TITLE
ci: only publish EFS latest symlinks when building main branch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -168,7 +168,7 @@ jobs:
           export BUILD_DIR="/efs/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
           cp -av artifacts/* "${BUILD_DIR}"
-          # perhaps help NFS sync
+          # flush artifacts to NFS
           sync
 
       # only publish EFS symlink to the latest build artifacts if building the
@@ -179,7 +179,7 @@ jobs:
           set -ux
           # create or update symlink
           ln -fnsv "${BUILD_ID}" "/efs/${KERNEL_NAME}"
-          # perhaps help NFS sync
+          # flush the symlink to NFS
           sync
 
       - name: Upload private artifacts

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -168,6 +168,15 @@ jobs:
           export BUILD_DIR="/efs/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
           cp -av artifacts/* "${BUILD_DIR}"
+          # perhaps help NFS sync
+          sync
+
+      # only publish EFS symlink to the latest build artifacts if building the
+      # main branch
+      - name: Publish EFS symlink
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -ux
           # create or update symlink
           ln -fnsv "${BUILD_ID}" "/efs/${KERNEL_NAME}"
           # perhaps help NFS sync

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -83,7 +83,7 @@ jobs:
           export BUILD_DIR="/efs/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
           cp -av artifacts/* "${BUILD_DIR}"
-          # perhaps help NFS sync
+          # flush artifacts to NFS
           sync
 
       # only publish EFS symlink to the latest build artifacts if building the
@@ -94,7 +94,7 @@ jobs:
           set -ux
           # create or update u-boot-rb1-latest symlink
           ln -fnsv "${BUILD_ID}" /efs/u-boot-rb1-latest
-          # perhaps help NFS sync
+          # flush the symlink to NFS
           sync
 
       - name: Upload private artifacts

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -83,6 +83,15 @@ jobs:
           export BUILD_DIR="/efs/${BUILD_ID}"
           mkdir -vp "${BUILD_DIR}"
           cp -av artifacts/* "${BUILD_DIR}"
+          # perhaps help NFS sync
+          sync
+
+      # only publish EFS symlink to the latest build artifacts if building the
+      # main branch
+      - name: Publish EFS symlink
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -ux
           # create or update u-boot-rb1-latest symlink
           ln -fnsv "${BUILD_ID}" /efs/u-boot-rb1-latest
           # perhaps help NFS sync


### PR DESCRIPTION
Both the kernel and the U-Boot workflows allow manual runs with `workflow_dispatch` from any branch of the main repository, so that workflow changes can be tested before they are merged. Those runs were also updating the EFS symlinks `/efs/${KERNEL_NAME}` and `/efs/u-boot-rb1-latest` to their build, which every consumer workflow resolves to pick up the latest artifacts.

A WIP branch build therefore can silently repoint the latest artifacts at its own artifacts, which could cause changes which are not ready to leak into stable image builds.

Move the symlink update into its own step guarded on the main branch. Branch builds still publish to /efs/${BUILD_ID} and still upload private artifacts, they just no longer update the latest symlinks.