### PR TITLE
ci: bump qcom-reusable-workflows to v2.0.10

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@b070a366a3cfc48e398e7008dab2590fa343daeb # v2.0.9
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@ceeddf6bfc0faeffa5ee0ac470752ae6cc2b78f4 # v2.0.10
     with:
       enable-semgrep-scan: true
       enable-dependency-review: true


### PR DESCRIPTION
The Copyright License Check job was failing while installing its Python dependencies: pip had no wheel for lxml and fell back to building it from source, which needs the libxml2 and libxslt development headers:

    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error

    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [3 lines of output]
        Building lxml version 6.1.3.
        Building without Cython.
        Error: Please make sure the libxml2 and libxslt development
        packages are installed.
        [end of output]

v2.0.10 fixes this, so pin the orchestrator to that tag.