### PR TITLE
feat(debos/rootfs): add URM (userspace-resource-manager) to rootfs

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -401,6 +401,13 @@ actions:
     packages:
       # fastrpc-tests pulls in fastrpc-support
       - fastrpc-tests
+
+  # userspace-resource-manager is available from QLI overlays for trixie and forky
+  - action: apt
+    description: Install userspace-resource-manager from QLI overlay
+    recommends: true
+    packages:
+      - userspace-resource-manager
 {{- end }}
 
   - action: run


### PR DESCRIPTION
Userspace Resource Manager(URM) is a lightweight userspace daemon
which monitors system resources and enforces policies using
Linux kernel interfaces such as cgroups and sysfs.

Various workloads on different platforms can be supported by URM,
through the addition of appropriate Resource and Signal
configurations, without requiring any code changes. If a workload
requires advanced handling, it can be implemented cleanly through
the URM-plugin framework.