### PR TITLE
fix: clean up snapshot state and read timestamp from rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ A few options are provided in the debos recipes; for the root filesystem recipe:
 - `suite`: Debian suite to use, defaults to `trixie`.
 - `snapshot`: use snapshot apt archives for a reproducible build
   (`YYYYMMDDTHHMMSSZ`); logged to `/etc/buildinfo` as `SNAPSHOT=<date>`.
+  Only the root filesystem recipe takes this option: the image build reads the
+  snapshot back from `/etc/buildinfo` and errors out if given one of its own.
   Live mirrors are restored in the final image to allow upgrades.
   See [docs/snapshot.md](docs/snapshot.md) for full usage and internals.
 

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -2,12 +2,24 @@
 {{- $imagesize := or .imagesize "6GiB" }}
 {{- $imagetype := or .imagetype "ufs" }}
 {{- $image := printf "disk-%s.img" $imagetype }}
-{{- $snapshot := or .snapshot "" }}
 
 architecture: arm64
 sectorsize: {{if eq $imagetype "ufs"}}4096{{else}}512{{end}}
 
 actions:
+{{- if .snapshot }}
+  # this recipe does not derive its own snapshot_*.sources, it only toggles the
+  # ones baked into rootfs.tar, so the snapshot is whatever the rootfs build
+  # recorded; a second value here could only ever disagree with it
+  - action: run
+    description: Reject the snapshot option
+    command: |
+      echo "ERROR: the image recipe takes no 'snapshot' option; the snapshot" \
+           "is read from SNAPSHOT= in the root filesystem's /etc/buildinfo." \
+           "Pass -t snapshot: to the rootfs build only." >&2
+      exit 1
+{{- end }}
+
   - action: unpack
     description: Unpack root filesystem
     file: rootfs.tar
@@ -78,15 +90,19 @@ actions:
     setup-fstab: true
     append-kernel-cmdline: clk_ignore_unused pd_ignore_unused audit=0 deferred_probe_timeout=30
 
-{{- if $snapshot }}
+  # /etc/buildinfo is the single source of truth for the snapshot; an unpinned
+  # rootfs simply has no SNAPSHOT= line and nothing to toggle here
   - action: run
-    description: Enable snapshot sources for image build
+    description: Enable snapshot sources for image build (if enabled in rootfs)
     chroot: true
     command: |
       set -eux
-      apt-snapshot-toggle enable
-      apt-get update
-{{- end }}
+      SNAPSHOT=$(sed -n 's/^SNAPSHOT=//p' /etc/buildinfo)
+      if [ -n "$SNAPSHOT" ]; then
+        echo "Building with snapshot timestamp $SNAPSHOT"
+        apt-snapshot-toggle enable
+        apt-get update
+      fi
 
   - action: apt
     description: Make system bootable with systemd-boot

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -153,16 +153,16 @@ actions:
       # enable unit
       systemctl enable debos-grow-rootfs
 
-{{- if $snapshot }}
   - action: run
     description: Restore APT sources to live mirrors and clean up snapshot helpers
     chroot: true
     command: |
       set -eux
-      apt-snapshot-toggle disable
+      if [ -x /usr/local/bin/apt-snapshot-toggle ]; then
+          apt-snapshot-toggle disable
+      fi
       rm -f /etc/apt/sources.list.d/snapshot_*.sources
       rm -f /usr/local/bin/apt-snapshot-toggle
-{{- end }}
 
   - action: run
     description: Extract partition images

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -37,19 +37,28 @@ supports the full form.
 ### Building with the Makefile
 
 The `snapshot` variable is a debos template variable, so it is passed through
-`EXTRA_DEBOS_OPTS`. It must be supplied to **both** the rootfs build and the
-image build, because each recipe re-pins its own APT sources:
+`EXTRA_DEBOS_OPTS`. It is supplied to the **rootfs build only**:
 
 ```bash
 # 1. root filesystem + DTBs, pinned to the snapshot
 EXTRA_DEBOS_OPTS="-t snapshot:20260115T000000Z" make rootfs.tar
 
-# 2. disk image, pinned to the same snapshot
-EXTRA_DEBOS_OPTS="-t snapshot:20260115T000000Z" make disk-ufs.img
+# 2. disk image; the snapshot is picked up from the root filesystem
+make disk-ufs.img
 ```
 
-Use the **same** timestamp for both steps. The flash recipe does not install
-packages and takes no `snapshot` option.
+The rootfs build records the timestamp in `/etc/buildinfo` as
+`SNAPSHOT=<date>`, and the image build reads it back from there, so the two
+cannot drift apart. Passing `snapshot` to the image build **aborts** it:
+
+```
+ERROR: the image recipe takes no 'snapshot' option; the snapshot is read from
+SNAPSHOT= in the root filesystem's /etc/buildinfo. Pass -t snapshot: to the
+rootfs build only.
+```
+
+The flash recipe does not install packages and takes no `snapshot` option
+either.
 
 You can combine `snapshot` with any other option, e.g. a desktop variant:
 
@@ -61,7 +70,7 @@ EXTRA_DEBOS_OPTS="-t snapshot:20260115T000000Z -t gnomedesktop:true" make rootfs
 
 ```bash
 debos -t snapshot:20260115T000000Z debos-recipes/qualcomm-linux-debian-rootfs.yaml
-debos -t snapshot:20260115T000000Z debos-recipes/qualcomm-linux-debian-image.yaml
+debos debos-recipes/qualcomm-linux-debian-image.yaml
 ```
 
 (The Makefile is still recommended, as it sets memory/scratchsize defaults that
@@ -232,10 +241,13 @@ When `snapshot` is non-empty, the following happens in order:
 The image recipe installs a few more packages (`systemd-boot`,
 `u-boot-efi-dtb`, `cloud-guest-utils`), so it must pin those too:
 
-1. After unpacking `rootfs.tar`, if `snapshot` is set: `apt-snapshot-toggle
-   enable` + `apt-get update`. This works because the `snapshot_*.sources` files
-   are still present from the rootfs build. (No re-derivation is needed here —
-   the image recipe only toggles.)
+1. After unpacking `rootfs.tar`, the recipe reads `SNAPSHOT=` back from the
+   unpacked `/etc/buildinfo`; if it is set: `apt-snapshot-toggle enable` +
+   `apt-get update`. This works because the `snapshot_*.sources` files are still
+   present from the rootfs build. (No re-derivation is needed here — the image
+   recipe only toggles.) The recipe takes no `snapshot` option of its own and
+   refuses to run if given one, so the pinning can only ever come from the
+   rootfs it is building an image from.
 2. Package installation proceeds against the snapshot.
 3. **Cleanup:** `apt-snapshot-toggle disable` (if the helper is present), then
    delete `/etc/apt/sources.list.d/snapshot_*.sources` and
@@ -266,9 +278,10 @@ gets out of the way so the running system tracks live updates.
   `Check-Valid-Until` but still requires a currently-valid archive signing key.
   Reaching back far enough that the key of the day has expired would
   additionally need `Apt::Key::gpgvcommand`; this is deliberately not enabled.
-- **Both recipes need the option.** rootfs and image builds each re-pin
-  independently; passing `snapshot` to only one leaves the other resolving live
-  packages.
+- **Only the rootfs recipe takes the option.** The image recipe does not derive
+  its own `snapshot_*.sources`, it only toggles the ones the rootfs build baked
+  into `rootfs.tar`, so it reads the date from `/etc/buildinfo` instead of
+  taking a second value that could disagree with it.
 - **Not every source supports snapshots.** Only Debian (main + security),
   `debian-backports`, and the Qualcomm Linux `qli` archive are rewritten. Any
   `aptlocalrepo`/`localdebs` sources are **not** pinned; packages from them are

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -237,9 +237,11 @@ The image recipe installs a few more packages (`systemd-boot`,
    are still present from the rootfs build. (No re-derivation is needed here —
    the image recipe only toggles.)
 2. Package installation proceeds against the snapshot.
-3. **Cleanup:** `apt-snapshot-toggle disable`, then delete
-   `/etc/apt/sources.list.d/snapshot_*.sources` and
-   `/usr/local/bin/apt-snapshot-toggle`.
+3. **Cleanup:** `apt-snapshot-toggle disable` (if the helper is present), then
+   delete `/etc/apt/sources.list.d/snapshot_*.sources` and
+   `/usr/local/bin/apt-snapshot-toggle`. This step is **unconditional**: what
+   the rootfs carries is decided by the rootfs build, not by the options given
+   to the image build, so the removal is never gated on the latter.
 
 ### What the shipped image looks like
 


### PR DESCRIPTION
Only the rootfs recipe does anything with a `snapshot` timestamp: it derives
the `snapshot_*.sources` and records the date in `/etc/buildinfo`. The image
recipe just toggles the sources baked into `rootfs.tar`, so its own `snapshot`
option never decided which archive packages came from; only whether to
toggle at all. Passing a different timestamp to the image build looked like it
re-pinned the extra packages when it did not and passing one over an unpinned
rootfs failed later with `apt-snapshot-toggle: not found`.

Two commits:

1. **Always clean up snapshot state from the rootfs.** The removal of
   `snapshot_*.sources` and `apt-snapshot-toggle` was gated on the image
   build's own `snapshot` option, so a snapshot rootfs built into an image
   without one shipped both. It now runs unconditionally. Closes #582.

2. **Read the snapshot from the root filesystem.** `/etc/buildinfo` becomes the
   single source of truth: the image recipe reads `SNAPSHOT=` back from the
   unpacked rootfs and toggles the sources when it is set. It no longer takes a
   `snapshot` option and aborts up front if given one, pointing at the rootfs
   build.

## Verification

Building image with `-t snapshot:value` now fails:
```
$ EXTRA_DEBOS_ARGS="-t snapshot:20260822T034007Z"
==== Reject the snapshot option ====
ERROR: the image recipe takes no 'snapshot' option; the snapshot is read from SNAPSHOT= in the root filesystem's /etc/buildinfo. Pass -t snapshot: to the rootfs build only.
Action `Reject the snapshot option` failed at stage Run, error: exit status 1
```

Building image without a snapshot set in rootfs doesn't build with a snapshot:
```
==== Enable snapshot sources for image build (if enabled in rootfs) ====
+ sed -n s/^SNAPSHOT=//p /etc/buildinfo
+ SNAPSHOT=
+ [ -n  ]
```

Building image with a snapshot set in rootfs builds with that snapshot timestamp:
```
==== Enable snapshot sources for image build (if enabled in rootfs) ====
+ sed -n s/^SNAPSHOT=//p /etc/buildinfo
+ SNAPSHOT=20260822T034007Z
+ [ -n 20260822T034007Z ]
+ echo Building with snapshot timestamp 20260822T034007Z
Building with snapshot timestamp 20260822T034007Z
+ apt-snapshot-toggle enable
```