### PR TITLE
feat(debos/flash): update qcom-ptool revision

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -15,10 +15,10 @@ architecture: arm64
 actions:
   - action: download
     description: Download qcom-ptool
-    url: https://github.com/qualcomm-linux/qcom-ptool/archive/b147606c32b7d29148eca16fbe071f9420dd51a9.tar.gz
+    url: https://github.com/qualcomm-linux/qcom-ptool/archive/83631c3415402908fedabf8b54dbf2363353094b.tar.gz
     name: qcom-ptool
     filename: qcom-ptool.tar.gz
-    sha256sum: a9fb80e1e03400d228c784a12c55de66ff7144ec8f07732f0dff332b33ead242
+    sha256sum: 39068987e6e3b8a892822d02e7e5bae75b8b589f3849f8f2e47bebed4f09eb94
     unpack: true
 
   - action: download


### PR DESCRIPTION
Bump the qcom-ptool dependency pin in qualcomm-linux-debian-flash.yaml to commit 83631c3415402908fedabf8b54dbf2363353094b, the current main tip of qualcomm-linux/qcom-ptool, and update the sha256sum accordingly.

This pulls in all upstream changes merged since the previous pin (b147606c32b7d29148eca16fbe071f9420dd51a9), including the Glymur spinor partition layout change from qcom-ptool#158, which resizes BOOT_FW1/BOOT_FW1_BACKUP and dtb_a/dtb_b to support dual boot (Windows and
  Linux) and drops the following partitions that are not part of the WP Meta:

  - TZAPPS / TZAPPS_BACKUP
  - XBL_RAMDUMP / XBL_RAMDUMP_BACKUP
  - MULTIIMGQTI / MULTIIMGQTI_BACKUP
  - SPU_PROD_BACKUP

See the commit message for the full list of changes included in this bump.

**Testing**: Verified on hardware — built locally with this ptool pin, flashed spinor and NVMe on Glymur, confirmed boot with the new partition layout.