### PR TITLE
chore: disable lemans-evk and monaco-evk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,5 +78,12 @@ jobs:
     with:
       url: ${{ needs.build.outputs.artifacts_url }}
       suite: ${{ matrix.suite }}
+      # monaco-arduino-monza and qrb2210-arduino-imola are only validated
+      # against the arduino kernel; see
       # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
+      # lemans-evk and monaco-evk fail to boot to a login prompt on most daily
+      # runs (initramfs/root device never shows up), which keeps this workflow
+      # red and hides real regressions on the other boards. Excluded until the
+      # boot failures are fixed; see
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/620
+      boards_exclude: '["lemans-evk", "monaco-arduino-monza", "monaco-evk", "qrb2210-arduino-imola"]'

--- a/.github/workflows/linux-qcom-next.yml
+++ b/.github/workflows/linux-qcom-next.yml
@@ -30,17 +30,12 @@ jobs:
       github.ref == 'refs/heads/main')
     uses: ./.github/workflows/linux.yml
     permissions:
-      checks: write
+      # skip_image_build below leaves the kernel deb build as the only job that
+      # runs, and it just checks out the repository
       contents: read
-      packages: read
-      pull-requests: write
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc7-20260821 prune.config qcom.config'
       # stop after publishing the debs to EFS; the "Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
-      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      lava_boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
-    secrets:
-      LAVATOKEN: ${{ secrets.LAVATOKEN }}


### PR DESCRIPTION
Temporarily disable lemans-evk and monaco-evk which fail CI; see #620. Cleanup a workflow while at it.
- **ci: exclude lemans-evk and monaco-evk**
- **ci: drop inert configs from qcom-next build**
