### PR TITLE
refactor(debos/flash)!: switch RB1 && UnoQ to EDK2-based boot firmware

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -111,9 +111,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Copy U-Boot for RB1 from EFS
-        run: cp -av "/efs/u-boot-rb1-latest/rb1-boot.img" .
-
       # mtools is needed for the flash recipe
       # file, device-tree-compiler and u-boot-tools are needed by qcom-dtb-metadata
       - name: Install debos and dependencies of the recipes and local tests
@@ -215,7 +212,7 @@ jobs:
       - name: Build flashable files with debos
         run: |
           set -ux
-          make flash FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="-t u_boot_rb1:rb1-boot.img -t buildid:${BUILD_ID} --print-recipe ${DEBOS_EXTRA_ARGS} ${DEBOS_VARIANT_ARGS}"
+          make flash FAKEMACHINE_OPTS="-b qemu" EXTRA_DEBOS_OPTS="-t buildid:${BUILD_ID} --print-recipe ${DEBOS_EXTRA_ARGS} ${DEBOS_VARIANT_ARGS}"
 
       - name: Stage debos artifacts for publishing
         run: |

--- a/.github/workflows/linux-mainline.yml
+++ b/.github/workflows/linux-mainline.yml
@@ -1,9 +1,8 @@
 name: mainline linux build
 
 on:
-  # run weekly on Monday at 2:30pm, after the daily builds and the weekly u-boot
-  # build have finished for the day, so this doesn't add its LAVA jobs on top of
-  # theirs
+  # run weekly on Monday at 2:30pm, after the daily builds have finished for
+  # the day, so this doesn't add its LAVA jobs on top of theirs
   schedule:
     - cron: '30 14 * * 1'
   # allow manual runs

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -1,10 +1,10 @@
+# DEPRECATED: RB1 boots the EDK2-based firmware shipped with its boot
+# binaries, so the U-Boot image built here is no longer used by the flash
+# recipe. This workflow is kept for manual runs only and is expected to be
+# removed along with scripts/build-u-boot-rb1.sh.
 name: Build U-Boot for RB1
 
 on:
-  # run weekly on Monday at 12:30pm, once the daily builds are done with the
-  # self-hosted runners for the day
-  schedule:
-    - cron: '30 12 * * 1'
   # allow manual runs
   workflow_dispatch:
 
@@ -23,13 +23,11 @@ concurrency:
 
 jobs:
   build-u-boot-rb1:
-    # don't run cron from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
     # that changes to the workflows can be tested before they are merged
     if: >-
       github.repository == 'qualcomm-linux/qcom-deb-images' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/main')
+      github.event_name == 'workflow_dispatch'
     permissions:
       contents: read # actions/checkout
     # for cross-builds

--- a/README.md
+++ b/README.md
@@ -46,23 +46,6 @@ version 2.1 as it contains important fixes.
 
 ## Steps
 
-### (optional) Build and flash U-Boot
-
-U-Boot is needed for the RB1 board. If you are not targeting this board, you
-can go to the next section.
-
-Building U-Boot for the RB1 requires the following extra build-dependencies:
-
-```bash
-apt -y install git crossbuild-essential-arm64 make bison flex bc libssl-dev gnutls-dev xxd coreutils gzip mkbootimg
-```
-
-To build U-Boot for the RB1, run:
-
-```bash
-scripts/build-u-boot-rb1.sh
-```
-
 ### (optional) Build custom kernel
 
 By default the image recipes will install the kernel provided by Debian.
@@ -104,9 +87,6 @@ To build flashable assets for all supported boards, follow these steps:
 1. build flashable assets from downloaded boot binaries, the DTBs, and pointing at the UFS/SD card disk images
     ```bash
     make flash
-
-    # (optional) if you've built U-Boot for the RB1, run this instead:
-    #EXTRA_DEBOS_OPTS="-t u_boot_rb1:u-boot/rb1-boot.img" make flash
 
     # (optional) build only a subset of boards:
     #EXTRA_DEBOS_OPTS="-t target_boards:qcs615-ride,qcs6490-rb3gen2-vision-kit" make flash
@@ -171,8 +151,6 @@ For the image recipe:
 
 For the flash recipe:
 
-- `u_boot_rb1`: prebuilt U-Boot binary for RB1 in Android boot image format --
-  see below (NB: debos expects relative pathnames)
 - `target_boards`: comma-separated list of board names to build (default:
   `all`). Accepted values are the board names defined in the flash recipe, e.g.
   `qcs615-ride`, `qcs6490-rb3gen2-vision-kit`, `qcs8300-ride`,
@@ -181,7 +159,7 @@ For the flash recipe:
 Note: Boards whose required device tree (.dtb) is not present in `dtbs.tar.gz` are automatically skipped during flash asset generation.
 
 Deprecated flash options:
-- `build_qcs615`, `build_qcm6490`, `build_qcs8300`, `build_qcs9100`, `build_rb1`: these per-family/per-board toggles are deprecated and will be removed. Use `target_boards` instead to select which boards to build.
+- `build_qcs615`, `build_qcm6490`, `build_qcs8300`, `build_qcs9100`: these per-family/per-board toggles are deprecated and will be removed. Use `target_boards` instead to select which boards to build.
 
 Here are some example invocations:
 

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -2,10 +2,6 @@
 {{- $build_qcm6490 := or .build_qcm6490 "true" }}
 {{- $build_qcs8300 := or .build_qcs8300 "true" }}
 {{- $build_qcs9100 := or .build_qcs9100 "true" }}
-{{- $build_rb1 := "false" -}}
-{{- if .u_boot_rb1 -}}
-{{- $build_rb1 = "true" }}
-{{- end -}}
 {{- $buildid := or .buildid "" }}
 
 {{- $target_boards := or .target_boards "all" }}
@@ -378,22 +374,27 @@ actions:
     "dtb" "qcom/lemans-evk.dtb"
 )}}
 {{- end }}
-{{- if eq $build_rb1 "true" }}
 {{- $boards = append $boards (dict
     "name" "qrb2210-rb1"
     "soc_id" "qcm2290"
     "ptool_platforms" (list "qrb2210-rb1/emmc")
     "boot_binaries_download" (dict
-        "description" "RB1 rescue image"
-        "url" "https://artifacts.codelinaro.org/artifactory/clo-549-96boards-backup/96boards/rb1/linaro/rescue/23.12/rb1-bootloader-emmc-linux-47528.zip"
-        "name" "qrb2210-rb1_rescue-image"
-        "filename" "qrb2210-rb1_rescue-image.zip"
-        "sha256sum" "c75b6c63eb24c8ca36dad08ba4d4e93f3f4cd7dce60cf1b6dfb5790dc181cc3d"
+        "description" "QRB2210 boot binaries"
+        "url" "https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QRB2210_bootbinaries.1.0/qrb2210_bootbinaries.1.0-test-device-public/00021/Agatti_bootbinaries_00021.zip"
+        "name" "qrb2210_boot-binaries"
+        "filename" "qrb2210_boot-binaries.zip"
+        "sha256sum" "26a8681834363cb8bc9e8149db27388406daf22af15d3b43c9649e180afb47f2"
     )
-    "u_boot_file" .u_boot_rb1
+    "cdt_download" (dict
+        "description" "QRB2210 RB1 Core Kit CDT"
+        "url" "https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QRB2210/cdt/rb1_core_kit.zip"
+        "name" "qrb2210-rb1-core-kit_cdt"
+        "filename" "qrb2210-rb1-core-kit_cdt.zip"
+        "sha256sum" "edacea2aafc8a79697135f4d9312528ba89a464251b566486b3b9d6213c90340"
+    )
+    "cdt_filename" "rb1_core_kit/cdt_rb1_core_kit.bin"
     "dtb" "qcom/qrb2210-rb1.dtb"
 )}}
-{{- end }}
 {{- $boards = append $boards (dict
     "name" "qrb2210-arduino-imola"
     "soc_id" "qcm2290"
@@ -549,10 +550,10 @@ actions:
       # Board metadata table: one record per board, fields separated by '|'.
       # Fields (in order):
       #   name|soc_id|dtb|dtb_bin_type|boot_binaries_filename|
-      #   cdt_download_filename|cdt_filename|u_boot_file|platforms
-      # The optional fields (cdt_download_filename, cdt_filename,
-      # u_boot_file) are empty when they don't apply. "platforms" is a
-      # space-separated list and comes last so "read" captures all of it.
+      #   cdt_download_filename|cdt_filename|platforms
+      # The optional fields (cdt_download_filename, cdt_filename) are empty
+      # when they don't apply. "platforms" is a space-separated list and comes
+      # last so "read" captures all of it.
       #
       # This table is rendered once from the templated $boards list and then
       # iterated in shell, so the (long) per-board/per-platform logic below is
@@ -561,12 +562,12 @@ actions:
       boards_table="build/boards.txt"
       : >"${boards_table}"
 {{- range $board := $boards }}
-      printf '%s\n' '{{ $board.name }}|{{ $board.soc_id }}|{{ $board.dtb }}|{{ or $board.dtb_bin_type "combineddtb" }}|{{ $board.boot_binaries_download.filename }}|{{ with $board.cdt_download }}{{ .filename }}{{ end }}|{{ if $board.cdt_download }}{{ $board.cdt_filename }}{{ end }}|{{ with $board.u_boot_file }}{{ . }}{{ end }}|{{ range $p := $board.ptool_platforms }}{{ $p }} {{ end }}' >>"${boards_table}"
+      printf '%s\n' '{{ $board.name }}|{{ $board.soc_id }}|{{ $board.dtb }}|{{ or $board.dtb_bin_type "combineddtb" }}|{{ $board.boot_binaries_download.filename }}|{{ with $board.cdt_download }}{{ .filename }}{{ end }}|{{ if $board.cdt_download }}{{ $board.cdt_filename }}{{ end }}|{{ range $p := $board.ptool_platforms }}{{ $p }} {{ end }}' >>"${boards_table}"
 {{- end }}
 
       while IFS='|' read -r board_name board_soc_id board_dtb \
           board_dtb_bin_type boot_binaries_filename \
-          board_cdt_download_filename board_cdt_filename board_u_boot_file \
+          board_cdt_download_filename board_cdt_filename \
           board_platforms; do
       # skip blank lines produced by template whitespace
       [ -n "${board_name}" ] || continue
@@ -686,13 +687,6 @@ actions:
           sail_nor_dir="build/${board_name}_boot-binaries/sail_nor"
           if [ -d "${sail_nor_dir}" ]; then
               cp --preserve=mode,timestamps -rv "${sail_nor_dir}" "${flash_dir}/"
-          fi
-
-          if [ -n "${board_u_boot_file}" ]; then
-              # copy U-Boot binary to boot.img; qcom-ptool partitions.conf
-              # files use filename=boot.img for boot_a and boot_b partitions
-              cp --preserve=mode,timestamps -v \
-                  "${ARTIFACTDIR}/${board_u_boot_file}" "${flash_dir}/boot.img"
           fi
 
           if [ -n "$board_cdt_filename" ]; then

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -15,10 +15,10 @@ architecture: arm64
 actions:
   - action: download
     description: Download qcom-ptool
-    url: https://github.com/qualcomm-linux/qcom-ptool/archive/80e52fcde1cbae7d725692dea98a27cb479c5a2c.tar.gz
+    url: https://github.com/qualcomm-linux/qcom-ptool/archive/fb8c99c308732eaaba427233029f33c5327beebf.tar.gz
     name: qcom-ptool
     filename: qcom-ptool.tar.gz
-    sha256sum: 4fe113e20fa8feffdd962612f17cb03e60e6e7f460738bbcf897c7c9c631ad06
+    sha256sum: 83a67bcd35de58e18559e9adea3c9de2bbaa424162d763a87a2f627d4cd4b8eb
     unpack: true
 
   - action: download

--- a/debos-recipes/qualcomm-linux-debian-image.yaml
+++ b/debos-recipes/qualcomm-linux-debian-image.yaml
@@ -97,34 +97,6 @@ actions:
       # Depends on grub packages
       - shim-signed-
 
-  # this is to provide an updated copy of DTBs from the OS to U-Boot, notably
-  # on RB1
-  - action: run
-    description: Setup copying of DTBs to ESP partition
-    chroot: true
-    command: |
-      set -eux
-      # Fixes error when running outside qemu
-      dpkg-divert --local --rename --add /etc/kernel/postinst.d/u-boot-efi-dtb
-      ln -s /usr/bin/true /etc/kernel/postinst.d/u-boot-efi-dtb
-      # u-boot-efi-dtb installs a kernel hook that will trigger on kernel
-      # installation/upgrade, but also calls it explicitely in its postinst in
-      # case it was installed after the kernel; it requires an ESP partition to
-      # copy the DTBs though, so install it after the ESP partition is
-      # available
-      apt -y install u-boot-efi-dtb
-      # Removing previous diversion and symlink
-      rm /etc/kernel/postinst.d/u-boot-efi-dtb
-      dpkg-divert --rename --remove /etc/kernel/postinst.d/u-boot-efi-dtb
-      # when building under debos, /sys/firmware/efi is not always present, so
-      # the u-boot-efi-dtb postinst doesn't install an initial copy of the
-      # DTBs; do this once here
-      # extract kernel list to variable to avoid silent pipeline failure
-      kernel_list=$(linux-version list)
-      latest_kernel=$(echo "$kernel_list" | linux-version sort --reverse | head -1)
-      dtb_path="/usr/lib/linux-image-${latest_kernel}"
-      cp -LRT "$dtb_path" "/boot/efi/dtb"
-
   - action: run
     description: Create task to grow root filesystem on first boot
     chroot: true

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -764,15 +764,6 @@ actions:
 {{- end }}
 {{- end }}
 
-  # this is currently needed on boards such as RB1 which are using Android
-  # bootloader to check the boot count of the boot_a/boot_b partitions
-  - action: apt
-    description: Support boards chainloading from Android bootloader
-    recommends: true
-    packages:
-      # marks the current Android boot partition as booted successfully
-      - qbootctl
-
 {{- if eq $multimedia "true" }}
 # Install the accelerated multimedia stack: out-of-tree kernel drivers and
 # closed source user-space from the Qualcomm Linux APT repository.

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -213,7 +213,6 @@ actions:
       "src:linux:any"
       "src:linux-signed-arm64:any"
       "src:mesa:any"
-      "src:u-boot-efi-dtb"
       "src:wireplumber:any" }}
 
   - action: run

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -276,7 +276,7 @@ When `snapshot` is non-empty, the following happens in order:
 ### Image recipe (`qualcomm-linux-debian-image.yaml`)
 
 The image recipe installs a few more packages (`systemd-boot`,
-`u-boot-efi-dtb`, `cloud-guest-utils`), so it must pin those too:
+`cloud-guest-utils`), so it must pin those too:
 
 1. After unpacking `rootfs.tar`, if `snapshot` is set: `apt-snapshot-toggle
    enable` + `apt-get update`. This works because the `snapshot_*.sources` files


### PR DESCRIPTION
Switch QRB2210-based devices (RB1 and UnoQ) to use the EDK2-based boot firmware. This removes the need for a custom U-Boot binary to be built and shipped with the images. 

Tested on Arduino UnoQ locally and RB1 in CI.

---
## Outstanding points (PR is draft until these are resolved)
- [ ] Test image on RB1
- [ ] Move the commit removing `u-boot-efi-dtb` to a separate PR?
- [ ] Move the commit removing `qbootctl` to a separate PR?