### PR TITLE
fix(debos/flash): update qcom-dtb-metadata for Glymur Staging support

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-flash.yaml
+++ b/debos-recipes/qualcomm-linux-debian-flash.yaml
@@ -23,10 +23,10 @@ actions:
 
   - action: download
     description: Download qcom-dtb-metadata (DTB image build scripts and ITS/metadata files)
-    url: https://github.com/qualcomm-linux/qcom-dtb-metadata/archive/d30e9cdb766f08b05160ededf53556ed665d0c0b.tar.gz
+    url: https://github.com/qualcomm-linux/qcom-dtb-metadata/archive/70b09af283da4fba2a2251ff73a7c59ec2699471.tar.gz
     name: qcom-dtb-metadata
     filename: qcom-dtb-metadata.tar.gz
-    sha256sum: a43ccf98149658352a74c54cac1455c35b44e7d48798dc0072540604ec475ae9
+    sha256sum: 0c9ef6ed0a07de39c178d42093f8c5c05b28da3fdaeaf506dacf8aa66b0e94b1
     unpack: true
 
 # soc_id identifies the SoC/SKU each board is built on, using the same


### PR DESCRIPTION
Update qcom-dtb-metadata for Glymur Staging support.

- Updated qcom-dtb-metadata SHA from d30e9cdb to 70b09af283da4fba2a2251ff73a7c59ec2699471
- Updated sha256sum accordingly to 0c9ef6ed0a07de39c178d42093f8c5c05b28da3fdaeaf506dacf8aa66b0e94b1
- This picks up PR # 133 changes from qcom-dtb-metadata which adds Glymur Staging overlay support
- fdt-glymur-staging.dtbo added in qcom-next-fitimage.its
- Validated on Glymur CRD device and glymur-staging.dtbo present at /usr/lib/linux-image-7.2.0-rc7-g011a82096bee/qcom/glymur-staging.dtbo
- Device boots successfully at end.