### PR TITLE
ci: fix workflow perms regression

### DIFF
--- a/.github/workflows/linux-qcom-next.yml
+++ b/.github/workflows/linux-qcom-next.yml
@@ -40,7 +40,5 @@ jobs:
       # stop after publishing the debs to EFS; the "Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
-      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
-      lava_boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/linux-qcom-next.yml
+++ b/.github/workflows/linux-qcom-next.yml
@@ -30,12 +30,17 @@ jobs:
       github.ref == 'refs/heads/main')
     uses: ./.github/workflows/linux.yml
     permissions:
-      # skip_image_build below leaves the kernel deb build as the only job that
-      # runs, and it just checks out the repository
+      checks: write
       contents: read
+      packages: read
+      pull-requests: write
     with:
       kernel_name: qcom-next
       build_linux_deb_extra_args: '--qcom-next --ref qcom-next-7.2-rc7-20260821 prune.config qcom.config'
       # stop after publishing the debs to EFS; the "Build" workflow
       # picks them up and builds and tests the images on every suite
       skip_image_build: true
+      # https://github.com/qualcomm-linux/qcom-deb-images/issues/537
+      lava_boards_exclude: '["monaco-arduino-monza", "qrb2210-arduino-imola"]'
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}


### PR DESCRIPTION
Workflow permissions are evaluated statically, so all potential permissions need to be documented. Revert a CI change that misassumed this, and bring back the only useful change which is dropping an unmaintained list of boards.
- **Revert "ci: drop inert configs from qcom-next build"**
- **chore(ci): drop lava_boards_exclude from linux-qcom-next**
