### PR TITLE
fix(debos/flash): revert qcom-ptool after RB1 regression

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -15,10 +15,10 @@ architecture: arm64
 actions:
   - action: download
     description: Download qcom-ptool
-    url: https://github.com/qualcomm-linux/qcom-ptool/archive/b147606c32b7d29148eca16fbe071f9420dd51a9.tar.gz
+    url: https://github.com/qualcomm-linux/qcom-ptool/archive/80e52fcde1cbae7d725692dea98a27cb479c5a2c.tar.gz
     name: qcom-ptool
     filename: qcom-ptool.tar.gz
-    sha256sum: a9fb80e1e03400d228c784a12c55de66ff7144ec8f07732f0dff332b33ead242
+    sha256sum: 4fe113e20fa8feffdd962612f17cb03e60e6e7f460738bbcf897c7c9c631ad06
     unpack: true
 
   - action: download

--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -15,10 +15,10 @@ architecture: arm64
 actions:
   - action: download
     description: Download qcom-ptool
-    url: https://github.com/qualcomm-linux/qcom-ptool/archive/83631c3415402908fedabf8b54dbf2363353094b.tar.gz
+    url: https://github.com/qualcomm-linux/qcom-ptool/archive/b147606c32b7d29148eca16fbe071f9420dd51a9.tar.gz
     name: qcom-ptool
     filename: qcom-ptool.tar.gz
-    sha256sum: 39068987e6e3b8a892822d02e7e5bae75b8b589f3849f8f2e47bebed4f09eb94
+    sha256sum: a9fb80e1e03400d228c784a12c55de66ff7144ec8f07732f0dff332b33ead242
     unpack: true
 
   - action: download


### PR DESCRIPTION
The reverted commit bumps qcom-ptool to a version which includes a
breaking change to the qrb2210-rb1 partition layout, which switches the
partitions to a new layout for the EDK-II based bootflow. Unfortunately
that is incompatible with the existing U-Boot based bootflow which the
qcom-deb-images currently uses (see switching to EDK-II in https://github.com/qualcomm-linux/qcom-deb-images/pull/593) and
removes the boot_a and boot_b partitions where we currently chain
U-Boot. Revert the change to allow qrb2210-rb1 to boot again.

Also, update qcom-ptool revision to 80e52fc, just before the breaking changes to qrb2210-rb1 were introduced, which still include the change for [platforms/glymur-crd: update spinor partitions for dual-boot support](https://github.com/qualcomm-linux/qcom-ptool/commit/80e52fcde1cbae7d725692dea98a27cb479c5a2c)

cc @neervish - can you re-test this on the glymur-crd ?