### PR TITLE
ci: build & test images using an APT snapshot

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -24,6 +24,8 @@ on:
           date of the commit being built.
         type: string
         default: ''
+  # WIP: Temporarily allow on branch pushes.
+  push:
 
 # grant nothing by default; every job below declares the scopes it needs
 permissions: {}
@@ -50,10 +52,10 @@ jobs:
     # don't run cron from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
-    if: >-
-      github.repository == 'qualcomm-linux/qcom-deb-images' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/main')
+    #if: >-
+    #  github.repository == 'qualcomm-linux/qcom-deb-images' &&
+    #  (github.event_name == 'workflow_dispatch' ||
+    #  github.ref == 'refs/heads/main')
     name: Determine the snapshot timestamp
     runs-on: ubuntu-latest
     permissions:
@@ -100,10 +102,10 @@ jobs:
     # don't run cron from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
-    if: >-
-      github.repository == 'qualcomm-linux/qcom-deb-images' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/main')
+    #if: >-
+    #  github.repository == 'qualcomm-linux/qcom-deb-images' &&
+    #  (github.event_name == 'workflow_dispatch' ||
+    #  github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -123,3 +123,9 @@ jobs:
       kernelpackages: efs/qcom-next
       # the default variant is enough: the snapshot code paths don't depend on
       # which variant is built
+      #
+      # the QEMU tests debos.yml runs are the same for every image; telling
+      # them the timestamp this build was pinned to is what turns their
+      # snapshot checks from "no snapshot was used" into "this exact snapshot
+      # was". they run in the build job, against the image still on that runner
+      qemu_test_env: EXPECTED_SNAPSHOT=${{ needs.snapshot-date.outputs.snapshot }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,0 +1,125 @@
+# Builds QLI Debian images from a dated APT snapshot with APT sources pinned to
+# snapshot.debian.org and the Qualcomm Linux archive (see docs/snapshot.md).
+#
+# The snapshot timestamp is derived from the HEAD commit's timestamp and can be
+# manually set when manually triggering the workflow.
+
+name: Build snapshot
+
+on:
+  # Weekly rather than daily and never on pull requests. These are full image
+  # builds and snapshot.debian.org is slower and more rate-limited than the
+  # regular mirrors. Run the job on Saturday when the daily builds are not
+  # competing for the builder runners.
+  schedule:
+    - cron: '30 3 * * 6'
+  # Allow manual runs; optionally accept a snapshot timestamp to build against
+  # rather than deriving it from the last commit timestamp.
+  workflow_dispatch:
+    inputs:
+      snapshot:
+        description: >
+          APT snapshot timestamp to pin this build to, as YYYYMMDDTHHMMSSZ
+          (e.g. 20260115T000000Z). Leave empty to derive it from the committer
+          date of the commit being built.
+        type: string
+        default: ''
+
+# grant nothing by default; every job below declares the scopes it needs
+permissions: {}
+
+jobs:
+  # Determine the snapshot timestamp, in the YYYYMMDDTHHMMSSZ form APT
+  # requires from the input specified from a manual workflow run or derive the
+  # timestamp from the date of the last git commit.
+  #
+  # Any well-formed timestamp resolves to the publication which was live at
+  # that moment, so the value only has to be a date the archives still serve,
+  # not one tied to a specific publication. The commit date of the tree being
+  # built is such a date and needs no maintenance: it moves forward on its own
+  # as the repository is worked on and two runs of the same commit still pin
+  # the same publication.
+  #
+  # This job cannot be folded into the `build-snapshot` job as that job calls a
+  # reusable workflow with `uses:` and such a job may not also have `steps:` so
+  # there is nowhere to run git.
+  # The value cannot be built inline in its `with:` as expressions have no date
+  # formatting so YYYYMMDDTHHMMSSZ cannot be derived from something like
+  # `github.event.repository.pushed_at`.
+  snapshot-date:
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
+    name: Determine the snapshot timestamp
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout
+    outputs:
+      snapshot: ${{ steps.snapshot.outputs.snapshot }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Determine the snapshot timestamp
+        id: snapshot
+        env:
+          INPUT_SNAPSHOT: ${{ inputs.snapshot }}
+        run: |
+          set -u
+          snapshot="${INPUT_SNAPSHOT:-}"
+          if [ -n "$snapshot" ]; then
+              origin="the workflow_dispatch input"
+          else
+              # committer date of HEAD; format-local: honours TZ, hence TZ=UTC
+              snapshot="$(TZ=UTC git log -1 --format=%cd \
+                  --date=format-local:%Y%m%dT%H%M%SZ)"
+              origin="commit $(git log -1 --format='%h ("%s")')"
+          fi
+
+          # The rootfs recipe also validates the snapshot timestamp; checking
+          # it early causes duplication but avoids wasting resources.
+          if ! echo "$snapshot" | grep -qE '^[0-9]{8}T[0-9]{6}Z$'; then
+              echo "ERROR: invalid snapshot timestamp '${snapshot}' from" \
+                  "${origin}; expected YYYYMMDDTHHMMSSZ" >&2
+              exit 1
+          fi
+
+          echo "snapshot=${snapshot}" >>"$GITHUB_OUTPUT"
+
+          # Show the timestamp and its origin in the job log and run summary.
+          echo "snapshot timestamp ${snapshot}, from ${origin}" |
+              tee -a "$GITHUB_STEP_SUMMARY"
+
+  build-snapshot:
+    # don't run cron from forks of the main repository or from other branches;
+    # manual runs are allowed from any branch of the main repository so
+    # that changes to the workflows can be tested before they are merged
+    if: >-
+      github.repository == 'qualcomm-linux/qcom-deb-images' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main')
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [trixie, forky]
+    uses: ./.github/workflows/debos.yml
+    needs: snapshot-date
+    permissions:
+      contents: read
+    with:
+      suite: ${{ matrix.suite }}
+      # Pass the snapshot timestamp to the rootfs/image builds.
+      debos_extra_args: -t snapshot:${{ needs.snapshot-date.outputs.snapshot }}
+      # QLI targets qcom-next; consume the debs published to EFS by the
+      # "qcom-next linux build" workflow rather than a kernel from an
+      # APT repository. note that a local kernel is not covered by the
+      # snapshot, see docs/snapshot.md
+      kernelpackages: efs/qcom-next
+      # the default variant is enough: the snapshot code paths don't depend on
+      # which variant is built

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -36,6 +36,20 @@ on:
         description: Skip QEMU tests
         type: boolean
         default: false
+      qemu_test_env:
+        description: >
+          Environment variables describing the image to the QEMU tests, one
+          NAME=value per line (e.g. EXPECTED_SNAPSHOT=20260115T000000Z). The
+          tests are the same for every image; what differs is what they are
+          told about it here, so a caller which builds an image a certain way
+          says so through this input rather than by running its own test files.
+          The variables are set for the pytest run only, not for any other
+          step, and every variable the tests understand is listed in the job
+          log before they run, set or not. A line which is not an assignment,
+          or which sets a name no test reads, fails the run rather than being
+          dropped silently. Ignored when skip_qemu_tests is set.
+        type: string
+        default: ''
 
     outputs:
       artifacts_url:
@@ -374,17 +388,34 @@ jobs:
         with:
           name: build_url
           path: build_url
+      # the tests boot the ./disk-ufs.img this job just built, which is why they
+      # run here rather than in a job of their own: that job would have to
+      # download the image back from the private artifact store, which a runner
+      # has no credentials for.
       - name: Invoke test runner
         if: ${{ !inputs.skip_qemu_tests }}
+        env:
+          # the qemu_test_env input, passed through as one payload of
+          # NAME=value lines: image_environment() in ci/qemu_test.py splits it,
+          # validates it and prints what it held before the tests run.
+          # splitting it here would mean doing it in POSIX sh -- this container
+          # has no bash -- which is both more code and code which can only be
+          # run in CI.
+          #
+          # set on this step rather than exported into the job: it describes
+          # the image to these tests and has no business affecting any other
+          # step
+          QEMU_TEST_ENV: ${{ inputs.qemu_test_env }}
         run: |
-           # This is currently a clone of Makefile's "test" target to avoid any
-           # unexpected interactions with triggering depending build targets.
-           # The plan is to move this entire workflow to use make targets
-           # instead but all at once. See #74 and #159.
+          # This is currently a clone of Makefile's "test" target to avoid any
+          # unexpected interactions with triggering depending build targets.
+          # The plan is to move this entire workflow to use make targets
+          # instead but all at once. See #74 and #159.
 
-           # rootfs/ is a build artifact, so should not be scanned for tests
-           # --verbose enables verbose output which shows each test's full name
-           #   and full result which makes CI failures much easier to diagnose
-           # --capture=no so pytest doesn't swallow stdout and only prints it
-           #   after a job fails. Instead, stream the log live.
-           py.test-3 --verbose --capture=no --ignore=rootfs
+          # rootfs/ is a build artifact, so should not be scanned for tests
+          # --verbose enables verbose output which shows each test's full name
+          #   and full result which makes CI failures much easier to diagnose
+          # --capture=no so pytest doesn't swallow stdout and only prints it
+          #   after a job fails. Instead, stream the log live. It is also what
+          #   lets the report of QEMU_TEST_ENV reach the log.
+          py.test-3 --verbose --capture=no --ignore=rootfs

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -405,7 +405,16 @@ jobs:
           # set on this step rather than exported into the job: it describes
           # the image to these tests and has no business affecting any other
           # step
-          QEMU_TEST_ENV: ${{ inputs.qemu_test_env }}
+          #
+          # the suite is added here rather than left to the callers: this
+          # workflow was told which one to build and passes it to debos on
+          # every run, so it can say so without any of them having to. the
+          # caller's own lines follow, and win on a repeated name, since a
+          # caller describing the image it asked for is the more specific
+          # statement of the two
+          QEMU_TEST_ENV: |
+            EXPECTED_SUITE=${{ inputs.suite }}
+            ${{ inputs.qemu_test_env }}
         run: |
           # This is currently a clone of Makefile's "test" target to avoid any
           # unexpected interactions with triggering depending build targets.

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -10,6 +10,7 @@ run() does, and nothing here should send anything that doesn't.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -25,6 +26,117 @@ PROMPT = "debian@debian:~$"
 # Password set by login(); the image ships with "debian" and forces a reset on
 # the first login, which login() walks through
 PASSWORD = "new password"
+
+# Variable through which a workflow passes the whole set of EXPECTED_* below at
+# once, as NAME=value lines; see image_environment()
+PAYLOAD = "QEMU_TEST_ENV"
+
+# What may appear left of the "=" in one of those lines, i.e. the shell's rule
+# for a variable name
+NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+# Every variable these tests read, and the whole of what a caller may say about
+# the image. Kept as a whitelist so a name nothing reads is an error rather
+# than a no-op: EXPECTED_SNAPSHOT and EXPECTED_SNAPSOHT are one keystroke
+# apart, and the typo would not fail, it would quietly turn test_snapshot()
+# from "this image was pinned to that timestamp" into "this image was never
+# pinned at all" -- and pass. Add to this when adding a variable.
+KNOWN = ("EXPECTED_SNAPSHOT",)
+
+
+def parse_payload(payload):
+    """Return the NAME=value lines of *payload* as a dict, ignoring blank ones
+
+    An empty payload is a caller which passed no variables.
+
+    A line which is not an assignment, or which sets a name outside KNOWN,
+    raises ValueError rather than being dropped. What these variables say is
+    not optional detail -- an EXPECTED_SNAPSHOT which never arrives does not
+    mean "skip the snapshot check", it means "this image was built without a
+    snapshot" -- so a dropped line would have the tests assert the opposite of
+    what was meant, and pass.
+    """
+    payload = payload.strip()
+    if not payload:
+        return {}
+
+    variables = {}
+    for line in payload.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        name, separator, value = line.partition("=")
+        if not separator or not NAME.match(name):
+            raise ValueError(f"{PAYLOAD} is not NAME=value: {line!r}")
+        if name not in KNOWN:
+            raise ValueError(
+                f"{PAYLOAD} sets {name}, which no test here reads; "
+                f"expected one of: {', '.join(KNOWN)}")
+        variables[name] = value
+    return variables
+
+
+def image_environment():
+    """Return what this run has been told about the image under test
+
+    One source, never a mix of the two. QEMU_TEST_ENV, if it is set at all,
+    is the whole of it, and the ambient environment is ignored; otherwise the
+    ambient environment is read directly. In CI the payload is the caller's
+    complete statement about the image it just built, so a stray EXPECTED_*
+    inherited by a runner has no way to contribute to it -- and by hand there
+    is no payload, so the variables work exactly as any other.
+
+    A workflow has the whole set to pass at once and no good way to say so:
+    listing them in the step's env: would hardcode in debos.yml which
+    variables its callers care about, and splitting a multi-line input into
+    one variable per line would have to happen in the test step, which runs in
+    a container with no bash -- a heredoc, the positional parameters as the
+    only list POSIX sh has, and a case glob standing in for a pattern match,
+    none of which could be run outside CI. So debos.yml passes its
+    qemu_test_env input straight through as one payload of NAME=value lines,
+    and it is split here.
+
+    A payload in a variable rather than a file or a CSV: the transport was
+    never the problem, a file would have to be written and cleaned up by the
+    same shell this avoids, and CSV or JSON would buy quoting rules for values
+    which are timestamps and suite names.
+
+    Every name in KNOWN is reported, with where it was read from and whether
+    it was set, because both halves change what the tests assert. An unset
+    EXPECTED_SNAPSHOT is not "one less check", it is the opposite check, and a
+    caller which meant to pass one and did not looks from the outside exactly
+    like one which never meant to.
+
+    That report needs --capture=no to be seen, which debos.yml passes. This
+    runs while the module is imported, i.e. during collection, and pytest
+    swallows anything printed then unless collection goes on to fail. A
+    pytest_report_header hook would show without it, but pytest only takes
+    hooks from conftest.py and plugins, never from a test module.
+    """
+    payload = os.environ.get(PAYLOAD)
+
+    if payload is None:
+        source = "the environment"
+        variables = {name: os.environ[name]
+                     for name in KNOWN if name in os.environ}
+    else:
+        source = PAYLOAD
+        variables = parse_payload(payload)
+
+    print(f"QEMU test environment, from {source}:")
+    for name in KNOWN:
+        if name in variables:
+            print(f"  {name}={variables[name]}")
+        else:
+            print(f"  {name} is unset")
+
+    return variables
+
+
+# Evaluated at import, so the EXPECTED_* below are in place before pytest
+# collects anything in this module
+ENVIRONMENT = image_environment()
 
 
 @pytest.fixture(scope="session")

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -3,11 +3,14 @@
 These run for every image debos.yml builds, so they must hold for all of them.
 What differs between images is described to the tests by the environment rather
 than by which tests are run: EXPECTED_SUITE below says which Debian suite the
-image under test was built for. Run them from the directory holding the image
-under test:
+image under test was built for, and EXPECTED_SNAPSHOT whether it was built
+from an APT snapshot -- the snapshot expectations are checked either way, as
+an image built without the option must not carry any trace of a snapshot. Run
+them from the directory holding the image under test:
 
     py.test-3 --verbose --capture=no --ignore=rootfs
-    EXPECTED_SUITE=trixie py.test-3 --verbose --capture=no
+    EXPECTED_SNAPSHOT=20260115T000000Z EXPECTED_SUITE=trixie \
+        py.test-3 --verbose --capture=no
 
 Booting the emulated guest costs minutes, so the whole module shares a single
 VM: the fixture below is session scoped and logs in once. The tests therefore
@@ -158,6 +161,15 @@ ENVIRONMENT = image_environment()
 # /etc/os-release does not record either of them and the check would fail on a
 # perfectly good image.
 EXPECTED_SUITE = ENVIRONMENT.get("EXPECTED_SUITE", "")
+
+# Timestamp the image under test was pinned to, as passed to debos with
+# -t snapshot:<timestamp>. The "Build snapshot" workflow sets this, so that the
+# image is checked against the snapshot it was actually asked to build from;
+# every other build leaves it unset, which asserts the opposite -- that the
+# image records no snapshot at all. So pass it whenever the image under test
+# was built from a snapshot, or test_snapshot() fails.
+# See docs/snapshot.md.
+EXPECTED_SNAPSHOT = ENVIRONMENT.get("EXPECTED_SNAPSHOT", "")
 
 
 @pytest.fixture(scope="session")
@@ -311,3 +323,135 @@ def test_suite(vm):
         "/etc/os-release does not record " \
         f"VERSION_CODENAME={EXPECTED_SUITE}; the image is not the suite " \
         "this build asked for"
+
+
+def test_snapshot(vm):
+    """The image records the snapshot it was built from -- and only that one,
+    or none at all -- and boots with its APT sources on the live mirrors"""
+    # the rootfs recipe always writes this file, and adds SNAPSHOT=<timestamp>
+    # to it when, and only when, the snapshot option is in use
+    assert run(vm, "test -e /etc/buildinfo") == 0, "/etc/buildinfo is missing"
+
+    if EXPECTED_SNAPSHOT:
+        # -F -x: the recorded timestamp has to be exactly the one the build was
+        # pinned to. an absent or empty value means the build silently ignored
+        # the option and used the live archives; a different one means the
+        # timestamp was mangled on its way to the recipes
+        grep = f"grep -Fxq 'SNAPSHOT={EXPECTED_SNAPSHOT}' /etc/buildinfo"
+        assert run(vm, grep) == 0, \
+            f"/etc/buildinfo does not record SNAPSHOT={EXPECTED_SNAPSHOT}"
+    else:
+        # nothing pinned this build, so a recorded snapshot means the image is
+        # not the one this run built, or that a stale timestamp leaked into the
+        # recipes. == 1 rather than != 0 for the reason given further down: 1
+        # is "no such line", anything else is grep failing to look
+        assert run(vm, "grep -q '^SNAPSHOT=' /etc/buildinfo") == 1, \
+            "/etc/buildinfo records a SNAPSHOT= but the image was not built " \
+            "from one; pass EXPECTED_SNAPSHOT if it was"
+
+    # Either way the shipped image has to point at the live mirrors: leaving it
+    # pinned would tie every apt update on the device to a dated archive. A
+    # snapshot build restores the mirrors and removes the snapshot helpers on
+    # the way out; an image built without the option never had them.
+    #
+    # Every check below is a negative one, so it has to tell "looked and found
+    # nothing" apart from "could not look": a missing path or an unreadable
+    # file fails these commands too, and a plain "!= 0" would then pass the
+    # test for entirely the wrong reason. Assert the exact status instead --
+    # grep exits 1 for no match and 2 for any error, ls exits 2 for a path that
+    # does not exist, test exits 1 for a file that does not exist.
+    #
+    # That is also why the greps stay inside /etc/apt/sources.list.d/ rather
+    # than sweeping /etc/apt: the .sources files there are world readable and
+    # the directory always exists, so exit 1 really does mean "found nothing",
+    # whereas a recursive grep of /etc/apt would exit 2 on root-only files such
+    # as auth.conf.d/* and pass every check for the wrong reason.
+
+    # the image recipe deletes both of these on its way out of a snapshot
+    # build; the rootfs recipe does not, so a rootfs built with -t snapshot:
+    # and an image built without it still carries them
+    assert run(vm, "ls /etc/apt/sources.list.d/snapshot_*.sources") == 2, \
+        "snapshot APT sources were left in the image"
+    assert run(vm, "test -e /usr/local/bin/apt-snapshot-toggle") == 1, \
+        "the apt-snapshot-toggle helper was left in the image"
+
+    # the two checks above detect a snapshot by *file name*, which is only
+    # equivalent to checking the URLs because the rootfs recipe derives
+    # separate snapshot_*.sources files. Rewriting the live sources in place
+    # instead would leave both of them green and still ship a pinned device --
+    # exactly the regression this test exists to catch -- so grep for what a
+    # pinned source actually looks like as well. The three checks below do that
+    # from three angles, none of which names an individual source, so they hold
+    # for every entry in sources.list.d/ rather than for the ones that happened
+    # to exist when they were written.
+
+    # by host: snapshot.debian.org serves the Debian archives, and it also
+    # accepts a short YYYYMMDD timestamp, which the dated-URL check below would
+    # not match
+    debian_snapshot = (r"grep -rq 'snapshot\.debian\.org' "
+                       r"/etc/apt/sources.list.d/")
+    assert run(vm, debian_snapshot) == 1, \
+        "APT sources still point at snapshot.debian.org"
+
+    # the one snapshot URL that would not live in sources.list.d/: mmdebstrap
+    # records the mirror it bootstrapped from, i.e. the snapshot URL, in the
+    # target's /etc/apt/sources.list. The rootfs recipe removes that file
+    # outright, so assert its absence rather than grepping it
+    assert run(vm, "test -e /etc/apt/sources.list") == 1, \
+        "/etc/apt/sources.list was left in the image; it still holds the " \
+        "mirror mmdebstrap bootstrapped from"
+
+    # not every archive is pinned by moving to a snapshot host: the Qualcomm
+    # Linux one is pinned by appending /<timestamp> to its own URL. Rather than
+    # listing the archives that do that -- qli today, qli-staging or whatever
+    # comes after it tomorrow, and an archive name is exactly the kind of
+    # detail that would silently turn this check into a no-op the day it
+    # changes -- match the shape all of them share: a URL whose last path
+    # component is a snapshot timestamp. That covers every source in the file,
+    # including any added after this was written.
+    #
+    # Images built with -t qliaptrepo:false (Vanilla Debian) or for unstable
+    # ship no Qualcomm Linux source at all, and then this simply finds nothing
+    # to object to; an image with no such source has no such URL that could
+    # have been left pinned.
+    dated_uri = (r"grep -rEq 'https?://[^[:space:]]*/[0-9]{8}T[0-9]{6}Z' "
+                 r"/etc/apt/sources.list.d/")
+    assert run(vm, dated_uri) == 1, \
+        "an APT source still points at a dated snapshot archive"
+
+    # the other half of "pinned", and the one that does not depend on the URL
+    # form at all: the derivation gives every snapshot source a
+    # "Check-Valid-Until: no", because a static snapshot's Release goes stale.
+    # No live source has any business carrying it, so it flags a source left in
+    # snapshot mode even if its URL were rewritten to a shape neither of the
+    # greps above knows about.
+    valid_until = (r"grep -rEq '^Check-Valid-Until: *(no|false|0)"
+                   r"[[:space:]]*$' /etc/apt/sources.list.d/")
+    assert run(vm, valid_until) == 1, \
+        "an APT source still has Check-Valid-Until disabled"
+
+    # same relaxation, but applied globally rather than per source: mmdebstrap
+    # persists the Acquire::Check-Valid-Until "false" it bootstrapped with into
+    # the rootfs, in /etc/apt/apt.conf.d/99mmdebstrap. The rootfs recipe strips
+    # that setting out, though it may leave the file itself behind holding the
+    # other options mmdebstrap wrote, so grep for the setting rather than
+    # testing for the file. Scanning the whole directory also catches the same
+    # relaxation reappearing under some other name.
+    global_valid_until = "grep -rq 'Check-Valid-Until' /etc/apt/apt.conf.d/"
+    assert run(vm, global_valid_until) == 1, \
+        "an APT config in the image sets Check-Valid-Until; the image would " \
+        "accept expired Release files for every archive"
+
+    # apt-snapshot-toggle disables the live sources while the build runs and
+    # re-enables them on the way out, and only then are the snapshot files
+    # deleted; nothing may be left disabled. This catches those two steps being
+    # swapped, which would ship an image whose every source is "Enabled: no"
+    # and whose apt update therefore finds nothing at all.
+    #
+    # deb822 spells false as no/false/0, hence the alternation, even though the
+    # toggle itself only ever writes yes/no. Anchored at both ends so that a
+    # value merely starting with one of them ("nonsense") is not a match
+    disabled = (r"grep -rEq '^Enabled: *(no|false|0)[[:space:]]*$' "
+                r"/etc/apt/sources.list.d/")
+    assert run(vm, disabled) == 1, \
+        "APT sources are still disabled in the image"

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -2,7 +2,8 @@
 
 Booting the emulated guest costs minutes, so the whole module shares a single
 VM: the fixture below is session scoped and logs in once. The tests therefore
-run sequentially against one console and must leave it at a shell prompt.
+run sequentially against one console and must leave it at a shell prompt --
+run() does, and nothing here should send anything that doesn't.
 """
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
@@ -113,10 +114,42 @@ def login(vm):
     vm.expect_exact(PROMPT)
 
 
+def run(vm, command):
+    """Run *command* in the VM's shell and return its exit status
+
+    The serial console echoes back everything that is sent to it, so anything
+    matched right after send() matches the echo of the command rather than its
+    output. Rather than matching the output, ask the shell for the exit status
+    of the command afterwards: the literal "rc=$?" of the echoed line can never
+    match the "rc=<digits>" the shell prints.
+    """
+    vm.send(f"{command}\r\n")
+    vm.expect_exact(PROMPT)
+    vm.send('echo "rc=$?"\r\n')
+    vm.expect(r"rc=(\d+)")
+    status = int(vm.match.group(1))
+    vm.expect_exact(PROMPT)
+    return status
+
+
 def test_boot_efi_not_world_accessible(vm):
     """The /boot/efi/loader/random-seed file is not readable to users"""
     # https://github.com/qualcomm-linux/qcom-deb-images/issues/279
-    vm.send("journalctl | grep 'is world accessible, which is a security hole' || echo not found\r\n")
-    # Need to match twice because of the serial echo of the command above
-    vm.expect_exact("not found")
-    vm.expect_exact("not found")
+    #
+    # Dumped to a file and grepped separately rather than piped: a pipeline
+    # reports only the status of its last command, so "journalctl | grep -q"
+    # cannot tell "the journal has no such line" from "the journal could not be
+    # read at all" -- grep sees empty input either way and reports no match,
+    # quietly passing the test. Splitting the two checks each of them.
+    #
+    # As the "debian" user, which is in the "adm" group and so can read the
+    # system journal; the dump lands in the guest's /tmp, which is thrown away
+    # with the CoW overlay when the VM dies.
+    assert run(vm, "journalctl --no-pager >/tmp/journal.txt") == 0, \
+        "could not read the guest's journal"
+
+    # == 1, not != 0: 1 is "grep read the file and found no such line", while
+    # 2 would mean grep failed and the check never happened
+    warning = "is world accessible, which is a security hole"
+    assert run(vm, f"grep -q '{warning}' /tmp/journal.txt") == 1, \
+        "systemd-boot reports /boot/efi/loader/random-seed as world accessible"

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -1,5 +1,14 @@
 """Tests that are entirely qemu based, so do not require test hardware
 
+These run for every image debos.yml builds, so they must hold for all of them.
+What differs between images is described to the tests by the environment rather
+than by which tests are run: EXPECTED_SUITE below says which Debian suite the
+image under test was built for. Run them from the directory holding the image
+under test:
+
+    py.test-3 --verbose --capture=no --ignore=rootfs
+    EXPECTED_SUITE=trixie py.test-3 --verbose --capture=no
+
 Booting the emulated guest costs minutes, so the whole module shares a single
 VM: the fixture below is session scoped and logs in once. The tests therefore
 run sequentially against one console and must leave it at a shell prompt --
@@ -41,7 +50,7 @@ NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 # apart, and the typo would not fail, it would quietly turn test_snapshot()
 # from "this image was pinned to that timestamp" into "this image was never
 # pinned at all" -- and pass. Add to this when adding a variable.
-KNOWN = ("EXPECTED_SNAPSHOT",)
+KNOWN = ("EXPECTED_SNAPSHOT", "EXPECTED_SUITE")
 
 
 def parse_payload(payload):
@@ -137,6 +146,18 @@ def image_environment():
 # Evaluated at import, so the EXPECTED_* below are in place before pytest
 # collects anything in this module
 ENVIRONMENT = image_environment()
+
+# Debian suite the image under test was built for, as passed to debos with
+# -t suite:<suite> and as /etc/os-release spells it, e.g. "trixie". debos.yml
+# sets this for every image it builds, from the suite it was asked for, so no
+# caller has to. There is no meaningful assertion to make when it is unset --
+# every image is some suite -- so test_suite() skips instead, which is what
+# running these by hand without it does.
+#
+# Don't pass "sid" or "unstable": those track whichever codename is next, so
+# /etc/os-release does not record either of them and the check would fail on a
+# perfectly good image.
+EXPECTED_SUITE = ENVIRONMENT.get("EXPECTED_SUITE", "")
 
 
 @pytest.fixture(scope="session")
@@ -265,3 +286,28 @@ def test_boot_efi_not_world_accessible(vm):
     warning = "is world accessible, which is a security hole"
     assert run(vm, f"grep -q '{warning}' /tmp/journal.txt") == 1, \
         "systemd-boot reports /boot/efi/loader/random-seed as world accessible"
+
+
+# skipif rather than a pytest.skip() in the body: a marker is evaluated before
+# the vm fixture is requested, so running this test alone with EXPECTED_SUITE
+# unset doesn't boot a VM only to skip. In CI the fixture is session scoped and
+# already up, so it costs nothing there either way
+@pytest.mark.skipif(not EXPECTED_SUITE,
+                    reason="EXPECTED_SUITE is unset, so the suite the image "
+                           "was built for is not known")
+def test_suite(vm):
+    """The image is the Debian suite the build was asked for"""
+    # os-release rather than the APT sources: this asks what the image *is*,
+    # which is what a caller asking for forky and getting trixie cares about,
+    # and it does not depend on how the recipe happens to name its sources.
+    # It comes from the base-files package the bootstrap pulled in, so it also
+    # catches a suite which was only applied to the later package installs.
+    assert run(vm, "test -e /etc/os-release") == 0, \
+        "/etc/os-release is missing"
+
+    # -F -x: the whole line, so that "trixie" cannot match a "trixie/sid"
+    grep = f"grep -Fxq 'VERSION_CODENAME={EXPECTED_SUITE}' /etc/os-release"
+    assert run(vm, grep) == 0, \
+        "/etc/os-release does not record " \
+        f"VERSION_CODENAME={EXPECTED_SUITE}; the image is not the suite " \
+        "this build asked for"

--- a/ci/qemu_test.py
+++ b/ci/qemu_test.py
@@ -1,4 +1,9 @@
-"""Tests that are entirely qemu based, so do not require test hardware"""
+"""Tests that are entirely qemu based, so do not require test hardware
+
+Booting the emulated guest costs minutes, so the whole module shares a single
+VM: the fixture below is session scoped and logs in once. The tests therefore
+run sequentially against one console and must leave it at a shell prompt.
+"""
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
@@ -12,11 +17,29 @@ import tempfile
 import pexpect
 import pytest
 
+# Shell prompt of the "debian" user once logged in; every command sent to the
+# console is expected to end back at it
+PROMPT = "debian@debian:~$"
 
-@pytest.fixture
+# Password set by login(); the image ships with "debian" and forces a reset on
+# the first login, which login() walks through
+PASSWORD = "new password"
+
+
+@pytest.fixture(scope="session")
 def vm():
-    """A pexpect.spawn object attached to the serial console of a VM freshly
-    booting with a CoW base of disk-ufs.img"""
+    """A pexpect.spawn object attached to the serial console of a VM booted
+    with a CoW base of disk-ufs.img, logged in and sitting at a shell prompt
+
+    One VM is shared by every test in this module: booting an emulated aarch64
+    guest takes minutes. The disk is a throwaway CoW overlay, so a test may
+    write scratch files to the guest, but the console is shared state and each
+    test has to leave it at a shell prompt. Note that logging in is part of
+    setting the VM up, so the mandatory password reset flow login() walks
+    through is exercised once here rather than by a test of its own; if the
+    image stops requiring it, every test in this module errors.
+    https://github.com/qualcomm-linux/qcom-deb-images/issues/69
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         qcow_path = os.path.join(tmpdir, "disk1.qcow")
         subprocess.run(
@@ -58,6 +81,9 @@ def vm():
             timeout=120,
         )
         child.logfile = sys.stdout.buffer
+
+        login(child)
+
         yield child
 
         # No need to be nice; that would take time
@@ -68,10 +94,9 @@ def vm():
         child.wait()
 
 
-def test_password_reset_required(vm):
-    """On first login, there should be a mandatory reset password flow"""
-    # https://github.com/qualcomm-linux/qcom-deb-images/issues/69
-
+def login(vm):
+    """Wait for the login prompt of a freshly booted VM, log in as "debian",
+    walk through the mandatory password reset and return at a shell prompt"""
     # This takes a minute or two on a ThinkPad T14s Gen 6 Snapdragon
     vm.expect_exact("debian login:", timeout=420)
 
@@ -82,12 +107,14 @@ def test_password_reset_required(vm):
     vm.expect_exact("Current password:")
     vm.send("debian\r\n")
     vm.expect_exact("New password:")
-    vm.send("new password\r\n")
+    vm.send(f"{PASSWORD}\r\n")
     vm.expect_exact("Retype new password:")
-    vm.send("new password\r\n")
-    vm.expect_exact("debian@debian:~$")
+    vm.send(f"{PASSWORD}\r\n")
+    vm.expect_exact(PROMPT)
 
-    # The /boot/efi/loader/random-seed file should not be readable to users
+
+def test_boot_efi_not_world_accessible(vm):
+    """The /boot/efi/loader/random-seed file is not readable to users"""
     # https://github.com/qualcomm-linux/qcom-deb-images/issues/279
     vm.send("journalctl | grep 'is world accessible, which is a security hole' || echo not found\r\n")
     # Need to match twice because of the serial echo of the command above

--- a/docs/qemu-tests.md
+++ b/docs/qemu-tests.md
@@ -1,0 +1,79 @@
+# The QEMU tests
+
+`ci/qemu_test.py` boots an image under QEMU and checks it from the inside. The
+tests need no hardware, so `debos.yml` runs them for every image it builds,
+in the build job and against the `disk-ufs.img` that job just produced.
+
+Because they run for *every* image, they have to hold for all of them. What
+differs between images is therefore described to the tests rather than
+expressed by running a different set of them: a caller says how it built the
+image, and the same tests assert accordingly. See
+[Passing variables to the tests](#passing-variables-to-the-tests) below.
+
+## Running them by hand
+
+From the directory holding the image under test:
+
+```bash
+py.test-3 --verbose --capture=no --ignore=rootfs
+```
+
+The tests boot a copy-on-write overlay of `./disk-ufs.img` in the working
+directory, so they need that file and leave it untouched. Dependencies are
+`python3-pexpect`, `python3-pytest`, `qemu-system-arm`, `qemu-efi-aarch64` and
+`qemu-utils`. The whole module shares one VM, booted and logged into once, and
+the guest CPU is emulated, so expect a few minutes for the boot and seconds per
+test after it.
+
+`--capture=no` is worth passing: the tests report what they were told about the
+image while the module is imported, and pytest swallows anything printed during
+collection unless collection then fails.
+
+## Passing variables to the tests
+
+### `EXPECTED_SUITE`
+
+The Debian suite the image was built for, as `/etc/os-release` spells it, e.g.
+`trixie`. `test_suite()` checks it against `VERSION_CODENAME` — what the image
+*is*, rather than how the recipe happens to name its APT sources, and it comes
+from the `base-files` the bootstrap pulled in, so a suite applied only to the
+later package installs is caught too.
+
+`debos.yml` sets this for every image it builds, from the `suite` input it was
+already passing to debos, so no caller has to. Running by hand:
+
+```bash
+EXPECTED_SUITE=trixie py.test-3 --verbose --capture=no --ignore=rootfs
+```
+
+There is nothing to assert when it is unset — every image is some suite — so
+the check is skipped instead. Don't pass `sid` or `unstable`: those track
+whichever codename is next, and `/etc/os-release` records neither, so the check
+would fail on a perfectly good image.
+
+### How they are passed
+
+`debos.yml` takes a `qemu_test_env` input — `NAME=value` lines, one per line —
+so that a caller which builds an image a certain way says so through the input
+rather than by running its own test files. It hands the whole set to pytest as
+one `QEMU_TEST_ENV` payload, set on the test step only, and
+`image_environment()` in `ci/qemu_test.py` splits it at import.
+
+When `QEMU_TEST_ENV` is set it is the *whole* of what the tests are told — the
+ambient environment is ignored, so a stray `EXPECTED_*` on a runner cannot
+contribute — and when it is unset the variables are read from the environment
+as normal, which is what running by hand does.
+
+Either way the log lists every variable the tests understand, with where it was
+read from and whether it was set. A line which is not an assignment, or which
+sets a name no test reads, fails the run rather than being dropped silently:
+the variables are whitelisted in `KNOWN`, because a name nothing reads is a
+mistake in the caller rather than a no-op.
+
+## Reference
+
+- `ci/qemu_test.py` — the tests themselves, and `image_environment()`, which
+  turns the `QEMU_TEST_ENV` payload into the variables they read.
+- `.github/workflows/debos.yml` — runs them for every image it builds, and
+  passes `EXPECTED_SUITE` for all of them.
+- [`docs/snapshot.md`](snapshot.md) — the `snapshot` build option.

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -254,6 +254,55 @@ After a snapshot build, the final image:
 In other words, the snapshot pins *what gets installed during the build*, then
 gets out of the way so the running system tracks live updates.
 
+## CI coverage
+
+The `build-snapshot.yml` workflow builds snapshot images for both `trixie` and
+`forky`. The timestamp is passed to the `debos.yml` workflow as
+`debos_extra_args: -t snapshot:<timestamp>`, which that workflow hands to both
+the rootfs and the image recipe.
+
+It runs weekly (Saturday) and on demand, rather than daily or on pull requests:
+these are full image builds and snapshot.debian.org is slower and more
+rate-limited than the regular mirrors. It is a workflow of its own rather than
+a job of the daily `build.yml` so that it can keep that slower cadence, and so
+that its artifacts land in their own destination — every job of a *run* uploads
+to one shared place, keyed on the run, and the daily build publishes the same
+suites under the same names.
+
+It only answers "do the snapshot code paths still work?": no LAVA job boots the
+images it builds, so the build going green and the QEMU tests which `debos.yml`
+runs are the coverage. Note that a build which silently fell back to the live
+mirrors would also go green; check `/etc/buildinfo` in the built rootfs as
+described in [Verifying a build](#verifying-a-build) when in doubt. Its
+artifacts are uploaded all the same, so that a failure can be investigated. Only
+the default variant is built, as the snapshot code paths don't depend on the
+variant.
+
+The timestamp is not hardcoded: the `snapshot-date` job derives it from the
+committer date of the commit being built (`git log -1`, rendered as
+`YYYYMMDDTHHMMSSZ` in UTC) and passes it to the build job as a job output.
+It prints the value, and where it came from, to the job log and the run
+summary.
+
+Any well-formed timestamp resolves to the publication which was live at that
+moment (see [Archive-side model](#archive-side-model)), so the value only has to
+be a date the archives still serve, not one which coincides with a publication.
+The commit date is such a date and needs no maintenance: it moves forward on its
+own as the repository is worked on, while two runs of the same commit still pin
+the same publication — so a failure points at a change in our recipes rather
+than at a change in the archives.
+
+A manual run may name a timestamp instead, through the `snapshot` input of the
+workflow's **Run workflow** dialog. That is what a date which always tracks the
+commit cannot do: reproduce an older build, or bisect a change in the archives
+by re-running the same tree against several dates. Leaving the input empty
+derives the timestamp as above, and every other trigger always does.
+
+Whichever it came from, the `snapshot-date` job checks it is `YYYYMMDDTHHMMSSZ`
+before any builder starts. The rootfs recipe validates it too, but only once
+debos is running, so a typo would otherwise fail the run minutes in — once per
+suite.
+
 ## Design notes and caveats
 
 - **The bootstrap resolves on the build host, not in the chroot.** Unlike the
@@ -290,4 +339,5 @@ gets out of the way so the running system tracks live updates.
   validation/recording, `snapshot_*.sources` derivation, live-mirror restore.
 - `debos-recipes/qualcomm-linux-debian-image.yaml` — re-enable snapshot for the
   image's extra package installs, then clean up.
+- `.github/workflows/build-snapshot.yml` — the weekly CI build.
 - `README.md` — the user-facing summary of the `snapshot` recipe option.

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -84,6 +84,44 @@ The presence of `SNAPSHOT=` confirms the build was pinned. Note that the
 `apt update` on the device will fetch current packages, not the snapshot — the
 snapshot governs only what was installed *at build time*.
 
+### Testing a snapshot image
+
+`ci/qemu_test.py` checks all of the above automatically, by booting the image
+in QEMU: that `/etc/buildinfo` records the expected snapshot — or, for an
+unpinned build, none at all — and that nothing snapshot-shaped survived into
+the shipped image. The APT side is checked from several angles, none of which
+names an individual source, so the checks hold for every entry in
+`sources.list.d/` rather than only for the ones that existed when they were
+written: by file name (no leftover `snapshot_*.sources`, no
+`apt-snapshot-toggle`, no bootstrap `/etc/apt/sources.list` or
+`apt.conf.d/99mmdebstrap`), by URL (no snapshot host, and no source whose URL
+carries a snapshot timestamp), by the `Check-Valid-Until: no` that pinning
+leaves behind, and by no source being left `Enabled: no`. Rewriting the live
+sources in place, rather than deriving `snapshot_*` files from them, would
+therefore not slip past either.
+
+These are part of the generic suite that `make test` runs, not a separate one:
+they hold for every image, because an image built *without* the option must not
+carry any trace of a snapshot either. What tells them which kind of image they
+are looking at is the `EXPECTED_SNAPSHOT` environment variable:
+
+```bash
+# 1. build an image pinned to a snapshot (or download one built by CI)
+EXTRA_DEBOS_OPTS="-t snapshot:20260115T000000Z" make disk-ufs.img
+
+# 2. boot it and check the snapshot expectations
+EXPECTED_SNAPSHOT=20260115T000000Z \
+    py.test-3 --verbose --capture=no --ignore=rootfs
+```
+
+`EXPECTED_SNAPSHOT` is the timestamp the image was built from, and
+`/etc/buildinfo` has to record exactly that value. Leaving it unset asserts the
+opposite — that the image records no `SNAPSHOT=` at all — so it must be passed
+whenever the image under test was built from a snapshot, or the test fails.
+
+See [The QEMU tests](qemu-tests.md) for what these tests need to run, how long
+they take, and the other variables they can be told about an image.
+
 ### Reproducing a build later
 
 To re-create a build as it was on a given date:
@@ -271,12 +309,10 @@ suites under the same names.
 
 It only answers "do the snapshot code paths still work?": no LAVA job boots the
 images it builds, so the build going green and the QEMU tests which `debos.yml`
-runs are the coverage. Note that a build which silently fell back to the live
-mirrors would also go green; check `/etc/buildinfo` in the built rootfs as
-described in [Verifying a build](#verifying-a-build) when in doubt. Its
-artifacts are uploaded all the same, so that a failure can be investigated. Only
-the default variant is built, as the snapshot code paths don't depend on the
-variant.
+runs — including the snapshot checks described below — are the coverage. Its
+artifacts are uploaded all the same, so that a failure can be investigated.
+Only the default variant is built, as the snapshot code paths don't depend on
+the variant.
 
 The timestamp is not hardcoded: the `snapshot-date` job derives it from the
 committer date of the commit being built (`git log -1`, rendered as
@@ -302,6 +338,30 @@ Whichever it came from, the `snapshot-date` job checks it is `YYYYMMDDTHHMMSSZ`
 before any builder starts. The rootfs recipe validates it too, but only once
 debos is running, so a typo would otherwise fail the run minutes in — once per
 suite.
+
+### The snapshot QEMU tests
+
+A build which silently fell back to the live mirrors would still go green, so
+each image is booted and checked with `ci/qemu_test.py` (see
+[Testing a snapshot image](#testing-a-snapshot-image)) once it is built.
+
+`debos.yml` runs the same tests for every image it builds; what differs is what
+they are told about the image. `build-snapshot.yml` passes
+`qemu_test_env: EXPECTED_SNAPSHOT=<timestamp>` — `NAME=value` lines, one per
+line — so that the tests require the image to record the exact timestamp this
+run pinned. Every other caller leaves the input empty, which requires the
+opposite: no `SNAPSHOT=` in `/etc/buildinfo` and no snapshot leftovers.
+
+How that input reaches the tests — the `QEMU_TEST_ENV` payload, and what
+happens to a line naming something no test reads — is described in
+[The QEMU tests](qemu-tests.md#how-they-are-passed). What matters here is that
+an unset `EXPECTED_SNAPSHOT` is not one less check, it is the opposite check,
+so a build which meant to pin and did not still fails.
+
+They run in the build job, in the working directory holding the `disk-ufs.img`
+that job just built. That is the only place the image can be booted without
+fetching it back: the artifacts are uploaded to a private store which a runner
+has no credentials for, so an anonymous download of them gets a 403.
 
 ## Design notes and caveats
 
@@ -339,5 +399,9 @@ suite.
   validation/recording, `snapshot_*.sources` derivation, live-mirror restore.
 - `debos-recipes/qualcomm-linux-debian-image.yaml` — re-enable snapshot for the
   image's extra package installs, then clean up.
-- `.github/workflows/build-snapshot.yml` — the weekly CI build.
+- `.github/workflows/build-snapshot.yml` — the weekly CI build, which also
+  asks `debos.yml` to boot what it built and run the snapshot tests against it.
+- `ci/qemu_test.py` — the QEMU tests, including the snapshot ones; they run for
+  every image and are told which snapshot to expect, if any, through
+  `EXPECTED_SNAPSHOT`. See [The QEMU tests](qemu-tests.md).
 - `README.md` — the user-facing summary of the `snapshot` recipe option.


### PR DESCRIPTION
Snapshot builds pin the APT sources to a dated archive (see
docs/snapshot.md). They have their own code paths in the rootfs and
image recipes which nothing else exercises, so build an image with them
regularly, in a workflow of their own.

It runs weekly and on demand rather than daily or on pull requests:
these are full image builds and snapshot.debian.org is slower and more
rate-limited than the regular mirrors. Keeping it out of build.yml is
what lets it have that cadence and gives its artifacts a destination of
their own and doesn't pollute the nightly builds with additional build jobs or artifacts.

This only ever answers "do the snapshot code paths still work?": no LAVA
job boots the images, the build going green and the QEMU tests ran by
debos.yml are the coverage we're after. The artifacts are uploaded all
the same, so that a failure can be investigated. The default image variant is
enough, as the snapshot code paths don't depend on it.

The snapshot timestamp is derived from the committer date of the commit being
built. Any well-formed timestamp resolves to the publication which was live at that
moment, so the value only has to be a date the archives still serve, not
one which coincides with a publication. The commit date is such a date
and needs no maintenance: it moves forward on its own as the repository
is worked on, while two runs of the same commit still pin the same
publication, so a failure points at a change in our recipes rather than
at a change in the archives.

Fixes: #564

## TODO

- Should we remove `flash` build as it is a waste of time/space?
- Remove dummy testing commits
- can't download image in `test-snapshot` job:
```
+ curl -fL --retry 3 https://qli-prod-artifacts.qualcomm.com/qcom-prd-gh-artifacts/qualcomm-linux/qcom-deb-images/*/forky-disk-ufs.img.gz
+ gunzip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 403
```
- CI check to check that buildinfo contains the expected SNAPSHOT= line
- CI check to verify that we've correctly cleaned up so apt-snapshot-toggle is removed (see https://github.com/qualcomm-linux/qcom-deb-images/issues/582) and snapshots are disabled on all sources.list and sources.list.d entries.
- snapshot job: upload `snapshot.txt` into artifacts
- snapshot tests: instead of separate test file `qemu_snapshot_tests.py`, add tests into `qemu_test.py` and only pass vars in debos job. this will allow us to run snapshot tests on non-snapshot enabled image too, and remove `extra_tests` from debos.yml. also, rename `test_env`. 

## Verification

TODO: See [sample build-snapshot.yml workflow run]()