### PR TITLE
chore(kernel-configs): sync kernel configs with pkg-linux-qcom

### DIFF
--- a/kernel-configs/arduino-accessories.config
+++ b/kernel-configs/arduino-accessories.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # these configs enable drivers for accessories used with Arduino boards, such
 # as camera sensors, displays, or expansion boards
 

--- a/kernel-configs/monza.config
+++ b/kernel-configs/monza.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Misc configs for Monza devboards that should be in defconfig
 
 # Microchip EMC2305 and compatible EMC2301/2/3; needed for fan control, hence

--- a/kernel-configs/qcom-imsdk.config
+++ b/kernel-configs/qcom-imsdk.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # many GStreamer plugins in the Qualcomm IMSDK use DMABUF userspace heaps
 CONFIG_DMABUF_HEAPS=y
 CONFIG_DMABUF_HEAPS_SYSTEM=y

--- a/kernel-configs/qcom-laptops.config
+++ b/kernel-configs/qcom-laptops.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # needed for M.2 pwrseq driver
 # https://lore.kernel.org/linux-pci/20260501164440.11788-1-manivannan.sadhasivam@oss.qualcomm.com/
 CONFIG_POWER_SEQUENCING_PCIE_M2=m

--- a/kernel-configs/qemu-boot.config
+++ b/kernel-configs/qemu-boot.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # CONFIG_SCSI_VIRTIO is not enabled in the upstream defconfig but it is needed
 # when running qemu with such a backend, e.g. for testing or for the run-qemu
 # script

--- a/kernel-configs/squashfs.config
+++ b/kernel-configs/squashfs.config
@@ -1,0 +1,9 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+CONFIG_SQUASHFS=y
+CONFIG_SQUASHFS_XZ=y
+CONFIG_SQUASHFS_LZO=y
+CONFIG_SQUASHFS_XATTR=y
+CONFIG_SQUASHFS_ZLIB=y
+CONFIG_SQUASHFS_LZ4=y

--- a/kernel-configs/systemd-boot.config
+++ b/kernel-configs/systemd-boot.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # systemd-boot won't implement support for compressed images (zImage); see
 # https://github.com/systemd/systemd/issues/23788
 CONFIG_EFI_ZBOOT=y

--- a/kernel-configs/usb-can.config
+++ b/kernel-configs/usb-can.config
@@ -1,3 +1,6 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 # support for USB CAN adapters for demos and testing
 #
 # this enables popular hardware like CANable, Candlelight and PEAK System


### PR DESCRIPTION
Bring `kernel-configs/` in line with the fragments in [pkg-linux-qcom `debian/config-available`](https://github.com/qualcomm-linux/pkg-linux-qcom/tree/qcom/debian/latest/debian/config-available) so the two trees do not drift apart.

- add the missing licence headers, so every fragment carries one
- drop `virtio-gpu.config`, a loose file that was always empty; the option it was meant to hold went into `qemu-boot.config` instead
- add `squashfs.config`, needed for Ubuntu compatibility as snapd mounts every snap as a squashfs image (currently unused in this repository)
