### PR TITLE
ci: build images from an APT snapshot in the daily build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,52 @@ jobs:
       # APT repository
       kernelpackages: efs/qcom-next
 
+  # snapshot builds pin the APT sources to a dated archive (see
+  # docs/snapshot.md); they have their own code paths in the rootfs and image
+  # recipes which nothing else exercises, so build an image with them every
+  # day. it runs here rather than on pull requests because it is a full image
+  # build and snapshot.debian.org is slower and more rate-limited than the
+  # regular mirrors.
+  #
+  # this only ever answers "do the snapshot code paths still work?": the images
+  # are not published and no LAVA job boots them, the build going green and the
+  # QEMU tests ran by debos.yml are the coverage we're after. the default
+  # variant is enough, as the snapshot code paths don't depend on it.
+  build-snapshot:
+    # don't run from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [trixie, forky]
+    uses: ./.github/workflows/debos.yml
+    permissions:
+      contents: read
+    with:
+      suite: ${{ matrix.suite }}
+      # both the rootfs and the image recipe re-pin their own APT sources, and
+      # debos_extra_args is passed to both.
+      #
+      # any well-formed timestamp resolves to the publication which was live at
+      # that moment, so this is a fixed date rather than something computed: it
+      # keeps the build reproducible and makes a failure a change in our
+      # recipes rather than a change in the archives. bump it when it gets old
+      # enough that the archives no longer serve it well.
+      debos_extra_args: -t snapshot:20260810T082104Z
+      # nothing consumes these images, so don't spend the time compressing
+      # them nor the storage keeping them around
+      upload_artifacts: false
+      # QLI targets qcom-next; consume the debs published to EFS by the
+      # "qcom-next linux build" workflow rather than a kernel from an
+      # APT repository. note that a local kernel is not covered by the
+      # snapshot, see docs/snapshot.md
+      kernelpackages: efs/qcom-next
+
   test:
     # don't run from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -31,6 +31,17 @@ on:
           other. Empty or "default" builds the default image.
         type: string
         default: ''
+      upload_artifacts:
+        description: >
+          Upload the built artifacts to the S3 artifact store. Set to
+          false for builds which are only ran to exercise the recipes and
+          whose output nothing downloads or tests: compressing the images is
+          then skipped as well, the artifacts_url output is empty, so
+          such a build cannot be chained to lava-test.yml. The images are
+          still built and the SBOM and vulnerability reports still generated
+          and summarised in the job summary.
+        type: boolean
+        default: true
       # useful if for some reason the kernel/image can't start in QEMU
       skip_qemu_tests:
         description: Skip QEMU tests
@@ -39,7 +50,9 @@ on:
 
     outputs:
       artifacts_url:
-        description: "URL to retrieve build artifacts"
+        description: >
+          URL to retrieve build artifacts; empty when upload_artifacts is
+          false
         value: ${{ jobs.build-debos.outputs.url }}
 
 # grant nothing by default; every job below declares the scopes it needs. these
@@ -218,6 +231,7 @@ jobs:
           make flash FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="-t u_boot_rb1:rb1-boot.img -t buildid:${BUILD_ID} --print-recipe ${DEBOS_EXTRA_ARGS} ${DEBOS_VARIANT_ARGS}"
 
       - name: Stage debos artifacts for publishing
+        if: ${{ inputs.upload_artifacts }}
         run: |
           set -ux
           # create a directory for the current run
@@ -241,6 +255,7 @@ jobs:
 
       # upload to a cloud storage space accessible by Axiom
       - name: Upload private artifacts (S3)
+        if: ${{ inputs.upload_artifacts }}
         uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         id: upload_artifacts_s3
         with:
@@ -339,6 +354,7 @@ jobs:
           cat rootfs-vulns.grype.txt
 
       - name: Stage SBOMs and Vulnerability report for publishing
+        if: ${{ inputs.upload_artifacts }}
         run: |
           set -ux
           dir="sboms"
@@ -348,6 +364,7 @@ jobs:
           done
 
       - name: Upload SBOMs as private artifacts
+        if: ${{ inputs.upload_artifacts }}
         uses: qualcomm-linux/upload-private-artifact-action@4940e9327cd7386acdb908b61c714c079b7d754b # aws-v4
         id: upload_sbom_artifacts
         with:
@@ -360,16 +377,24 @@ jobs:
         env:
           build_url: ${{ steps.upload_artifacts_s3.outputs.url }}
         run: |
-          echo "Downloads URL: ${build_url}"
-          echo "url=\"${build_url}\"" >> $GITHUB_OUTPUT
-          echo "${build_url}" > build_url
-          echo "## Download URL" >> $GITHUB_STEP_SUMMARY
-          echo "[${build_url}](${build_url})" >> $GITHUB_STEP_SUMMARY
+          # empty when the artifacts were not uploaded (upload_artifacts: false)
+          if [ -n "${build_url}" ]; then
+              echo "Downloads URL: ${build_url}"
+              echo "url=\"${build_url}\"" >> $GITHUB_OUTPUT
+              echo "${build_url}" > build_url
+              echo "## Download URL" >> $GITHUB_STEP_SUMMARY
+              echo "[${build_url}](${build_url})" >> $GITHUB_STEP_SUMMARY
+          else
+              echo "artifacts were not uploaded"
+              echo "## Artifacts were not uploaded" >> $GITHUB_STEP_SUMMARY
+          fi
           # append the Grype summary after the download link, so the link stays
           # at the top of the job summary
           scripts/grype-vulnerability-summary.py rootfs-vulns.grype.json \
               >> $GITHUB_STEP_SUMMARY
       - name: Upload build URL
+        # there is no URL to publish when nothing was uploaded
+        if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build_url

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -256,6 +256,29 @@ After a snapshot build, the final image:
 In other words, the snapshot pins *what gets installed during the build*, then
 gets out of the way so the running system tracks live updates.
 
+## CI coverage
+
+The `build.yml` workflow builds snapshot images (`build-snapshot` job) for
+both `trixie` and `forky`. The timestamp is passed to the `debos.yml` workflow
+as `debos_extra_args: -t snapshot:<timestamp>`, which that workflow hands to
+both the rootfs and the image recipe. Pull requests do not build them — these
+are full image builds and snapshot.debian.org is slower and more rate-limited
+than the regular mirrors.
+
+The job only answers "do the snapshot code paths still work?": it passes
+`upload_artifacts: false`, so the images are neither compressed nor published,
+and no LAVA job boots them. The build going green and the QEMU tests which
+`debos.yml` runs are the coverage. Note that a build which silently fell back to
+the live mirrors would also go green; check `/etc/buildinfo` in the built rootfs
+as described in [Verifying a build](#verifying-a-build) when in doubt.
+
+The timestamp is hardcoded rather than computed. Any well-formed timestamp
+resolves to the publication which was live at that moment (see [Archive-side
+model](#archive-side-model)), so a fixed date keeps the build reproducible and
+makes a failure point at a change in our recipes rather than at a change in the
+archives. Bump it when it gets old enough that the archives no longer serve it
+well.
+
 ## Design notes and caveats
 
 - **The bootstrap resolves on the build host, not in the chroot.** Unlike the
@@ -293,4 +316,5 @@ gets out of the way so the running system tracks live updates.
   validation/recording, `snapshot_*.sources` derivation, live-mirror restore.
 - `debos-recipes/qualcomm-linux-debian-image.yaml` — re-enable snapshot for the
   image's extra package installs, then clean up.
+- `.github/workflows/build.yml` — the `build-snapshot` job.
 - `README.md` — the user-facing summary of the `snapshot` recipe option.


### PR DESCRIPTION
Build the trixie and forky images from a snapshot every day, pinned to
a fixed timestamp.

This runs in the daily build rather than on pull requests because these
are full image builds and snapshot.debian.org is slower and more
rate-limited than the regular mirrors.

The images are only built to exercise the snapshot code paths: they are
not uploaded and no LAVA job boots them. The build going green and the
QEMU tests ran by the debos workflow are the coverage this is after.

The timestamp is hardcoded rather than computed: any well-formed
timestamp resolves to the publication which was live at that moment, so
a fixed date keeps the build reproducible and makes a failure point at
a change in our recipes rather than at a change in the archives.

Fixes: #564

## Verification

See 