### PR TITLE
ci: test forky in test-on-pr.yml workflow

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -61,6 +61,10 @@ jobs:
           echo "url=${BUILD_URL}" >> $GITHUB_OUTPUT
 
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [trixie, forky]
     uses: ./.github/workflows/lava-test.yml
     permissions:
       checks: write
@@ -72,10 +76,7 @@ jobs:
     needs: retrieve-build-url
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}
-      # trixie is default in lava-test so this is a no-op
-      # however the publish job below hard-codes this in its artifact
-      # download patterns, so keep them in sync if this changes.
-      suite: trixie
+      suite: ${{ matrix.suite }}
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
       boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
 

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -94,18 +94,19 @@ jobs:
     steps:
       # Scope to the test suite's current results so a re-run doesn't pull stale
       # artifacts from superseded attempts and 404 on the orphaned ones. These
-      # patterns must match the names set in lava-test.yml (suite: trixie above).
-      - name: Download test results (latest per board)
+      # patterns must match the names set in lava-test.yml, which prefixes them
+      # with the suite (trixie and forky, per the test job above).
+      - name: Download test results (latest per suite and board)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
-          pattern: test-results-trixie-*
+          pattern: test-results-*
 
       - name: Download job details (this run attempt)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
-          pattern: trixie-${{ github.run_attempt }}-test-job-*
+          pattern: '*-${{ github.run_attempt }}-test-job-*'
 
       - name: Download event file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -132,15 +133,26 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          echo "## Test jobs for commit ${HEAD_SHA}" > pr-comment.txt
-          for json_file in $(find ${{ github.workspace }} -name "*test-job-*.json")
-          do
-              DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")
-              URL=$(cat "$json_file" | jq -r ".url")
-              JOB_ID=$(cat "$json_file" | jq -r ".id")
-              echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)"
-              echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)" >> pr-comment.txt
-          done
+          {
+              echo "## Test jobs for commit ${HEAD_SHA}"
+              # job details are downloaded into a directory named after their
+              # artifact, which lava-test.yml prefixes with the suite and the
+              # run attempt; keep this list in sync with the test job's matrix
+              for suite in trixie forky
+              do
+                  echo ""
+                  echo "### ${suite}"
+                  find "${GITHUB_WORKSPACE}" -name "*test-job-*.json" \
+                          -path "*/${suite}-${GITHUB_RUN_ATTEMPT}-*" |
+                      while read -r json_file
+                      do
+                          DEVICE_TYPE=$(jq -r ".requested_device_type" "$json_file")
+                          URL=$(jq -r ".url" "$json_file")
+                          JOB_ID=$(jq -r ".id" "$json_file")
+                          echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)"
+                      done
+              done
+          } | tee pr-comment.txt
           PR_NUMBER=$(cat "artifacts/Event File/event.json" | jq -r ".number")
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This is a draft as it may be superseded by #628 

---

`Build on PR` builds images for both trixie and forky, but only
trixie was ever booted on the boards. Run the LAVA tests over both
suites, like build-debian.yml and linux.yml already do.

Both builds are published to the same URL, with the suite as a
filename prefix, so the build URL retrieved from the build workflow
covers both and only the suite passed to lava-test.yml changes.

The publish job still only reports the trixie results; the next
commit extends it to both suites.

This is a follow-up from https://github.com/qualcomm-linux/qcom-deb-images/pull/385

## Verification
None yet...

`workflow_run` triggered workflows always execute the version of the file on the repo's default branch. So `test-on-pr.yml` on a PR branch can't be ran against the "new" workflow changes.

see sample workflow: https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/31854327928