### PR TITLE
ci: always report LAVA results; even on failure

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -47,11 +47,16 @@ jobs:
   test-debian:
     # don't run cron from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
-    # that changes to the workflows can be tested before they are merged
+    # that changes to the workflows can be tested before they are merged.
+    # this explicit if: replaces the implicit success(), so the state of the
+    # build job has to be checked too, otherwise LAVA jobs would be submitted
+    # with an empty image url once it fails; checking the result rather than
+    # calling success() also covers the case where the build was skipped
     if: >-
       github.repository == 'qualcomm-linux/qcom-deb-images' &&
       (github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/main')
+      github.ref == 'refs/heads/main') &&
+      needs.build-debian.result == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,11 +57,16 @@ jobs:
   test:
     # don't run from forks of the main repository or from other branches;
     # manual runs are allowed from any branch of the main repository so
-    # that changes to the workflows can be tested before they are merged
+    # that changes to the workflows can be tested before they are merged.
+    # this explicit if: replaces the implicit success(), so the state of the
+    # build job has to be checked too, otherwise LAVA jobs would be submitted
+    # with an empty image url once it fails; checking the result rather than
+    # calling success() also covers the case where the build was skipped
     if: >-
       github.repository == 'qualcomm-linux/qcom-deb-images' &&
       (github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/main')
+      github.ref == 'refs/heads/main') &&
+      needs.build.result == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -170,6 +170,11 @@ jobs:
   publish-test-results:
     name: Publish Tests Results
     needs: submit-job
+    # a failed submit job (LAVA submission error, timeout, ...) must not hide
+    # the results of the boards that did run: publish whatever artifacts exist
+    # anyway. only skip when there is nothing to report, i.e. when no job
+    # matched the board filters or the run was cancelled.
+    if: ${{ !cancelled() && needs.submit-job.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       checks: write # EnricoMi/publish-unit-test-result-action
@@ -212,7 +217,8 @@ jobs:
 
       - name: Publish Test Job Details
         run: |
-          for json_file in $(find ${{ github.workspace }} -name "*test-job-*.json")
+          JOB_FILES=$(find ${{ github.workspace }} -name "*test-job-*.json")
+          for json_file in $JOB_FILES
           do
               DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")
               URL=$(cat "$json_file" | jq -r ".url")
@@ -220,3 +226,9 @@ jobs:
               echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)"
               echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)" >> $GITHUB_STEP_SUMMARY
           done
+          # every board failed to submit, or none matched the filters: say so
+          # rather than leaving an empty job list in the summary, which reads
+          # like the tests passed
+          if [ -z "$JOB_FILES" ]; then
+              echo "No test jobs were submitted." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/lava-test.yml
+++ b/.github/workflows/lava-test.yml
@@ -170,6 +170,11 @@ jobs:
   publish-test-results:
     name: Publish Tests Results
     needs: submit-job
+    # a failed submit job (LAVA submission error, timeout, ...) must not hide
+    # the results of the boards that did run: publish whatever artifacts exist
+    # anyway. only skip when there is nothing to report, i.e. when no job
+    # matched the board filters or the run was cancelled.
+    if: ${{ !cancelled() && needs.submit-job.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       checks: write # EnricoMi/publish-unit-test-result-action

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -183,7 +183,14 @@ jobs:
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
 
   debos-linux-deb:
-    if: ${{ !inputs.skip_image_build }}
+    # an explicit if: replaces the implicit success(), so the state of the
+    # dependency has to be checked here as well; without it the image would
+    # be built from a kernel build which failed or never ran. checking the
+    # result rather than calling success() also covers the skipped case,
+    # e.g. when build-linux-deb is guarded out on a fork
+    if: >-
+      ${{ !inputs.skip_image_build &&
+      needs.build-linux-deb.result == 'success' }}
     needs: build-linux-deb
     strategy:
       fail-fast: false
@@ -199,7 +206,11 @@ jobs:
       skip_qemu_tests: ${{ inputs.skip_qemu_tests || false }}
 
   test-linux-deb:
-    if: ${{ !inputs.skip_lava_tests }}
+    # as above: without checking the dependency's result, LAVA jobs would be
+    # submitted with an empty image url after a failed or skipped image build
+    if: >-
+      ${{ !inputs.skip_lava_tests &&
+      needs.debos-linux-deb.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -135,8 +135,13 @@ jobs:
         id: pr_comment_prep
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # the "Build on PR" run this workflow was triggered by
+          BUILD_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           echo "## Test jobs for commit ${HEAD_SHA}" > pr-comment.txt
+          echo "" >> pr-comment.txt
+          echo "Triggered by [build workflow run](${BUILD_RUN_URL})" >> pr-comment.txt
+          echo "" >> pr-comment.txt
           for json_file in $(find ${{ github.workspace }} -name "*test-job-*.json")
           do
               DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -82,6 +82,11 @@ jobs:
   publish-test-results:
     name: "Publish Tests Results"
     needs: test
+    # a failed submit job (LAVA submission error, timeout, ...) must not hide
+    # the results of the boards that did run: publish whatever artifacts exist
+    # and comment on the PR anyway. only skip when there is nothing to report,
+    # i.e. when the test workflow itself never ran or the run was cancelled.
+    if: ${{ !cancelled() && needs.test.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       checks: write # EnricoMi/publish-unit-test-result-action
@@ -132,7 +137,8 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           echo "## Test jobs for commit ${HEAD_SHA}" > pr-comment.txt
-          for json_file in $(find ${{ github.workspace }} -name "*test-job-*.json")
+          JOB_FILES=$(find ${{ github.workspace }} -name "*test-job-*.json")
+          for json_file in $JOB_FILES
           do
               DEVICE_TYPE=$(cat "$json_file" | jq -r ".requested_device_type")
               URL=$(cat "$json_file" | jq -r ".url")
@@ -140,6 +146,12 @@ jobs:
               echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)"
               echo " * [Job $JOB_ID on $DEVICE_TYPE]($URL)" >> pr-comment.txt
           done
+          # every board failed to submit, or none matched the filters: say so
+          # rather than posting a comment with an empty job list, which reads
+          # like the tests passed
+          if [ -z "$JOB_FILES" ]; then
+              echo "No test jobs were submitted." >> pr-comment.txt
+          fi
           PR_NUMBER=$(cat "artifacts/Event File/event.json" | jq -r ".number")
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -135,8 +135,13 @@ jobs:
         id: pr_comment_prep
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # the "Build on PR" run this workflow was triggered by
+          BUILD_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           echo "## Test jobs for commit ${HEAD_SHA}" > pr-comment.txt
+          echo "" >> pr-comment.txt
+          echo "Triggered by [build workflow run](${BUILD_RUN_URL})" >> pr-comment.txt
+          echo "" >> pr-comment.txt
           JOB_FILES=$(find ${{ github.workspace }} -name "*test-job-*.json")
           for json_file in $JOB_FILES
           do

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -78,6 +78,12 @@ jobs:
       suite: trixie
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
       boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
+      # the publish job below owns all external reporting: under workflow_run,
+      # github.sha is the default branch tip, so lava-test's own check run and
+      # PR comment would target the wrong commit. it has no way to know the PR
+      # head, while the job below passes commit:, event_file: and event_name:
+      # explicitly. results still land in lava-test's job summary.
+      report_test_results_externally: false
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -82,6 +82,11 @@ jobs:
   publish-test-results:
     name: "Publish Tests Results"
     needs: test
+    # a failed submit job (LAVA submission error, timeout, ...) must not hide
+    # the results of the boards that did run: publish whatever artifacts exist
+    # and comment on the PR anyway. only skip when there is nothing to report,
+    # i.e. when the test workflow itself never ran or the run was cancelled.
+    if: ${{ !cancelled() && needs.test.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       checks: write # EnricoMi/publish-unit-test-result-action


### PR DESCRIPTION
Draft as will need rebasing on https://github.com/qualcomm-linux/qcom-deb-images/pull/628 and will need reworking once #405 lands.

---

Currently the LAVA results are not published (to workflow summary or PR comments) if a LAVA job fails. Fix it so the results are always published.

See these sample workflow runs to see broken behaviour:

`build.yml`:
- fail: https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/32498536635
- pass: https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/32434811822

`test-on-pr.yml`:
- fail: https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/32502848140
- pass: https://github.com/qualcomm-linux/qcom-deb-images/actions/runs/32503226131


### Effect on other callers

`lava-test.yml` has more callers than just the PR path and external reporting (`report_test_results_externally`) is left at its `true` default for `build.yml`, `build-on-push.yml` and via `linux.yml`, `linux-qcom-next.yml` and `linux-arduino.yml`. It is off for `build-debian.yml`, `linux-next.yml` and `linux-mainline.yml`.

Because `publish-test-results` previously skipped whenever any board's submit job failed, partial LAVA failures in those runs reported nothing at all. They will now publish: expect "Test Results" check runs on the daily `build.yml` and qcom-next/arduino kernel runs and on pushes to `main` and, since `comment_mode` is `always`, comments on the associated, already-merged PRs. That is the intended effect of the fix, but it is a visible increase in CI noise beyond the PR path, so the first failure should not come as a surprise.

The PR path itself does not gain a duplicate: `test-on-pr.yml` now passes `report_test_results_externally: false`, because the inner job has no way to know the PR head SHA under `workflow_run` and was attaching its check run to the default-branch tip. `test-on-pr.yml`'s own publish job does the external reporting with the correct commit.

### Testing

The `test-on-pr.yml` half cannot be exercised before merge: `workflow_run` always runs the default-branch copy of the workflow file. The `lava-test.yml` half can: every scheduled caller permits `workflow_dispatch` from any branch of the main repo, so dispatching `build.yml` from this branch exercises the new guard, including the partial-failure path if a board is currently flaky.