### PR TITLE
feat(debos/rootfs): prefer alsa-ucm-conf&fastrpc from Qualcomm Linux

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -276,6 +276,24 @@ actions:
        =bX6V
        -----END PGP PUBLIC KEY BLOCK-----
       EOF
+
+{{- /* prefer installing these packages from Qualcomm Linux over backports */}}
+{{- $qlipackages := list
+      "src:alsa-ucm-conf:any" }}
+
+  - action: run
+    description: Add Qualcomm Linux APT preferences for {{ $suite }}
+    chroot: true
+    command: |
+      set -eux
+      tee /etc/apt/preferences.d/qli.pref <<EOF
+      # for binary packages built from these source packages, score the version
+      # from Qualcomm Linux higher than the one from Debian backports
+
+      Package: {{ join " " $qlipackages }}
+      Pin: release o=Qualcomm,l=qli
+      Pin-Priority: 1000
+      EOF
 {{- end }}
 
 {{- if $snapshot }}

--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -279,7 +279,8 @@ actions:
 
 {{- /* prefer installing these packages from Qualcomm Linux over backports */}}
 {{- $qlipackages := list
-      "src:alsa-ucm-conf:any" }}
+      "src:alsa-ucm-conf:any"
+      "src:fastrpc" }}
 
   - action: run
     description: Add Qualcomm Linux APT preferences for {{ $suite }}


### PR DESCRIPTION
Pin binary packages built from src:alsa-ucm-conf/src:fastrpc to the Qualcomm Linux
repository so they win over the version in Debian backports when the
QLI APT repository is enabled.

This change installs the new alsa-ucm-conf package from QLI repository
which includes patches backported from upstream to add UCM
configuration for the Arduino VENTUNO Q and Arduino UNO Q devices.

This change installs the new fastrpc-support package from the QLI
repository which includes a patch to bring the DSPs up at boot.

Fixes: https://github.com/qualcomm-linux/qcom-deb-images/issues/496
Fixes: https://github.com/qualcomm-linux/qcom-deb-images/issues/600