### PR TITLE
fix(debos): use :any qualifier for all APT pins

### DIFF
--- a/debos-recipes/qualcomm-linux-debian-rootfs.yaml
+++ b/debos-recipes/qualcomm-linux-debian-rootfs.yaml
@@ -205,15 +205,15 @@ actions:
 {{- $backportpackages := list
       "src:alsa-lib:any"
       "src:alsa-ucm-conf:any"
-      "src:efivar"
-      "src:fastrpc"
+      "src:efivar:any"
+      "src:fastrpc:any"
       "src:firmware-free:any"
       "src:firmware-nonfree:any"
-      "src:hexagon-dsp-binaries"
+      "src:hexagon-dsp-binaries:any"
       "src:linux:any"
       "src:linux-signed-arm64:any"
       "src:mesa:any"
-      "src:u-boot-efi-dtb"
+      "src:u-boot-efi-dtb:any"
       "src:wireplumber:any" }}
 
   - action: run


### PR DESCRIPTION
When pinning source packages, the :any qualifier is needed to match
arch: all packages, otherwise only packages from the native
architecture are pinned. Add :any to all source pins as we don't
want inconsistencies between packages from the same source.
