### PR TITLE
ci: improve the Grype vulnerability summary

### DIFF
--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -368,6 +368,7 @@ jobs:
           # append the Grype summary after the download link, so the link stays
           # at the top of the job summary
           scripts/grype-vulnerability-summary.py rootfs-vulns.grype.json \
+              --sbom rootfs-sbom.syft.json \
               >> $GITHUB_STEP_SUMMARY
       - name: Upload build URL
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -61,15 +61,17 @@ def count_by_severity(grouped):
     return counts
 
 
-def describe_distro(data):
-    # the distro Grype matched against; name is e.g. "debian" and version the
-    # major release, e.g. "13". idLike is a list, so join it rather than
-    # interpolating it, and only use it when there is no name at all
-    distro = data.get("distro", {})
-    name = distro.get("name")
+def describe_distro(data, sbom=None):
+    # Prefer the SBOM so stable and testing releases use the same naming: Syft
+    # preserves versionCodename, giving e.g. "debian trixie" and "debian
+    # forky". Fall back to Grype when no usable SBOM distro is available.
+    distro = ((sbom or {}).get("distro") or data.get("distro") or {})
+    name = distro.get("id") or distro.get("name")
     if not name:
         name = " ".join(distro.get("idLike") or []) or "unknown"
-    version = distro.get("version") or ""
+    version = (distro.get("versionCodename") or
+               distro.get("versionID") or
+               distro.get("version") or "")
     return f"{name} {version}".strip()
 
 
@@ -88,13 +90,13 @@ def describe_database(data):
             status.get("schemaVersion") or "unknown")
 
 
-def print_summary(grouped, data):
+def print_summary(grouped, data, sbom=None):
     counts = count_by_severity(grouped)
     built, schema = describe_database(data)
 
     print("## Vulnerability summary (Grype)")
     print()
-    print(f"Distribution: `{describe_distro(data)}`  ")
+    print(f"Distribution: `{describe_distro(data, sbom)}`  ")
     print(f"Vulnerability database built: `{built}` (schema `{schema}`)  ")
     print(f"Total unique vulnerabilities: **{len(grouped)}**")
     print()
@@ -132,8 +134,20 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
                  description="Summarize Grype vulnerability data.")
     parser.add_argument("grype_json", help="Path to the Grype JSON file")
+    parser.add_argument("--sbom",
+                        help="Path to the Syft JSON SBOM, used to describe "
+                             "the distribution consistently")
     args = parser.parse_args()
 
     grype_data = load_grype_json(args.grype_json)
+    # the SBOM only supplies the distro label, so a missing or unreadable one
+    # must not fail the build: report the vulnerabilities regardless
+    sbom_data = None
+    if args.sbom:
+        try:
+            sbom_data = load_grype_json(args.sbom)
+        except (OSError, ValueError):
+            sbom_data = None
+
     grype_grouped = collect_matches(grype_data)
-    print_summary(grype_grouped, grype_data)
+    print_summary(grype_grouped, grype_data, sbom_data)

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -61,18 +61,32 @@ def count_by_severity(grouped):
     return counts
 
 
+def describe_database(data):
+    # Grype records the vulnerability database it used under descriptor.db.
+    # since the v6 database (Grype 0.90) those fields sit in a "status"
+    # sub-object, while older releases wrote them directly under "db"; look in
+    # the nested location first and fall back to the flat one, so the summary
+    # survives Grype upgrades in either direction. descriptor.db is omitted
+    # entirely when Grype has no database loaded, hence the "or {}"
+    db = data.get("descriptor", {}).get("db") or {}
+    status = db.get("status") or db
+    # schemaVersion is a string ("v6.1.9") for the v6 database and an int for
+    # the older ones, so format it rather than assuming either
+    return (status.get("built") or "unknown",
+            status.get("schemaVersion") or "unknown")
+
+
 def print_summary(grouped, data):
     counts = count_by_severity(grouped)
     distro = data.get("distro", {})
     distro_name = distro.get("name", "unknown")
     distro_version = distro.get("version") or distro.get("idLike") or ""
-    db = data.get("descriptor", {}).get("db", {})
+    built, schema = describe_database(data)
 
     print("## Vulnerability summary (Grype)")
     print()
     print(f"Distribution: `{distro_name} {distro_version}`".rstrip() + "  ")
-    print(f"Vulnerability database built: "
-          f"`{db.get('built', 'unknown')}`  ")
+    print(f"Vulnerability database built: `{built}` (schema `{schema}`)  ")
     print(f"Total unique vulnerabilities: **{len(grouped)}**")
     print()
 

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -61,6 +61,18 @@ def count_by_severity(grouped):
     return counts
 
 
+def describe_distro(data):
+    # the distro Grype matched against; name is e.g. "debian" and version the
+    # major release, e.g. "13". idLike is a list, so join it rather than
+    # interpolating it, and only use it when there is no name at all
+    distro = data.get("distro", {})
+    name = distro.get("name")
+    if not name:
+        name = " ".join(distro.get("idLike") or []) or "unknown"
+    version = distro.get("version") or ""
+    return f"{name} {version}".strip()
+
+
 def describe_database(data):
     # Grype records the vulnerability database it used under descriptor.db.
     # since the v6 database (Grype 0.90) those fields sit in a "status"
@@ -78,14 +90,11 @@ def describe_database(data):
 
 def print_summary(grouped, data):
     counts = count_by_severity(grouped)
-    distro = data.get("distro", {})
-    distro_name = distro.get("name", "unknown")
-    distro_version = distro.get("version") or distro.get("idLike") or ""
     built, schema = describe_database(data)
 
     print("## Vulnerability summary (Grype)")
     print()
-    print(f"Distribution: `{distro_name} {distro_version}`".rstrip() + "  ")
+    print(f"Distribution: `{describe_distro(data)}`  ")
     print(f"Vulnerability database built: `{built}` (schema `{schema}`)  ")
     print(f"Total unique vulnerabilities: **{len(grouped)}**")
     print()

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -90,6 +90,14 @@ def describe_database(data):
             status.get("schemaVersion") or "unknown")
 
 
+def code(items):
+    # wrap each value in a code span so Markdown leaves it alone: a Debian
+    # revision like 2.84.4-3~deb13u3 has tildes, and a pair of them on the same
+    # line is GFM strikethrough, so the tildes and the text between them get
+    # eaten. underscores and asterisks in package names bite the same way
+    return ", ".join(f"`{item}`" for item in sorted(items))
+
+
 def print_summary(grouped, data, sbom=None):
     counts = count_by_severity(grouped)
     built, schema = describe_database(data)
@@ -122,10 +130,12 @@ def print_summary(grouped, data, sbom=None):
     print("| --- | --- | --- | --- |")
     for severity, vuln_id in detailed:
         entry = grouped[(severity, vuln_id)]
-        packages = ", ".join(sorted(entry["packages"]))
+        packages = code(entry["packages"])
         if entry["fix_versions"]:
-            fix = ", ".join(sorted(entry["fix_versions"]))
+            fix = code(entry["fix_versions"])
         else:
+            # fix states are Grype's own vocabulary ("not-fixed", "wont-fix"),
+            # not package versions, so they are not code-wrapped
             fix = ", ".join(sorted(entry["fix_state"]))
         print(f"| {severity} | {vuln_id} | {packages} | {fix} |")
 

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -124,7 +124,14 @@ def print_summary(grouped, data, sbom=None):
               "severity vulnerabilities found.")
         return
 
-    print(f"### {' and '.join(DETAIL_SEVERITIES)} severity vulnerabilities")
+    # the detail table is long enough to dominate the job summary page, and the
+    # counts above are what most readers want, so collapse it by default. the
+    # blank lines inside <details> are required: without them GitHub doesn't
+    # render the Markdown table within the HTML block
+    print("<details>")
+    print(f"<summary>{len(detailed)} "
+          f"{' and '.join(DETAIL_SEVERITIES).lower()} "
+          "severity vulnerabilities</summary>")
     print()
     print("| Vulnerability | Severity | Packages | Fixed in |")
     print("| --- | --- | --- | --- |")
@@ -138,6 +145,8 @@ def print_summary(grouped, data, sbom=None):
             # not package versions, so they are not code-wrapped
             fix = ", ".join(sorted(entry["fix_state"]))
         print(f"| {vuln_id} | {severity} | {packages} | {fix} |")
+    print()
+    print("</details>")
 
 
 if __name__ == "__main__":

--- a/scripts/grype-vulnerability-summary.py
+++ b/scripts/grype-vulnerability-summary.py
@@ -126,7 +126,7 @@ def print_summary(grouped, data, sbom=None):
 
     print(f"### {' and '.join(DETAIL_SEVERITIES)} severity vulnerabilities")
     print()
-    print("| Severity | Vulnerability | Packages | Fixed in |")
+    print("| Vulnerability | Severity | Packages | Fixed in |")
     print("| --- | --- | --- | --- |")
     for severity, vuln_id in detailed:
         entry = grouped[(severity, vuln_id)]
@@ -137,7 +137,7 @@ def print_summary(grouped, data, sbom=None):
             # fix states are Grype's own vocabulary ("not-fixed", "wont-fix"),
             # not package versions, so they are not code-wrapped
             fix = ", ".join(sorted(entry["fix_state"]))
-        print(f"| {severity} | {vuln_id} | {packages} | {fix} |")
+        print(f"| {vuln_id} | {severity} | {packages} | {fix} |")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Read database metadata from Grype’s v6 descriptor.db.status structure, while retaining compatibility with older output.
- Include the vulnerability database schema version.
- Correct distribution formatting and use the Syft codename for Debian testing releases such as forky.
- Put CVE identifiers first in the vulnerability table.
- Format package names and versions as inline code.
- Collapse the detailed Critical/High vulnerability table by default.

Closes #567.